### PR TITLE
Fix: Eliminate Dead Space in Page Builder Layout

### DIFF
--- a/frontend/src/features/plugin-studio/components/PluginStudioLayoutUnified.tsx
+++ b/frontend/src/features/plugin-studio/components/PluginStudioLayoutUnified.tsx
@@ -170,8 +170,13 @@ export const PluginStudioLayoutUnified: React.FC = () => {
       {/* Main Content Area */}
       <Box sx={{ 
         flex: 1,
-        overflow: 'auto',
-        position: 'relative'
+        position: 'relative',
+        // Prevent horizontal overflow/dead space while allowing vertical scroll
+        overflowY: 'auto',
+        overflowX: 'hidden',
+        width: '100%',
+        maxWidth: '100%',
+        minWidth: 0
       }}>
         <ErrorBoundary>
           {useUnifiedRenderer && currentPage && layouts ? (

--- a/frontend/src/features/unified-dynamic-page-renderer/adapters/PluginStudioAdapter.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/adapters/PluginStudioAdapter.tsx
@@ -720,13 +720,14 @@ export const PluginStudioAdapter: React.FC<PluginStudioAdapterProps> = ({
               display: none !important;
             }
 
-            /* Remove scrollbars and create expandable canvas like legacy */
+            /* Ensure unified container never exceeds its parent width */
             .unified-page-renderer,
             .unified-page-renderer .layout-engine,
             .unified-page-renderer .responsive-container {
               height: 100% !important;
               width: 100% !important;
-              overflow: visible !important;
+              max-width: 100% !important;
+              overflow-x: hidden !important;
             }
 
             /* Create expandable grid background like legacy Plugin Studio - Theme aware */
@@ -744,7 +745,8 @@ export const PluginStudioAdapter: React.FC<PluginStudioAdapterProps> = ({
               background-color: ${theme.palette.mode === 'dark' ? '#303030' : '#f5f5f5'};
               z-index: -1;
               min-height: 100vh;
-              min-width: 100vw;
+              /* IMPORTANT: limit to container width (not viewport) to prevent right-side dead space */
+              min-width: 100%;
             }
 
             /* Ensure the grid container can expand beyond viewport */
@@ -752,6 +754,8 @@ export const PluginStudioAdapter: React.FC<PluginStudioAdapterProps> = ({
               min-height: 100vh !important;
               position: relative !important;
               width: 100% !important;
+              max-width: 100% !important;
+              overflow-x: hidden !important;
             }
 
             /* Force proper grid layout behavior - CRITICAL for positioning */


### PR DESCRIPTION
## 🛠️ Fix: Eliminate Dead Space in Page Builder Layout

### 📌 Summary

This PR addresses unwanted horizontal scrolling and right-side dead space in the **Plugin Studio Unified Layout** and **Unified Page Renderer Adapter**. The issue was caused by container elements exceeding their parent width, resulting in horizontal overflow and inconsistent rendering behavior.

---

### 🐞 Problem

* The main content area in `PluginStudioLayoutUnified` allowed both horizontal and vertical overflow, which caused **horizontal scrollbars** and **dead space** beyond the visible canvas.
* In `PluginStudioAdapter`, containers (`.unified-page-renderer`, `.layout-engine`, `.responsive-container`) and the grid background were configured with `min-width: 100vw`, which locked them to the viewport rather than the container.
  This produced **right-side blank space** and misaligned layouts.

---

### ✅ Solution

1. **`PluginStudioLayoutUnified.tsx`**

   * Replaced `overflow: auto` with explicit `overflowY: auto` and `overflowX: hidden`.
   * Added `width: 100%`, `maxWidth: 100%`, and `minWidth: 0` to enforce container sizing without horizontal bleed.

2. **`PluginStudioAdapter.tsx`**

   * Updated CSS for unified container classes:

     * Added `max-width: 100%` and `overflow-x: hidden`.
     * Replaced `min-width: 100vw` with `min-width: 100%` to align with container width instead of viewport width.
   * Strengthened grid container constraints with `max-width: 100%`.

---

### 🧪 Test Coverage

* Verified across multiple layouts in Plugin Studio:

  * **No horizontal scrollbars** appear during normal use.
  * **Dead space on the right side** is eliminated.
  * Vertical scrolling remains functional for long content.
* Confirmed behavior in both **light and dark modes**.

---

### 🗂️ Affected Files

* `PluginStudioLayoutUnified.tsx` — Hardened container overflow handling
* `PluginStudioAdapter.tsx` — CSS adjustments to prevent horizontal overflow and viewport bleed


