### PR TITLE
Dashboard Plugin Update Panel

### DIFF
--- a/frontend/src/features/plugin-manager/components/PluginUpdatesPanel.tsx
+++ b/frontend/src/features/plugin-manager/components/PluginUpdatesPanel.tsx
@@ -1,0 +1,315 @@
+import React from 'react';
+import {
+  Alert,
+  Box,
+  Button,
+  Card,
+  CardContent,
+  Chip,
+  CircularProgress,
+  Divider,
+  IconButton,
+  LinearProgress,
+  Link,
+  Skeleton,
+  Stack,
+  Tooltip,
+  Typography,
+} from '@mui/material';
+import SystemUpdateAltIcon from '@mui/icons-material/SystemUpdateAlt';
+import RefreshIcon from '@mui/icons-material/Refresh';
+import ScheduleIcon from '@mui/icons-material/Schedule';
+import CloseIcon from '@mui/icons-material/Close';
+import InfoOutlinedIcon from '@mui/icons-material/InfoOutlined';
+import ErrorOutlineIcon from '@mui/icons-material/ErrorOutline';
+import {
+  PluginUpdateBatchProgress,
+  PluginUpdateFeedItem,
+  PluginUpdateFeedStatus,
+} from '../hooks/usePluginUpdateFeed';
+
+interface PluginUpdatesPanelProps {
+  updates: PluginUpdateFeedItem[];
+  status: PluginUpdateFeedStatus;
+  error: string | null;
+  lastChecked: string | null;
+  isUpdatingAll: boolean;
+  batchProgress: PluginUpdateBatchProgress;
+  onUpdate: (pluginId: string) => void | Promise<void>;
+  onUpdateAll: () => void | Promise<void>;
+  onRefresh: () => void | Promise<void>;
+  onDismiss: (pluginId: string) => void;
+  onRetry: () => void | Promise<void>;
+}
+
+const formatTimestamp = (timestamp: string | null): string => {
+  if (!timestamp) {
+    return 'Never checked';
+  }
+
+  const date = new Date(timestamp);
+  if (Number.isNaN(date.getTime())) {
+    return 'Last check unknown';
+  }
+
+  return `Last checked ${date.toLocaleString()}`;
+};
+
+const formatPluginLabel = (plugin: PluginUpdateFeedItem): string => {
+  if (plugin.pluginName && plugin.pluginName.trim()) {
+    return plugin.pluginName;
+  }
+
+  const slug = plugin.pluginId.split('_').slice(1).join('_') || plugin.pluginId;
+  const spaced = slug
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!spaced) {
+    return plugin.pluginId;
+  }
+
+  return spaced
+    .split(' ')
+    .map(part => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(' ');
+};
+
+const PluginUpdatesPanel: React.FC<PluginUpdatesPanelProps> = ({
+  updates,
+  status,
+  error,
+  lastChecked,
+  isUpdatingAll,
+  batchProgress,
+  onUpdate,
+  onUpdateAll,
+  onRefresh,
+  onDismiss,
+  onRetry,
+}) => {
+  const showSkeleton = status === 'loading' && updates.length === 0 && !lastChecked;
+  const showEmpty = status === 'empty';
+  const showError = status === 'error';
+
+  const lastCheckedLabel = formatTimestamp(lastChecked);
+  const progressValue = batchProgress.total > 0 && batchProgress.processed <= batchProgress.total
+    ? Math.round((batchProgress.processed / batchProgress.total) * 100)
+    : 0;
+
+  const renderHeaderActions = () => (
+    <Stack direction="row" spacing={1} alignItems="center">
+      <Tooltip title="Refresh now">
+        <span>
+          <IconButton
+            color="primary"
+            onClick={() => onRefresh()}
+            disabled={status === 'loading'}
+            size="small"
+          >
+            <RefreshIcon fontSize="small" />
+          </IconButton>
+        </span>
+      </Tooltip>
+      <Button
+        variant="contained"
+        onClick={() => onUpdateAll()}
+        disabled={updates.length === 0 || isUpdatingAll}
+        startIcon={
+          isUpdatingAll ? <CircularProgress size={16} color="inherit" /> : <SystemUpdateAltIcon fontSize="small" />
+        }
+      >
+        {isUpdatingAll ? 'Updating...' : 'Update All'}
+      </Button>
+    </Stack>
+  );
+
+  const renderProgress = () => {
+    if (!isUpdatingAll && batchProgress.processed === 0) {
+      return null;
+    }
+
+    return (
+      <Box mt={2}>
+        <LinearProgress
+          variant={batchProgress.total > 0 ? 'determinate' : 'indeterminate'}
+          value={batchProgress.total > 0 ? progressValue : undefined}
+        />
+        {batchProgress.total > 0 && (
+          <Typography variant="caption" color="text.secondary" display="block" mt={1}>
+            {`Processed ${batchProgress.processed} of ${batchProgress.total} (Success: ${batchProgress.succeeded}, Failed: ${batchProgress.failed})`}
+          </Typography>
+        )}
+      </Box>
+    );
+  };
+
+  const renderError = () => {
+    if (!showError) {
+      return null;
+    }
+
+    return (
+      <Box mt={2}>
+        <Alert
+          severity="error"
+          icon={<ErrorOutlineIcon fontSize="small" />}
+          action={
+            <Button color="inherit" size="small" onClick={() => onRetry()}>
+              Retry
+            </Button>
+          }
+        >
+          {error || 'We hit a snag while checking for plugin updates.'}
+        </Alert>
+      </Box>
+    );
+  };
+
+  const renderEmpty = () => {
+    if (!showEmpty) {
+      return null;
+    }
+
+    return (
+      <Box mt={2}>
+        <Alert severity="info" icon={<InfoOutlinedIcon fontSize="small" />}>No plugins need updates right now.</Alert>
+      </Box>
+    );
+  };
+
+  const renderSkeleton = () => {
+    if (!showSkeleton) {
+      return null;
+    }
+
+    return (
+      <Stack spacing={2} mt={2}>
+        {Array.from({ length: 3 }).map((_, index) => (
+          <Box key={`plugin-update-skeleton-${index}`}>
+            <Skeleton variant="text" width="30%" height={28} />
+            <Skeleton variant="text" width="45%" height={24} />
+            <Skeleton variant="rectangular" width="100%" height={40} sx={{ mt: 1 }} />
+          </Box>
+        ))}
+      </Stack>
+    );
+  };
+
+  const renderUpdates = () => {
+    if (showSkeleton || showEmpty) {
+      return null;
+    }
+
+    return (
+      <Stack
+        mt={2}
+        spacing={2}
+        divider={<Divider flexItem sx={{ borderColor: 'divider', opacity: 0.5 }} />}
+      >
+        {updates.map(update => {
+          const isProcessing = update.status === 'updating';
+
+          return (
+            <Box
+              key={update.pluginId}
+              sx={{
+                display: 'flex',
+                flexDirection: { xs: 'column', md: 'row' },
+                alignItems: { xs: 'flex-start', md: 'center' },
+                justifyContent: 'space-between',
+                gap: 2,
+              }}
+            >
+              <Box sx={{ flexGrow: 1, minWidth: 0 }}>
+                <Typography variant="subtitle1" sx={{ wordBreak: 'break-word' }}>
+                  {formatPluginLabel(update)}
+                </Typography>
+                <Stack direction="row" spacing={1} alignItems="center" mt={0.5} flexWrap="wrap">
+                  <Chip size="small" label={`Current ${update.currentVersion || 'n/a'}`} variant="outlined" />
+                  <Chip size="small" label={`Latest ${update.latestVersion || 'n/a'}`} color="primary" />
+                  <Stack direction="row" spacing={0.5} alignItems="center">
+                    <ScheduleIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+                    <Typography variant="caption" color="text.secondary">
+                      {update.lastChecked ? new Date(update.lastChecked).toLocaleString() : 'Not yet checked'}
+                    </Typography>
+                  </Stack>
+                </Stack>
+                {update.repoUrl && (
+                  <Typography variant="caption" color="text.secondary" display="block" mt={0.5}>
+                    <Link href={update.repoUrl} target="_blank" rel="noopener">
+                      {update.repoUrl}
+                    </Link>
+                  </Typography>
+                )}
+                {update.status === 'error' && update.error && (
+                  <Alert severity="warning" sx={{ mt: 1 }}>
+                    {update.error}
+                  </Alert>
+                )}
+              </Box>
+              <Stack direction="row" spacing={1} alignItems="center">
+                <Button
+                  variant="contained"
+                  color="primary"
+                  onClick={() => onUpdate(update.pluginId)}
+                  disabled={isProcessing || isUpdatingAll}
+                  startIcon={
+                    isProcessing ? <CircularProgress size={16} color="inherit" /> : <SystemUpdateAltIcon fontSize="small" />
+                  }
+                >
+                  {isProcessing ? 'Updating...' : 'Update'}
+                </Button>
+                <Button
+                  variant="text"
+                  color="inherit"
+                  onClick={() => onDismiss(update.pluginId)}
+                  startIcon={<CloseIcon fontSize="small" />}
+                >
+                  Later
+                </Button>
+              </Stack>
+            </Box>
+          );
+        })}
+      </Stack>
+    );
+  };
+
+  return (
+    <Card>
+      <CardContent sx={{ p: 3 }}>
+        <Stack
+          direction={{ xs: 'column', sm: 'row' }}
+          spacing={2}
+          alignItems={{ xs: 'flex-start', sm: 'center' }}
+          justifyContent="space-between"
+        >
+          <Box>
+            <Typography variant="h6">Plugin updates</Typography>
+            <Stack direction="row" spacing={0.75} alignItems="center" mt={0.5}>
+              <ScheduleIcon sx={{ fontSize: 16, color: 'text.secondary' }} />
+              <Typography variant="caption" color="text.secondary">
+                {lastCheckedLabel}
+              </Typography>
+            </Stack>
+          </Box>
+          {renderHeaderActions()}
+        </Stack>
+
+        {renderProgress()}
+        {renderError()}
+        {renderSkeleton()}
+        {renderEmpty()}
+        {renderUpdates()}
+      </CardContent>
+    </Card>
+  );
+};
+
+export default PluginUpdatesPanel;
+
+
+

--- a/frontend/src/features/plugin-manager/hooks/__tests__/usePluginUpdateFeed.test.ts
+++ b/frontend/src/features/plugin-manager/hooks/__tests__/usePluginUpdateFeed.test.ts
@@ -1,0 +1,107 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { usePluginUpdateFeed } from '../usePluginUpdateFeed';
+import { useAuth } from '../../../../contexts/AuthContext';
+import moduleService from '../../services/moduleService';
+
+type MockedAuth = jest.MockedFunction<typeof useAuth>;
+type MockedModuleService = {
+  checkForUpdates: jest.Mock;
+  updatePlugin: jest.Mock;
+};
+
+jest.mock('../../../../contexts/AuthContext', () => ({
+  useAuth: jest.fn(),
+}));
+
+jest.mock('../../services/moduleService', () => ({
+  __esModule: true,
+  default: {
+    checkForUpdates: jest.fn(),
+    updatePlugin: jest.fn(),
+  },
+}));
+
+const mockedUseAuth = useAuth as unknown as MockedAuth;
+const mockedModuleService = moduleService as unknown as MockedModuleService;
+
+const mockUpdatePayload = [
+  {
+    plugin_id: 'plugin-1',
+    plugin_name: 'Sample Plugin',
+    current_version: '1.0.0',
+    latest_version: '1.2.0',
+    repo_url: 'https://example.com/plugin-1',
+  },
+];
+
+describe('usePluginUpdateFeed', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    localStorage.clear();
+    mockedUseAuth.mockReturnValue({
+      user: { id: 'user-123', username: 'Test User', email: 'test@example.com' } as any,
+      isAuthenticated: true,
+    } as any);
+    mockedModuleService.checkForUpdates.mockResolvedValue(mockUpdatePayload);
+    mockedModuleService.updatePlugin.mockResolvedValue(undefined);
+  });
+
+  it('fetches plugin updates on mount', async () => {
+    const { result } = renderHook(() => usePluginUpdateFeed());
+
+    await waitFor(() => expect(result.current.status === 'ready' || result.current.status === 'empty').toBe(true));
+
+    expect(mockedModuleService.checkForUpdates).toHaveBeenCalledTimes(1);
+    expect(result.current.updates).toHaveLength(1);
+    expect(result.current.updates[0].pluginName).toBe('Sample Plugin');
+  });
+
+  it('can dismiss a plugin update without deleting cache data', async () => {
+    const { result } = renderHook(() => usePluginUpdateFeed());
+
+    await waitFor(() => expect(result.current.status === 'ready' || result.current.status === 'empty').toBe(true));
+
+    act(() => {
+      result.current.dismiss('plugin-1');
+    });
+
+    expect(result.current.updates).toHaveLength(0);
+    const cached = localStorage.getItem('pluginUpdates::user-123');
+    expect(cached).toContain('"plugin-1"');
+  });
+
+  it('calls updatePlugin and removes the entry on success', async () => {
+    const { result } = renderHook(() => usePluginUpdateFeed());
+
+    await waitFor(() => expect(result.current.status === 'ready' || result.current.status === 'empty').toBe(true));
+
+    await act(async () => {
+      await result.current.triggerUpdate('plugin-1');
+    });
+
+    expect(mockedModuleService.updatePlugin).toHaveBeenCalledWith('plugin-1');
+    expect(result.current.updates).toHaveLength(0);
+    expect(result.current.status).toBe('empty');
+  });
+
+  it('refresh restores dismissed updates', async () => {
+    const { result } = renderHook(() => usePluginUpdateFeed());
+
+    await waitFor(() => expect(result.current.status === 'ready' || result.current.status === 'empty').toBe(true));
+
+    act(() => {
+      result.current.dismiss('plugin-1');
+    });
+
+    mockedModuleService.checkForUpdates.mockResolvedValueOnce(mockUpdatePayload);
+
+    await act(async () => {
+      await result.current.refresh();
+    });
+
+    await waitFor(() => expect(result.current.updates).toHaveLength(1));
+    expect(mockedModuleService.checkForUpdates).toHaveBeenCalledTimes(2);
+  });
+});
+
+

--- a/frontend/src/features/plugin-manager/hooks/usePluginUpdateFeed.ts
+++ b/frontend/src/features/plugin-manager/hooks/usePluginUpdateFeed.ts
@@ -1,0 +1,534 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import moduleService from '../services/moduleService';
+import { PluginUpdateInfo } from '../../plugin-installer/types';
+import { useAuth } from '../../../contexts/AuthContext';
+
+const CACHE_TTL_MS = 60 * 60 * 1000;
+const CACHE_PREFIX = 'pluginUpdates::';
+
+const debugLog = (...args: unknown[]): void => {
+  try {
+    console.debug('[PluginUpdateFeed]', ...args);
+  } catch {
+    // no-op if console unavailable
+  }
+};
+
+const isBrowserEnvironment = typeof window !== 'undefined' && typeof window.localStorage !== 'undefined';
+
+
+
+const derivePluginName = (rawName: unknown, pluginId: string): string => {
+  const explicitName = typeof rawName === 'string' ? rawName.trim() : '';
+  if (explicitName) {
+    return explicitName;
+  }
+
+  const segments = pluginId.split('_').filter(Boolean);
+  const candidate = segments.length > 1 ? segments.slice(1).join('_') : pluginId;
+
+  const spaced = candidate
+    .replace(/[_-]+/g, ' ')
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .replace(/\s+/g, ' ')
+    .trim();
+
+  if (!spaced) {
+    return pluginId;
+  }
+
+  return spaced
+    .split(' ')
+    .map(part => (part ? part[0].toUpperCase() + part.slice(1) : part))
+    .join(' ');
+};
+
+export type PluginUpdateFeedStatus = 'idle' | 'loading' | 'ready' | 'empty' | 'error';
+export type PluginUpdateOperationStatus = 'idle' | 'updating' | 'success' | 'error';
+
+export interface PluginUpdateFeedItem {
+  pluginId: string;
+  pluginName?: string;
+  currentVersion: string;
+  latestVersion: string;
+  repoUrl?: string;
+  lastChecked: string;
+  status: PluginUpdateOperationStatus;
+  error?: string;
+}
+
+interface PluginUpdatesCacheShape {
+  fetchedAt: string;
+  updates: Array<{
+    pluginId: string;
+    pluginName?: string;
+    currentVersion: string;
+    latestVersion: string;
+    repoUrl?: string;
+    lastChecked?: string;
+  }>;
+  dismissed: string[];
+}
+
+export interface PluginUpdateBatchProgress {
+  total: number;
+  processed: number;
+  succeeded: number;
+  failed: number;
+}
+
+const normalizeUpdateInfo = (
+  info: Partial<PluginUpdateInfo> & Record<string, any>,
+  timestamp: string
+): PluginUpdateFeedItem | null => {
+  const pluginId = info.plugin_id ?? info.pluginId;
+  if (!pluginId) {
+    return null;
+  }
+
+  const currentVersion = info.current_version ?? info.currentVersion ?? '';
+  const latestVersion = info.latest_version ?? info.latestVersion ?? '';
+  const pluginName = derivePluginName(info.plugin_name ?? info.pluginName ?? info.name, pluginId);
+
+  return {
+    pluginId,
+    pluginName,
+    currentVersion,
+    latestVersion,
+    repoUrl: info.repo_url ?? info.repoUrl,
+    lastChecked: timestamp,
+    status: 'idle',
+  };
+};
+export const usePluginUpdateFeed = (): UsePluginUpdateFeedResult => {
+  const { user, isAuthenticated } = useAuth();
+  const userIdentifier = useMemo(() => {
+    if (!user) {
+      return null;
+    }
+
+    const shape = user as Record<string, any>;
+    const candidate = shape.id ?? shape.user_id ?? shape.email ?? shape.username;
+
+    return candidate ? String(candidate) : null;
+  }, [user]);
+
+  const cacheKey = useMemo(() => {
+    if (!isAuthenticated) {
+      return null;
+    }
+
+    const suffix = userIdentifier ?? 'global';
+    return `${CACHE_PREFIX}${suffix}`;
+  }, [isAuthenticated, userIdentifier]);
+
+  const [status, setStatus] = useState<PluginUpdateFeedStatus>('idle');
+  const [error, setError] = useState<string | null>(null);
+  const [updates, setUpdates] = useState<PluginUpdateFeedItem[]>([]);
+  const [dismissedIds, setDismissedIds] = useState<string[]>([]);
+  const [lastChecked, setLastChecked] = useState<string | null>(null);
+  const [isUpdatingAll, setIsUpdatingAll] = useState(false);
+  const [batchProgress, setBatchProgress] = useState<PluginUpdateBatchProgress>({
+    total: 0,
+    processed: 0,
+    succeeded: 0,
+    failed: 0,
+  });
+
+  const inflightRef = useRef<Promise<void> | null>(null);
+  const updatesRef = useRef<PluginUpdateFeedItem[]>(updates);
+  const dismissedRef = useRef<string[]>(dismissedIds);
+  const lastCheckedRef = useRef<string | null>(lastChecked);
+  const statusRef = useRef<PluginUpdateFeedStatus>(status);
+  const isMountedRef = useRef(true);
+
+  useEffect(() => {
+    updatesRef.current = updates;
+  }, [updates]);
+
+  useEffect(() => {
+    dismissedRef.current = dismissedIds;
+  }, [dismissedIds]);
+
+  useEffect(() => {
+    lastCheckedRef.current = lastChecked;
+  }, [lastChecked]);
+
+  useEffect(() => {
+    statusRef.current = status;
+  }, [status]);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const dismissedSet = useMemo(() => new Set(dismissedIds), [dismissedIds]);
+
+  const persistCache = useCallback((overrides?: Partial<{ updates: PluginUpdateFeedItem[]; dismissed: string[]; fetchedAt: string | null }>) => {
+    if (!cacheKey || !isBrowserEnvironment) {
+      return;
+    }
+
+    const updatesToPersist = overrides?.updates ?? updatesRef.current;
+    const dismissedToPersist = overrides?.dismissed ?? dismissedRef.current;
+    const fetchedAt = overrides?.fetchedAt ?? lastCheckedRef.current;
+
+    if (!fetchedAt) {
+      return;
+    }
+
+    debugLog('persistCache', { cacheKey, fetchedAt, updates: updatesToPersist.length, dismissed: dismissedToPersist.length });
+    const payload: PluginUpdatesCacheShape = {
+      fetchedAt,
+      updates: updatesToPersist.map(({ pluginId, pluginName, currentVersion, latestVersion, repoUrl, lastChecked: itemLastChecked }) => ({
+        pluginId,
+        pluginName,
+        currentVersion,
+        latestVersion,
+        repoUrl,
+        lastChecked: itemLastChecked,
+      })),
+      dismissed: dismissedToPersist,
+    };
+
+    try {
+      window.localStorage.setItem(cacheKey, JSON.stringify(payload));
+    } catch (storageError) {
+      console.warn('Failed to persist plugin update cache', storageError);
+    }
+  }, [cacheKey]);
+
+  const loadFromCache = useCallback(() => {
+    if (!cacheKey || !isBrowserEnvironment) {
+      return { hasCache: false, isFresh: false };
+    }
+
+    const raw = window.localStorage.getItem(cacheKey);
+    if (!raw) {
+      return { hasCache: false, isFresh: false };
+    }
+
+    try {
+      const parsed = JSON.parse(raw) as PluginUpdatesCacheShape;
+      if (!parsed || !Array.isArray(parsed.updates)) {
+        return { hasCache: false, isFresh: false };
+      }
+
+      const fetchedAt = parsed.fetchedAt ?? new Date().toISOString();
+      const hydrated = parsed.updates
+        .map(item => {
+          const base = normalizeUpdateInfo(
+            {
+              plugin_id: item.pluginId,
+              plugin_name: item.pluginName,
+              current_version: item.currentVersion,
+              latest_version: item.latestVersion,
+              repo_url: item.repoUrl,
+            },
+            item.lastChecked ?? fetchedAt
+          );
+          return base;
+        })
+        .filter((item): item is PluginUpdateFeedItem => Boolean(item));
+
+      if (!isMountedRef.current) {
+        return { hasCache: false, isFresh: false };
+      }
+
+      setUpdates(hydrated);
+      setLastChecked(fetchedAt);
+
+      const validDismissed = Array.isArray(parsed.dismissed)
+        ? parsed.dismissed.filter(id => hydrated.some(update => update.pluginId === id))
+        : [];
+
+      setDismissedIds(validDismissed);
+
+      const isFresh = Date.now() - new Date(fetchedAt).getTime() < CACHE_TTL_MS;
+      debugLog('loadFromCache', { cacheKey, hydrated: hydrated.length, dismissed: validDismissed.length, fetchedAt, isFresh });
+
+      const visibleCount = hydrated.filter(update => !validDismissed.includes(update.pluginId)).length;
+      setStatus(visibleCount > 0 ? 'ready' : 'empty');
+      setError(null);
+
+      return { hasCache: true, isFresh };
+    } catch (parseError) {
+      console.warn('Failed to read plugin update cache', parseError);
+      window.localStorage.removeItem(cacheKey);
+      return { hasCache: false, isFresh: false };
+    }
+  }, [cacheKey]);
+
+  const fetchUpdates = useCallback(async (force = false) => {
+    if (!cacheKey) {
+      debugLog('fetchUpdates:abort-no-cacheKey', { force });
+      return;
+    }
+
+    if (inflightRef.current) {
+      if (!force) {
+        debugLog('fetchUpdates:await-existing', { cacheKey });
+        await inflightRef.current;
+        return;
+      }
+
+      debugLog('fetchUpdates:force-after-await', { cacheKey });
+      await inflightRef.current;
+    }
+
+    const run = (async () => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      debugLog('fetchUpdates:start', { cacheKey, force });
+      setStatus('loading');
+      setError(null);
+
+      try {
+        const response = (await moduleService.checkForUpdates()) as PluginUpdateInfo[];
+        const fetchedAt = new Date().toISOString();
+
+        debugLog('fetchUpdates:received', { items: Array.isArray(response) ? response.length : 'unknown', fetchedAt });
+
+        const uniqueMap = new Map<string, PluginUpdateFeedItem>();
+        (response || []).forEach(item => {
+          const normalized = normalizeUpdateInfo(item, fetchedAt);
+          if (normalized) {
+            uniqueMap.set(normalized.pluginId, normalized);
+          }
+        });
+
+        const nextUpdates = Array.from(uniqueMap.values());
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        debugLog('fetchUpdates:normalized', { total: nextUpdates.length });
+
+        setUpdates(nextUpdates);
+        setLastChecked(fetchedAt);
+
+        const currentDismissed = dismissedRef.current;
+        const validDismissed = currentDismissed.filter(id => nextUpdates.some(update => update.pluginId === id));
+        setDismissedIds(validDismissed);
+
+        const visibleCount = nextUpdates.filter(update => !validDismissed.includes(update.pluginId)).length;
+        const nextStatus: PluginUpdateFeedStatus = visibleCount > 0 ? 'ready' : 'empty';
+        setStatus(nextStatus);
+
+        debugLog('fetchUpdates:status', { status: nextStatus, visibleCount, dismissed: validDismissed.length });
+
+        persistCache({ updates: nextUpdates, dismissed: validDismissed, fetchedAt });
+      } catch (fetchError: unknown) {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        const message = fetchError instanceof Error ? fetchError.message : 'Unable to fetch plugin updates';
+        debugLog('fetchUpdates:error', { message });
+        setError(message);
+        setStatus('error');
+      } finally {
+        inflightRef.current = null;
+        debugLog('fetchUpdates:complete', { cacheKey });
+      }
+    })();
+
+    inflightRef.current = run;
+    await run;
+  }, [cacheKey, persistCache]);
+
+  const refresh = useCallback(async () => {
+    setDismissedIds([]);
+    persistCache({ dismissed: [] });
+    await fetchUpdates(true);
+  }, [fetchUpdates, persistCache]);
+
+  const retry = useCallback(async () => {
+    await fetchUpdates(true);
+  }, [fetchUpdates]);
+
+  const dismiss = useCallback((pluginId: string) => {
+    setDismissedIds(prev => {
+      if (prev.includes(pluginId)) {
+        return prev;
+      }
+      const next = [...prev, pluginId];
+      persistCache({ dismissed: next });
+      const remaining = updatesRef.current.filter(update => !next.includes(update.pluginId)).length;
+      if (remaining === 0 && statusRef.current !== 'loading') {
+        setStatus('empty');
+      }
+      return next;
+    });
+  }, [persistCache]);
+
+  const runPluginUpdate = useCallback(async (pluginId: string) => {
+    const existing = updatesRef.current.find(update => update.pluginId === pluginId);
+    if (!existing) {
+      debugLog('runPluginUpdate:missing', { pluginId });
+      return { success: false, error: 'Plugin not found in update feed' };
+    }
+
+    debugLog('runPluginUpdate:start', { pluginId });
+    setUpdates(prev =>
+      prev.map(update =>
+        update.pluginId === pluginId
+          ? { ...update, status: 'updating', error: undefined }
+          : update
+      )
+    );
+
+    try {
+      await moduleService.updatePlugin(pluginId);
+
+      let nextUpdates: PluginUpdateFeedItem[] = [];
+      setUpdates(prev => {
+        nextUpdates = prev.filter(update => update.pluginId !== pluginId);
+        return nextUpdates;
+      });
+
+      const nextDismissed = dismissedRef.current.filter(id => id !== pluginId);
+      setDismissedIds(nextDismissed);
+
+      const updatedAt = new Date().toISOString();
+      setLastChecked(updatedAt);
+      persistCache({ updates: nextUpdates, dismissed: nextDismissed, fetchedAt: updatedAt });
+
+      const remainingVisible = nextUpdates.filter(update => !nextDismissed.includes(update.pluginId)).length;
+      setStatus(remainingVisible > 0 ? 'ready' : 'empty');
+      debugLog('runPluginUpdate:success', { pluginId });
+
+      return { success: true };
+    } catch (updateError: unknown) {
+      const message = updateError instanceof Error ? updateError.message : 'Failed to update plugin';
+      debugLog('runPluginUpdate:error', { pluginId, message });
+      setUpdates(prev =>
+        prev.map(update =>
+          update.pluginId === pluginId
+            ? { ...update, status: 'error', error: message }
+            : update
+        )
+      );
+      setError(message);
+      return { success: false, error: message };
+    }
+  }, [persistCache]);
+
+  const triggerUpdate = useCallback(async (pluginId: string) => {
+    const result = await runPluginUpdate(pluginId);
+    if (!result.success) {
+      throw new Error(result.error || 'Failed to update plugin');
+    }
+  }, [runPluginUpdate]);
+
+  const triggerUpdateAll = useCallback(async () => {
+    if (isUpdatingAll) {
+      return;
+    }
+
+    const pending = updatesRef.current.filter(update => !dismissedSet.has(update.pluginId));
+    if (pending.length === 0) {
+      return;
+    }
+
+    setIsUpdatingAll(true);
+    setBatchProgress({ total: pending.length, processed: 0, succeeded: 0, failed: 0 });
+
+    for (const item of pending) {
+      const result = await runPluginUpdate(item.pluginId);
+      setBatchProgress(prev => ({
+        total: pending.length,
+        processed: prev.processed + 1,
+        succeeded: prev.succeeded + (result.success ? 1 : 0),
+        failed: prev.failed + (result.success ? 0 : 1),
+      }));
+    }
+
+    setIsUpdatingAll(false);
+    setBatchProgress({ total: 0, processed: 0, succeeded: 0, failed: 0 });
+  }, [dismissedSet, isUpdatingAll, runPluginUpdate]);
+
+  useEffect(() => {
+    debugLog('effect:hydration-check', { isAuthenticated, cacheKey });
+    if (!isAuthenticated || !cacheKey) {
+      setUpdates([]);
+      setDismissedIds([]);
+      setLastChecked(null);
+      setStatus('idle');
+      setError(null);
+      return;
+    }
+
+    const result = loadFromCache();
+    debugLog('effect:cache-result', result);
+    if (!result.isFresh) {
+      fetchUpdates();
+    }
+  }, [cacheKey, fetchUpdates, isAuthenticated, loadFromCache]);
+
+  const visibleUpdates = useMemo(
+    () => updates.filter(update => !dismissedSet.has(update.pluginId)),
+    [updates, dismissedSet]
+  );
+
+  return {
+    updates: visibleUpdates,
+    status,
+    error,
+    lastChecked,
+    isUpdatingAll,
+    batchProgress,
+    refresh,
+    retry,
+    dismiss,
+    triggerUpdate,
+    triggerUpdateAll,
+  };
+};
+
+export default usePluginUpdateFeed;
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/frontend/src/features/plugin-manager/index.ts
+++ b/frontend/src/features/plugin-manager/index.ts
@@ -8,11 +8,22 @@ export { default as ModuleSearch } from './components/ModuleSearch';
 export { default as ModuleFilters } from './components/ModuleFilters';
 export { default as ModuleStatusToggle } from './components/ModuleStatusToggle';
 export { default as ModuleDetailHeader } from './components/ModuleDetailHeader';
+export { default as PluginUpdatesPanel } from './components/PluginUpdatesPanel';
 
 // Export hooks
 export { default as useModules } from './hooks/useModules';
 export { default as useModuleDetail } from './hooks/useModuleDetail';
 export { default as useModuleFilters } from './hooks/useModuleFilters';
+export { default as usePluginUpdateFeed } from './hooks/usePluginUpdateFeed';
+export type {
+  PluginUpdateFeedItem,
+  PluginUpdateFeedStatus,
+  PluginUpdateOperationStatus,
+  PluginUpdateBatchProgress,
+  UsePluginUpdateFeedResult,
+} from './hooks/usePluginUpdateFeed';
 
 // Export services
 export { default as moduleService } from './services/moduleService';
+
+

--- a/frontend/src/features/plugin-manager/services/moduleService.ts
+++ b/frontend/src/features/plugin-manager/services/moduleService.ts
@@ -412,6 +412,7 @@ export class ModuleService {
   async checkForUpdates(): Promise<any[]> {
     try {
       const response = await this.apiService.get('/api/v1/plugins/updates/available');
+      console.debug('[ModuleService] checkForUpdates response', response);
       return response.data?.available_updates || [];
     } catch (error) {
       console.error('Failed to check for updates:', error);
@@ -424,3 +425,4 @@ export class ModuleService {
 export const moduleService = ModuleService.getInstance();
 
 export default moduleService;
+

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -11,16 +11,18 @@ import {
 import { useNavigate } from 'react-router-dom';
 import ExtensionIcon from '@mui/icons-material/Extension';
 import SettingsIcon from '@mui/icons-material/Settings';
-import BuildIcon from '@mui/icons-material/Build'; // Icon for Plugin Manager
+import BuildIcon from '@mui/icons-material/Build';
 import { useAuth } from '../contexts/AuthContext';
+import { PluginUpdatesPanel, usePluginUpdateFeed } from '../features/plugin-manager';
 
 const Dashboard = () => {
   const navigate = useNavigate();
   const { user } = useAuth();
+  const updateFeed = usePluginUpdateFeed();
 
   const cards = [
     {
-      title: 'BrainDrive Studio',
+      title: 'Page Builder',
       description: 'Create and manage your plugins',
       icon: <ExtensionIcon sx={{ fontSize: 40 }} />,
       path: '/plugin-studio',
@@ -53,7 +55,7 @@ const Dashboard = () => {
         </Typography>
       </Paper>
 
-      <Grid container spacing={3}>
+      <Grid container spacing={3} sx={{ mb: 3 }}>
         {cards.map((card) => (
           <Grid item xs={12} sm={6} md={4} key={card.title}>
             <Card>
@@ -87,6 +89,24 @@ const Dashboard = () => {
             </Card>
           </Grid>
         ))}
+      </Grid>
+
+      <Grid container spacing={3}>
+        <Grid item xs={12} md={6}>
+          <PluginUpdatesPanel
+            updates={updateFeed.updates}
+            status={updateFeed.status}
+            error={updateFeed.error}
+            lastChecked={updateFeed.lastChecked}
+            isUpdatingAll={updateFeed.isUpdatingAll}
+            batchProgress={updateFeed.batchProgress}
+            onUpdate={(pluginId) => void updateFeed.triggerUpdate(pluginId)}
+            onUpdateAll={() => void updateFeed.triggerUpdateAll()}
+            onRefresh={() => void updateFeed.refresh()}
+            onDismiss={updateFeed.dismiss}
+            onRetry={() => void updateFeed.retry()}
+          />
+        </Grid>
       </Grid>
     </Box>
   );


### PR DESCRIPTION
## ✨ Pull Request: Dashboard Plugin Update Panel

### Summary

This PR introduces a new **Plugin Updates Panel** to the dashboard, enabling users to view, refresh, and apply available plugin updates directly within the UI. It also adds a supporting hook (`usePluginUpdateFeed`) with local caching, batch update logic, and error handling.

### Key Changes

#### New Components & Hooks

* **`PluginUpdatesPanel.tsx`**

  * UI card that lists plugins with available updates.
  * Provides update, update-all, refresh, dismiss, and retry actions.
  * Shows progress indicators, error messages, and empty/skeleton states.

* **`usePluginUpdateFeed.ts`**

  * Custom hook for managing plugin update state.
  * Features localStorage caching with TTL, dismissed update persistence, and refresh/retry logic.
  * Supports batch update progress tracking and single plugin update operations.

* **Unit Tests** (`usePluginUpdateFeed.test.ts`)

  * Validates fetching, dismissing, updating, and refresh flows.
  * Uses mocks for `AuthContext` and `moduleService`.

#### Updated Files

* **`Dashboard.tsx`**

  * Integrated `PluginUpdatesPanel` into the dashboard layout.
  * Uses `usePluginUpdateFeed` to connect the panel to live update data.
  * Adjusted layout spacing and updated card title (“Page Builder”).

* **`plugin-manager/index.ts`**

  * Exported new panel, hook, and related types.

* **`moduleService.ts`**

  * Added debug logging for update checks.

### Why This Change?

* Users need a **clear and centralized way** to see when plugins have updates available.
* Adds automation for **bulk updates**, reducing manual effort.
* Improves UX by handling empty, loading, and error states gracefully.
* Provides test coverage for reliability.

### Testing & Verification

* ✅ Loaded dashboard with no updates → panel shows “No plugins need updates”.
* ✅ Simulated available updates → panel lists items with update and later actions.
* ✅ Verified “Update All” runs batch updates with progress tracking.
* ✅ Confirmed dismissed items persist in cache but reappear after refresh.
* ✅ Unit tests pass for fetch, dismiss, update, and refresh flows.

### Next Steps / Future Considerations

* Extend panel to support **rollback/downgrade** actions.
* Add notifications (e.g., snackbar) for completed updates.
* Explore integration with backend events for real-time update availability.

