### PR TITLE
Small Change to Settings Page

### DIFF
--- a/frontend/src/pages/Settings.tsx
+++ b/frontend/src/pages/Settings.tsx
@@ -32,7 +32,6 @@ import DarkModeIcon from '@mui/icons-material/DarkMode';
 import LanguageIcon from '@mui/icons-material/Language';
 import StorageIcon from '@mui/icons-material/Storage';
 import AddIcon from '@mui/icons-material/Add';
-import CloseIcon from '@mui/icons-material/Close';
 import SettingsIcon from '@mui/icons-material/Settings';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
@@ -446,19 +445,6 @@ const Settings = () => {
 		}
 	};
 
-	// Remove a plugin from the active list
-	const handleRemovePlugin = (pluginToRemove: SettingsPlugin) => {
-		const updatedActivePlugins = activePlugins.filter(
-			(plugin) =>
-				!(
-					plugin.pluginId === pluginToRemove.pluginId &&
-					plugin.moduleId === pluginToRemove.moduleId
-				)
-		);
-
-		setActivePlugins(updatedActivePlugins);
-	};
-
   return (
     <Box sx={{ width: '100%', p: 2 }}>
       <Typography variant="h4" gutterBottom>
@@ -562,31 +548,20 @@ const Settings = () => {
                     title={plugin.displayName}
                     subheader={`Priority: ${plugin.priority}`}
                     action={
-                      <>
-                        <Tooltip title={collapsed[pluginKey(plugin)] ? 'Expand' : 'Collapse'}>
-                          <IconButton
-                            aria-label="toggle"
-                            aria-expanded={!collapsed[pluginKey(plugin)]}
-                            onClick={() => toggleCollapsed(pluginKey(plugin))}
-                            size="small"
-                          >
-                            {collapsed[pluginKey(plugin)] ? (
-                              <ExpandMoreIcon />
-                            ) : (
-                              <ExpandLessIcon />
-                            )}
-                          </IconButton>
-                        </Tooltip>
-                        <Tooltip title="Remove">
-                          <IconButton 
-                            aria-label="remove" 
-                            onClick={() => handleRemovePlugin(plugin)}
-                            size="small"
-                          >
-                            <CloseIcon />
-                          </IconButton>
-                        </Tooltip>
-                      </>
+                      <Tooltip title={collapsed[pluginKey(plugin)] ? 'Expand' : 'Collapse'}>
+                        <IconButton
+                          aria-label="toggle"
+                          aria-expanded={!collapsed[pluginKey(plugin)]}
+                          onClick={() => toggleCollapsed(pluginKey(plugin))}
+                          size="small"
+                        >
+                          {collapsed[pluginKey(plugin)] ? (
+                            <ExpandMoreIcon />
+                          ) : (
+                            <ExpandLessIcon />
+                          )}
+                        </IconButton>
+                      </Tooltip>
                     }
                     avatar={<SettingsIcon />}
                   />


### PR DESCRIPTION
## 📝 Pull Request: Small Change to Settings Page

### Summary

This PR cleans up the `Settings.tsx` component by simplifying the plugin management UI and removing unused functionality. It reduces complexity while preserving core settings functionality.

### Changes

* **Removed**:

  * `CloseIcon` import (no longer used).
  * `handleRemovePlugin` function for removing plugins.
  * UI elements allowing plugins to be removed from the active list.

* **Updated**:

  * Simplified `CardHeader.action` by retaining only the expand/collapse toggle.
  * Reduced code complexity by eliminating unnecessary `<Tooltip>` and `<IconButton>` wrappers for removal actions.

### Files Modified

* `frontend/src/pages/Settings.tsx`

  * **14 insertions**, **39 deletions**

### Why This Change?

* The ability to remove plugins from the settings page was unused and potentially confusing to users.
* Removing unused imports, functions, and UI elements improves maintainability and readability.
* Simplification helps prevent errors and ensures consistent plugin management behavior.

### Testing & Verification

* Verified that expand/collapse toggle continues to function correctly.
* Confirmed no runtime errors due to removed code.
* UI displays cleanly without the plugin removal option.

### Next Steps / Future Considerations

* Evaluate whether plugin removal should exist elsewhere in the system (e.g., dedicated plugin management page).
* Continue to streamline settings UI for clarity and simplicity.

