### PR TITLE
Improve Plugin Studio Layout Handling & Default Plugins

### DIFF
--- a/backend/app/core/user_initializer/initializers/github_plugin_initializer.py
+++ b/backend/app/core/user_initializer/initializers/github_plugin_initializer.py
@@ -30,12 +30,12 @@ class GitHubPluginInitializer(UserInitializerBase):
     # Default plugins to install for new users
     DEFAULT_PLUGINS = [
         {
-            "repo_url": "https://github.com/DJJones66/BrainDriveSettings",
+            "repo_url": "https://github.com/BrainDriveAI/BrainDrive-Settings-Plugin",
             "version": "latest",
             "name": "BrainDrive Settings"
         },
         {
-            "repo_url": "https://github.com/DJJones66/BrainDriveChat", 
+            "repo_url": "https://github.com/BrainDriveAI/BrainDrive-Chat-Plugin", 
             "version": "latest",
             "name": "BrainDrive Chat"
         }

--- a/frontend/src/features/plugin-studio/components/canvas/DropZone.tsx
+++ b/frontend/src/features/plugin-studio/components/canvas/DropZone.tsx
@@ -1,8 +1,6 @@
 import React, { useState } from 'react';
 import { Box, Snackbar, Alert } from '@mui/material';
 import { usePluginStudio } from '../../hooks';
-import { useLayout } from '../../hooks/layout/useLayout';
-import { usePlugins } from '../../hooks/plugin/usePlugins';
 import { DragData } from '../../types';
 import { VIEW_MODE_LAYOUTS } from '../../constants';
 
@@ -17,11 +15,8 @@ interface DropZoneProps {
  * @returns The drop zone component
  */
 export const DropZone: React.FC<DropZoneProps> = ({ children, onNewItem }) => {
-  const { viewMode, currentPage, savePage } = usePluginStudio();
-  const { getModuleById } = usePlugins();
-  const { addItem } = useLayout(currentPage, getModuleById);
+  const { viewMode, currentPage, savePage, addItem } = usePluginStudio();
   const [isDragOver, setIsDragOver] = useState(false);
-  const [newItemId, setNewItemId] = useState<string | null>(null);
   const [warningOpen, setWarningOpen] = useState(false);
   
   /**
@@ -145,9 +140,6 @@ export const DropZone: React.FC<DropZoneProps> = ({ children, onNewItem }) => {
         }
       }, viewMode.type === 'custom' ? 'desktop' : viewMode.type);
       
-      // Set the new item ID for animation
-      setNewItemId(uniqueId);
-      
       // Notify parent component about the new item
       if (onNewItem) {
         onNewItem(uniqueId);
@@ -155,8 +147,6 @@ export const DropZone: React.FC<DropZoneProps> = ({ children, onNewItem }) => {
       
       // Clear the new item ID after animation completes
       setTimeout(() => {
-        setNewItemId(null);
-        
         // Notify parent component that animation is complete
         if (onNewItem) {
           onNewItem(null);

--- a/frontend/src/features/plugin-studio/components/canvas/PluginCanvas.tsx
+++ b/frontend/src/features/plugin-studio/components/canvas/PluginCanvas.tsx
@@ -17,21 +17,7 @@ export const PluginCanvas: React.FC = () => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [saveSuccess, setSaveSuccess] = useState(false);
   const [saveError, setSaveError] = useState(false);
-  const [key, setKey] = useState(0); // Add a key to force re-render
   const [newItemId, setNewItemId] = useState<string | null>(null);
-  
-  // Log layouts whenever they change
-  useEffect(() => {
-    //console.log('PluginCanvas received layouts:', layouts);
-    if (layouts) {
-    //  console.log('Desktop layouts:', layouts.desktop);
-    //  console.log('Tablet layouts:', layouts.tablet);
-    //  console.log('Mobile layouts:', layouts.mobile);
-      
-      // Force a re-render when layouts change
-      setKey(prevKey => prevKey + 1);
-    }
-  }, [layouts]);
   
   // Handle save button click
   const handleSave = async () => {
@@ -65,11 +51,10 @@ export const PluginCanvas: React.FC = () => {
       
       <Box
         ref={containerRef}
-        sx={{ p: 3, flex: 1, overflow: 'auto' }}
+        sx={{ p: 0, flex: 1, overflow: 'auto' }}
       >
         <DropZone onNewItem={setNewItemId}>
           <GridContainer
-            key={key} // Add key to force re-render
             layouts={layouts}
             onLayoutChange={handleLayoutChange}
             onResizeStart={handleResizeStart}

--- a/frontend/src/features/plugin-studio/constants/layout.constants.ts
+++ b/frontend/src/features/plugin-studio/constants/layout.constants.ts
@@ -26,8 +26,8 @@ export const VIEW_MODE_LAYOUTS: ViewModeConfigs = {
   mobile: {
     cols: 4,
     rowHeight: 50,
-    margin: [4, 4],
-    padding: [8, 8],
+    margin: [0, 0],
+    padding: [0, 0],
     defaultItemSize: {
       w: 4,
       h: 4
@@ -36,8 +36,8 @@ export const VIEW_MODE_LAYOUTS: ViewModeConfigs = {
   tablet: {
     cols: 8,
     rowHeight: 60,
-    margin: [8, 8],
-    padding: [12, 12],
+    margin: [0, 0],
+    padding: [0, 0],
     defaultItemSize: {
       w: 4,
       h: 4
@@ -46,8 +46,8 @@ export const VIEW_MODE_LAYOUTS: ViewModeConfigs = {
   desktop: {
     cols: 12,
     rowHeight: 70,
-    margin: [12, 12],
-    padding: [16, 16],
+    margin: [0, 0],
+    padding: [0, 0],
     defaultItemSize: {
       w: 3,
       h: 4
@@ -56,8 +56,8 @@ export const VIEW_MODE_LAYOUTS: ViewModeConfigs = {
   custom: {
     cols: 12,
     rowHeight: 70,
-    margin: [12, 12],
-    padding: [16, 16],
+    margin: [0, 0],
+    padding: [0, 0],
     defaultItemSize: {
       w: 3,
       h: 4

--- a/frontend/src/features/plugin-studio/context/PluginStudioContext.tsx
+++ b/frontend/src/features/plugin-studio/context/PluginStudioContext.tsx
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import { Page, Layouts, ViewModeState, DynamicPluginConfig } from '../types';
+import { Page, Layouts, ViewModeState, DynamicPluginConfig, GridItem, LayoutItem } from '../types';
 
 /**
  * Interface for the PluginStudio context
@@ -23,7 +23,8 @@ export interface PluginStudioContextType {
   
   // Layout state
   layouts: Layouts | null;
-  handleLayoutChange: (layout: any[], newLayouts: Layouts) => void;
+  handleLayoutChange: (layout: any[], newLayouts: Layouts, metadata?: { origin?: { source?: string }; [key: string]: unknown }) => void;
+  addItem: (item: GridItem | LayoutItem, activeDeviceType: keyof Layouts) => void;
   removeItem: (id: string) => void;
   handleResizeStart: () => void;
   handleResizeStop: () => void;

--- a/frontend/src/features/plugin-studio/context/PluginStudioProvider.tsx
+++ b/frontend/src/features/plugin-studio/context/PluginStudioProvider.tsx
@@ -52,6 +52,7 @@ export const PluginStudioProvider: React.FC<{ children: React.ReactNode }> = ({ 
     removeItem,
     handleResizeStart,
     handleResizeStop,
+    addItem,
     flush: flushLayoutChanges // Phase 3: Get flush method from useLayout
   } = useLayout(currentPage, getModuleById);
   // View mode state
@@ -95,6 +96,7 @@ export const PluginStudioProvider: React.FC<{ children: React.ReactNode }> = ({ 
     removeItem,
     handleResizeStart,
     handleResizeStop,
+    addItem,
     flushLayoutChanges, // Phase 3: Add flush method to context
     
     // Plugin state
@@ -129,7 +131,7 @@ export const PluginStudioProvider: React.FC<{ children: React.ReactNode }> = ({ 
     savePage, publishPage, backupPage, restorePage, updatePage,
     
     // Layout state
-    layouts, handleLayoutChange, removeItem, handleResizeStart, handleResizeStop, flushLayoutChanges,
+    layouts, handleLayoutChange, removeItem, handleResizeStart, handleResizeStop, addItem, flushLayoutChanges,
     
     // Plugin state
     availablePlugins,

--- a/frontend/src/features/plugin-studio/hooks/layout/__tests__/useLayout.test.tsx
+++ b/frontend/src/features/plugin-studio/hooks/layout/__tests__/useLayout.test.tsx
@@ -1,0 +1,64 @@
+import React, { forwardRef, useImperativeHandle } from 'react';
+import { render, act } from '@testing-library/react';
+import { useLayout } from '../useLayout';
+import type { Layouts, Page } from '../../../types';
+
+describe('useLayout', () => {
+  const createInitialPage = (): Page => ({
+    id: 'page-1',
+    name: 'Test Page',
+    layouts: {
+      desktop: [{ i: 'widget-1', x: 0, y: 0, w: 2, h: 2 }],
+      tablet: [],
+      mobile: []
+    },
+    content: {
+      layouts: {
+        desktop: [{ i: 'widget-1', x: 0, y: 0, w: 2, h: 2 }],
+        tablet: [],
+        mobile: []
+      }
+    }
+  } as unknown as Page);
+
+  type LayoutHookHandle = ReturnType<typeof useLayout>;
+
+  const LayoutHarness = forwardRef<LayoutHookHandle, { page: Page }>((props, ref) => {
+    const hook = useLayout(props.page, undefined);
+    useImperativeHandle(ref, () => hook, [hook]);
+
+    return <div data-testid="layouts-state">{JSON.stringify(hook.layouts)}</div>;
+  });
+  LayoutHarness.displayName = 'LayoutHarness';
+
+  it('applies user-driven layout changes in the same render tick', () => {
+    const initialPage = createInitialPage();
+    const ref = React.createRef<LayoutHookHandle>();
+
+    const { getByTestId } = render(<LayoutHarness ref={ref} page={initialPage} />);
+
+    const baselineLayouts = JSON.parse(getByTestId('layouts-state').textContent || '{}');
+    expect(baselineLayouts.desktop[0].x).toBe(0);
+
+    const nextLayout = [{ i: 'widget-1', x: 3, y: 0, w: 2, h: 2 }];
+    const nextLayouts: Layouts = {
+      desktop: nextLayout,
+      tablet: [],
+      mobile: []
+    };
+
+    act(() => {
+      ref.current?.handleLayoutChange(nextLayout, nextLayouts, { origin: { source: 'user-drag' } });
+    });
+
+    const updatedLayouts = JSON.parse(getByTestId('layouts-state').textContent || '{}');
+    expect(updatedLayouts.desktop[0].x).toBe(3);
+
+    act(() => {
+      ref.current?.handleLayoutChange(nextLayout, nextLayouts, { origin: { source: 'user-drag' } });
+    });
+
+    const dedupedLayouts = JSON.parse(getByTestId('layouts-state').textContent || '{}');
+    expect(dedupedLayouts.desktop[0].x).toBe(3);
+  });
+});

--- a/frontend/src/features/plugin-studio/hooks/ui/useViewMode.ts
+++ b/frontend/src/features/plugin-studio/hooks/ui/useViewMode.ts
@@ -56,8 +56,8 @@ export const useViewMode = () => {
         return DEVICE_BREAKPOINTS.tablet;
       
       case 'desktop':
-        // Desktop view is 1200px or 90% of container width, whichever is smaller
-        return Math.min(DEVICE_BREAKPOINTS.desktop, containerWidth * 0.9);
+        // Desktop view fills the available container width while honoring the minimum
+        return Math.max(MIN_WIDTH, containerWidth);
       
       case 'custom':
       default:

--- a/frontend/src/features/unified-dynamic-page-renderer/adapters/PluginStudioAdapter.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/adapters/PluginStudioAdapter.tsx
@@ -3,7 +3,6 @@ import { Box, useTheme } from '@mui/material';
 import { LayoutCommitBadge } from '../components/LayoutCommitBadge';
 import { UnifiedPageRenderer } from '../components/UnifiedPageRenderer';
 import { ResponsiveContainer } from '../components/ResponsiveContainer';
-import { LayoutEngine } from '../components/LayoutEngine';
 import { PageProvider } from '../contexts/PageContext';
 import { RenderMode, PageData, ResponsiveLayouts, LayoutItem, ModuleConfig } from '../types';
 import { usePluginStudioDevMode } from '../../../hooks/usePluginStudioDevMode';

--- a/frontend/src/features/unified-dynamic-page-renderer/components/DisplayLayoutEngine.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/DisplayLayoutEngine.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import { RenderMode } from '../types';
+import DisplayLayoutEngineImpl, { DisplayLayoutEngineProps as DisplayLayoutEngineImplProps } from './DisplayLayoutEngineImpl';
+
+export type DisplayLayoutEngineProps = DisplayLayoutEngineImplProps;
+
+export const DisplayLayoutEngine: React.FC<DisplayLayoutEngineProps> = (props) => {
+  if (process.env.NODE_ENV === 'development' && props.mode === RenderMode.STUDIO) {
+    console.warn('[DisplayLayoutEngine] Studio mode detected. Use StudioLayoutEngine instead to avoid controller V2 guards.');
+  }
+
+  return <DisplayLayoutEngineImpl {...props} />;
+};
+
+export default DisplayLayoutEngine;

--- a/frontend/src/features/unified-dynamic-page-renderer/components/DisplayLayoutEngineImpl.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/DisplayLayoutEngineImpl.tsx
@@ -1,0 +1,1672 @@
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Responsive, WidthProvider } from 'react-grid-layout';
+import { useTheme, Box, Chip } from '@mui/material';
+import { RenderMode, ResponsiveLayouts, LayoutItem, ModuleConfig } from '../types';
+import { ModuleRenderer } from './ModuleRenderer';
+import { LegacyModuleAdapter } from '../adapters/LegacyModuleAdapter';
+import { useBreakpoint } from '../hooks/useBreakpoint';
+import { GridItemControls } from '../../plugin-studio/components/canvas/GridItemControls';
+import { LayoutChangeOrigin } from '../utils/layoutChangeManager';
+import { useControlVisibility } from '../../../hooks/useControlVisibility';
+import { useDisplayLayoutController } from './display-controller/useDisplayLayoutController';
+import { useGuardedCommitQueue } from './display-controller/useGuardedCommitQueue';
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+export interface DisplayLayoutEngineProps {
+  layouts: ResponsiveLayouts;
+  modules: ModuleConfig[];
+  mode: RenderMode;
+  lazyLoading?: boolean;
+  preloadPlugins?: string[];
+  pageId?: string; // Add pageId to detect page changes
+  onLayoutChange?: (layouts: ResponsiveLayouts) => void;
+  onItemAdd?: (item: LayoutItem) => void;
+  onItemRemove?: (itemId: string) => void;
+  onItemSelect?: (itemId: string) => void;
+  onItemConfig?: (itemId: string) => void;
+  useSafeCommitSetters?: boolean;
+}
+
+const defaultGridConfig = {
+  cols: { xxl: 12, xl: 12, lg: 12, sm: 8, xs: 4 },
+  rowHeight: 60,
+  margin: [10, 10] as [number, number],
+  containerPadding: [10, 10] as [number, number],
+  breakpoints: { xxl: 1600, xl: 1400, lg: 1024, sm: 768, xs: 0 },
+};
+
+export const DisplayLayoutEngineImpl: React.FC<DisplayLayoutEngineProps> = React.memo(({
+  layouts,
+  modules,
+  mode,
+  lazyLoading = true,
+  preloadPlugins = [],
+  pageId,
+  onLayoutChange,
+  onItemAdd,
+  onItemRemove,
+  onItemSelect,
+  onItemConfig,
+  useSafeCommitSetters = false,
+}) => {
+  const theme = useTheme();
+  const containerRef = useRef<HTMLDivElement>(null);
+  
+  // Debug: Track component re-renders
+  const layoutEngineRenderCount = useRef(0);
+  layoutEngineRenderCount.current++;
+  
+  const {
+    unifiedLayoutState,
+    currentLayouts,
+    displayedLayouts,
+    ENABLE_LAYOUT_CONTROLLER_V2,
+    isDebugMode,
+    layoutGracePeriod,
+    userCommitDelayMs,
+    controllerStateRef,
+    workingLayoutsRef,
+    canonicalLayoutsRef,
+    lastVersionRef,
+    transitionToState,
+    logControllerState,
+  } = useDisplayLayoutController({
+    layouts,
+    onLayoutChange,
+    debounceMs: 200,
+    onError: (error) => {
+      console.error('[DisplayLayoutEngine] Layout state error:', error);
+    },
+  });
+
+    const currentOperationId = useRef<string | null>(null);
+
+  const { scheduleCommit, isAwaitingCommit, commitHighlightId } = useGuardedCommitQueue({
+    ENABLE_LAYOUT_CONTROLLER_V2,
+    layoutGracePeriod,
+    userCommitDelayMs,
+    isDebugMode,
+    logControllerState,
+    transitionToState,
+    unifiedLayoutState,
+    workingLayoutsRef,
+    canonicalLayoutsRef,
+    lastVersionRef,
+    controllerStateRef,
+    currentOperationIdRef: currentOperationId,
+    useSafeCommitSetters,
+  });
+
+  const [selectedItem, setSelectedItem] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  const stableIdentityRef = useRef<Map<string, { pluginId: string; moduleId: string }>>(new Map());
+
+  const { currentBreakpoint } = useBreakpoint();
+
+  // --- Adaptive rowHeight calculation (tracks container + viewport height) ---
+  const [computedRowHeight, setComputedRowHeight] = useState<number>(defaultGridConfig.rowHeight);
+  const [containerHeight, setContainerHeight] = useState<number>(0);
+
+  // Observe container size
+  useEffect(() => {
+    if (!containerRef.current) return;
+    const el = containerRef.current;
+    const ro = new ResizeObserver(() => setContainerHeight(el.clientHeight));
+    ro.observe(el);
+    setContainerHeight(el.clientHeight);
+    return () => ro.disconnect();
+  }, []);
+
+  // Recompute on window resize to follow viewport height changes
+  useEffect(() => {
+    const onResize = () => setContainerHeight(containerRef.current ? containerRef.current.clientHeight : window.innerHeight);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  useEffect(() => {
+    try {
+      const bpMap: Record<string, keyof ResponsiveLayouts> = { xs: 'mobile', sm: 'tablet', lg: 'desktop', xl: 'wide', xxl: 'ultrawide' };
+      const ourBp = bpMap[currentBreakpoint || 'lg'] || 'desktop';
+      const items = (displayedLayouts?.[ourBp] || []) as LayoutItem[];
+
+      const wantsFill = items.some(it => (it as any)?.config?.viewportFill === true) || items.length === 1;
+      if (!wantsFill) {
+        if (computedRowHeight !== defaultGridConfig.rowHeight) setComputedRowHeight(defaultGridConfig.rowHeight);
+        return;
+      }
+
+      // Available height: prefer remaining viewport below grid top so the grid
+      // shrinks with browser height; fallback to container clientHeight
+      const el = containerRef.current;
+      const rect = el?.getBoundingClientRect();
+      const viewportAvailable = rect ? Math.max(0, window.innerHeight - rect.top - 8) : 0;
+      const available = viewportAvailable > 0 ? viewportAvailable : containerHeight;
+      if (available <= 0 || items.length === 0) return;
+
+      // Determine effective vertical paddings/margins from grid config
+      const marginY = defaultGridConfig.margin[1];
+      const containerPadY = defaultGridConfig.containerPadding[1];
+
+      const targetRows = Math.max(...items.map(it => it.h || 1));
+      const verticalGutter = marginY * Math.max(0, targetRows - 1);
+      const availableForRows = Math.max(0, available - (containerPadY * 2));
+      const desired = Math.max(24, Math.floor((availableForRows - verticalGutter) / (targetRows || 1)));
+
+      const next = Math.min(140, Math.max(36, desired));
+      if (Number.isFinite(next) && next > 0 && next !== computedRowHeight) setComputedRowHeight(next);
+    } catch {
+      if (computedRowHeight !== defaultGridConfig.rowHeight) setComputedRowHeight(defaultGridConfig.rowHeight);
+    }
+  }, [displayedLayouts, currentBreakpoint, containerHeight]);
+  
+  // Control visibility based on context
+  const { showControls } = useControlVisibility(mode);
+
+  // Failsafe: Programmatically remove resize handles when controls should be hidden
+  useEffect(() => {
+    if (!showControls) {
+      const removeResizeHandles = () => {
+        const resizeHandles = document.querySelectorAll('.react-resizable-handle');
+        resizeHandles.forEach(handle => {
+          (handle as HTMLElement).style.display = 'none';
+          (handle as HTMLElement).style.visibility = 'hidden';
+          (handle as HTMLElement).style.pointerEvents = 'none';
+        });
+      };
+
+      // Remove immediately
+      removeResizeHandles();
+
+      // Also remove after a short delay to catch any dynamically added handles
+      const timeoutId = setTimeout(removeResizeHandles, 100);
+
+      // Set up a mutation observer to catch any new resize handles
+      const observer = new MutationObserver(() => {
+        if (!showControls) {
+          removeResizeHandles();
+        }
+      });
+
+      observer.observe(document.body, {
+        childList: true,
+        subtree: true,
+        attributes: true,
+        attributeFilter: ['class']
+      });
+
+      return () => {
+        clearTimeout(timeoutId);
+        observer.disconnect();
+      };
+    }
+  }, [showControls]);
+  
+  // Track page ID for proper state management
+  const pageIdRef = useRef<string | undefined>(pageId);
+  
+  // Operation deduplication tracking
+  const processedOperations = useRef<Set<string>>(new Set());
+  const operationCleanupTimers = useRef<Map<string, NodeJS.Timeout>>(new Map());
+  
+  // Bounce detection tracking
+  const previousPositionsRef = useRef<Map<string, { x: number; y: number; w: number; h: number; timestamp?: number }>>(new Map());
+  
+  // Track intended positions (the position user actually wanted)
+  const intendedPositionsRef = useRef<Map<string, { x: number; y: number; w: number; h: number; timestamp: number }>>(new Map());
+  
+  // Track bounce suppression window
+  const bounceSuppressionRef = useRef<Map<string, number>>(new Map());
+  
+  // Debug logging for bounce detection
+  const debugLog = useCallback((message: string, data?: any) => {
+    const timestamp = performance.now();
+    const stack = new Error().stack?.split('\n').slice(2, 5).join(' -> ') || 'unknown';
+    console.log(`[BOUNCE-DEBUG ${timestamp.toFixed(2)}ms] ${message}`, data ? { ...data, stack } : { stack });
+  }, []);
+
+  // Handle external layout changes (from props)
+  useEffect(() => {
+    // Phase 5: More careful page change detection to avoid resetting after save
+    // Only reset if the pageId actually changed (not just the reference)
+    const pageIdChanged = pageId !== pageIdRef.current && pageId !== undefined && pageIdRef.current !== undefined;
+    
+    if (pageIdChanged) {
+      console.log('[LayoutEngine] Page ID changed, resetting layouts', {
+        oldPageId: pageIdRef.current,
+        newPageId: pageId
+      });
+      unifiedLayoutState.resetLayouts(layouts);
+      pageIdRef.current = pageId;
+
+      // Clear bounce detection tracking when page changes
+      previousPositionsRef.current.clear();
+      intendedPositionsRef.current.clear();
+      debugLog('🔄 Page changed - cleared bounce detection tracking', { newPageId: pageId });
+      return;
+    }
+    
+    // Update pageId ref if it was undefined before
+    if (pageIdRef.current === undefined && pageId !== undefined) {
+      pageIdRef.current = pageId;
+    }
+
+    // Skip if layouts are semantically identical
+    if (unifiedLayoutState.compareWithCurrent(layouts)) {
+      return;
+    }
+
+    // Skip during active operations to prevent interference
+    if (isDragging || isResizing) {
+      debugLog('EXTERNAL SYNC BLOCKED - Active operation in progress', { isDragging, isResizing });
+      return;
+    }
+
+    // Update from external source
+    debugLog('EXTERNAL SYNC TRIGGERED', {
+      layoutsKeys: Object.keys(layouts),
+      currentOperationId: currentOperationId.current
+    });
+    unifiedLayoutState.updateLayouts(layouts, {
+      source: 'external-sync',
+      timestamp: Date.now()
+    });
+  }, [layouts, pageId, isDragging, isResizing, unifiedLayoutState]);
+
+  // Handle layout change - Enhanced with controller V2
+  const handleLayoutChange = useCallback((layout: any[], allLayouts: any) => {
+    const operationId = currentOperationId.current;
+    
+    debugLog('handleLayoutChange called', {
+      operationId,
+      isResizing,
+      isDragging,
+      layoutLength: layout?.length,
+      allLayoutsKeys: Object.keys(allLayouts || {}),
+      layoutData: layout?.map(item => ({ i: item.i, x: item.x, y: item.y, w: item.w, h: item.h }))
+    });
+
+    // RECODE V2 BLOCK: Capture layout during resize BEFORE controller checks
+    // Store the layout data immediately if we're resizing
+    if (isResizing && layout && layout.length > 0 && currentBreakpoint) {
+      const breakpointMap: Record<string, keyof ResponsiveLayouts> = {
+        xs: 'mobile',
+        sm: 'tablet',
+        lg: 'desktop',
+        xl: 'wide',
+        xxl: 'ultrawide'
+      };
+      
+      const ourBreakpoint = breakpointMap[currentBreakpoint];
+      if (ourBreakpoint && workingLayoutsRef.current) {
+        // Ensure the working buffer has the structure
+        if (!workingLayoutsRef.current[ourBreakpoint]) {
+          workingLayoutsRef.current[ourBreakpoint] = [];
+        }
+        workingLayoutsRef.current[ourBreakpoint] = layout as LayoutItem[];
+        
+        console.log('[RECODE_V2_BLOCK] IMMEDIATE resize capture in handleLayoutChange', {
+          operationId,
+          breakpoint: ourBreakpoint,
+          itemCount: layout.length,
+          items: layout.map((item: any) => ({
+            id: item.i,
+            dimensions: { w: item.w, h: item.h, x: item.x, y: item.y }
+          }))
+        });
+      }
+    }
+
+    // Controller V2: Handle layout changes based on controller state
+    if (ENABLE_LAYOUT_CONTROLLER_V2) {
+      const state = controllerStateRef.current;
+      
+      // During resize/drag operations, update working buffer only
+      if (state === 'resizing' || state === 'dragging') {
+        // Convert to ResponsiveLayouts format
+        const convertedLayouts: ResponsiveLayouts = {
+          mobile: [],
+          tablet: [],
+          desktop: [],
+          wide: [],
+          ultrawide: []
+        };
+
+        const breakpointMap: Record<string, keyof ResponsiveLayouts> = {
+          xs: 'mobile',
+          sm: 'tablet',
+          lg: 'desktop',
+          xl: 'wide',
+          xxl: 'ultrawide'
+        };
+
+        // RECODE V2 BLOCK: Use the current layout for the active breakpoint during resize
+        // This ensures we capture the actual resized dimensions
+        if (layout && layout.length > 0 && currentBreakpoint) {
+          const ourBreakpoint = breakpointMap[currentBreakpoint];
+          if (ourBreakpoint) {
+            convertedLayouts[ourBreakpoint] = layout as LayoutItem[];
+            console.log('[RECODE_V2_BLOCK] Working buffer update with resize dimensions', {
+              state,
+              breakpoint: ourBreakpoint,
+              itemCount: layout.length,
+              items: layout.map((item: any) => ({
+                id: item.i,
+                dimensions: { w: item.w, h: item.h, x: item.x, y: item.y }
+              }))
+            });
+          }
+        } else {
+          console.warn('[RECODE_V2_BLOCK] No layout data during resize!', {
+            state,
+            hasLayout: !!layout,
+            layoutLength: layout?.length,
+            currentBreakpoint,
+            allLayoutsKeys: Object.keys(allLayouts || {})
+          });
+        }
+
+        // Fill in other breakpoints from allLayouts
+        Object.entries(allLayouts).forEach(([gridBreakpoint, gridLayout]: [string, any]) => {
+          const ourBreakpoint = breakpointMap[gridBreakpoint];
+          if (ourBreakpoint && Array.isArray(gridLayout)) {
+            // Only use allLayouts if we haven't already set this breakpoint from the current layout
+            if (gridBreakpoint !== currentBreakpoint || !layout) {
+              convertedLayouts[ourBreakpoint] = gridLayout as LayoutItem[];
+            }
+          }
+        });
+        
+        // Update working buffer only
+        workingLayoutsRef.current = convertedLayouts;
+        logControllerState('WORKING_BUFFER_UPDATE', {
+          state,
+          operationId,
+          layoutItemCount: layout?.length,
+          version: lastVersionRef.current,  // PHASE B: Include version in logs
+          hasLayouts: Object.values(convertedLayouts).some(l => l.length > 0)
+        });
+        
+        // Don't persist during operations
+        return;
+      }
+      
+      // During grace period, ignore all layout changes
+      if (state === 'grace') {
+        logControllerState('GRACE_PERIOD_IGNORE', {
+          reason: 'Layout change during grace period',
+          operationId,
+          version: lastVersionRef.current  // PHASE B: Include version in logs
+        });
+        return;
+      }
+      
+      // During commit state, also ignore
+      if (state === 'commit') {
+        logControllerState('COMMIT_STATE_IGNORE', {
+          reason: 'Layout change during commit',
+          operationId,
+          version: lastVersionRef.current  // PHASE B: Include version in logs
+        });
+        return;
+      }
+    }
+
+    // EARLY BOUNCE DETECTION: Block suspicious layout changes immediately
+    if (!operationId && !isResizing && !isDragging && layout && layout.length > 0) {
+      // Check if any item is trying to change to a position we've seen before (potential bounce)
+      for (const item of layout) {
+        const itemKey = `${item.i}`;
+        const intendedPos = intendedPositionsRef.current.get(itemKey);
+        
+        if (intendedPos) {
+          const timeSinceIntended = Date.now() - intendedPos.timestamp;
+          const currentPos = { x: item.x, y: item.y, w: item.w, h: item.h };
+          
+          // If this change is happening soon after an intended position was set
+          // and it's different from the intended position, it's likely a bounce
+          if (timeSinceIntended < 1000) {
+            const isDifferentFromIntended = intendedPos.x !== currentPos.x || intendedPos.y !== currentPos.y ||
+                                          intendedPos.w !== currentPos.w || intendedPos.h !== currentPos.h;
+            
+            if (isDifferentFromIntended) {
+              debugLog('🚫 EARLY BOUNCE BLOCK - Rejecting suspicious layout change', {
+                itemId: item.i,
+                currentPosition: currentPos,
+                intendedPosition: intendedPos,
+                timeSinceIntended,
+                reason: 'SUSPICIOUS_CHANGE_AFTER_OPERATION'
+              });
+              
+              // Completely reject this layout change - CRITICAL: This prevents the bounce!
+              return;
+            }
+          }
+        }
+      }
+    }
+
+    // BOUNCE DETECTION: Track position changes to detect visual bounces
+    if (layout && layout.length > 0) {
+      layout.forEach(item => {
+        const currentPos = { x: item.x, y: item.y, w: item.w, h: item.h };
+        const itemKey = `${item.i}`;
+        
+        // Get previous position from ref
+        if (!previousPositionsRef.current) {
+          previousPositionsRef.current = new Map();
+        }
+        
+        const prevPos = previousPositionsRef.current.get(itemKey);
+        
+        if (prevPos) {
+          // Check if position changed
+          const posChanged = prevPos.x !== currentPos.x || prevPos.y !== currentPos.y ||
+                           prevPos.w !== currentPos.w || prevPos.h !== currentPos.h;
+          
+          if (posChanged) {
+            // Check if this is a bounce back to an even earlier position
+            const prevPrevPos = previousPositionsRef.current.get(`${itemKey}_prev`);
+            if (prevPrevPos) {
+              const isBouncingBack = prevPrevPos.x === currentPos.x && prevPrevPos.y === currentPos.y &&
+                                   prevPrevPos.w === currentPos.w && prevPrevPos.h === currentPos.h;
+              
+              if (isBouncingBack) {
+                debugLog('🔴 BOUNCE DETECTED! Item returned to previous position', {
+                  itemId: item.i,
+                  operationId,
+                  isResizing,
+                  isDragging,
+                  previousPosition: prevPos,
+                  currentPosition: currentPos,
+                  bouncedBackTo: prevPrevPos,
+                  timeSinceLastChange: Date.now() - (prevPos.timestamp || 0)
+                });
+                
+                // AGGRESSIVE BOUNCE PREVENTION: Completely block bounce changes
+                const intendedPos = intendedPositionsRef.current.get(itemKey);
+                if (intendedPos && !operationId && !isResizing && !isDragging) {
+                  // This is a bounce occurring after operation completion
+                  const timeSinceIntended = Date.now() - intendedPos.timestamp;
+                  
+                  // Block bounces that occur within 1 second of the intended position being set
+                  if (timeSinceIntended < 1000) {
+                    debugLog('🚫 BLOCKING BOUNCE - Rejecting entire layout change', {
+                      itemId: item.i,
+                      bouncedTo: currentPos,
+                      intendedPosition: intendedPos,
+                      timeSinceIntended,
+                      action: 'REJECTING_LAYOUT_CHANGE'
+                    });
+                    
+                    // COMPLETELY REJECT this layout change by returning early
+                    // This prevents the bounce from being processed at all
+                    return;
+                  }
+                }
+              }
+            }
+            
+            debugLog('📍 POSITION CHANGE', {
+              itemId: item.i,
+              operationId,
+              isResizing,
+              isDragging,
+              from: prevPos,
+              to: currentPos,
+              deltaX: currentPos.x - prevPos.x,
+              deltaY: currentPos.y - prevPos.y,
+              deltaW: currentPos.w - prevPos.w,
+              deltaH: currentPos.h - prevPos.h
+            });
+            
+            // Store previous position as prev_prev for bounce detection
+            previousPositionsRef.current.set(`${itemKey}_prev`, prevPos);
+          }
+        }
+        
+        // Update current position with timestamp
+        previousPositionsRef.current.set(itemKey, { ...currentPos, timestamp: Date.now() });
+      });
+    }
+    
+    // Check for duplicate processing
+    if (operationId && processedOperations.current.has(operationId)) {
+      debugLog('Skipping duplicate processing for operation', { operationId });
+      return;
+    }
+    
+    // Allow layout changes during active operations OR during resize/drag state
+    const hasActiveOperation = !!operationId;
+    const isInActiveState = isResizing || isDragging;
+    
+    if (!hasActiveOperation && !isInActiveState) {
+      debugLog('Ignoring layout change - no active operation or state');
+      return;
+    }
+
+    // Convert react-grid-layout layouts back to our ResponsiveLayouts format
+    const convertedLayouts: ResponsiveLayouts = {
+      mobile: [],
+      tablet: [],
+      desktop: [],
+      wide: [],
+      ultrawide: []
+    };
+
+    // Helper: normalize an RGL layout array to include moduleId/pluginId
+    const extractPluginId = (compositeId: string): string => {
+      if (!compositeId) return 'unknown';
+      const tokens = compositeId.split('_');
+      if (tokens.length === 1) return tokens[0];
+      const idx = tokens.findIndex(t => /^(?:[0-9a-f]{24,}|\d{12,})$/i.test(t));
+      const boundary = idx > 0 ? idx : 2; // heuristic: often 2 tokens like ServiceExample_Theme
+      return tokens.slice(0, boundary).join('_');
+    };
+
+    const normalizeItems = (items: any[] = []): LayoutItem[] => {
+      return (items || []).map((it: any) => {
+        const id = it?.i ?? '';
+        const pluginId = it?.pluginId || extractPluginId(typeof id === 'string' ? id : '');
+        
+        // CRITICAL: Preserve moduleId from config if available (from args)
+        let moduleId = it?.moduleId;
+        if (!moduleId && it?.config?.moduleId) {
+          moduleId = it.config.moduleId;
+        }
+        if (!moduleId) {
+          moduleId = id; // Last resort fallback
+        }
+        
+        return {
+          i: id,
+          x: it?.x ?? 0,
+          y: it?.y ?? 0,
+          w: it?.w ?? 2,
+          h: it?.h ?? 2,
+          moduleId: moduleId,
+          pluginId: pluginId || 'unknown',
+          minW: it?.minW,
+          minH: it?.minH,
+          isDraggable: it?.isDraggable ?? true,
+          isResizable: it?.isResizable ?? true,
+          static: it?.static ?? false,
+          config: it?.config
+        } as LayoutItem;
+      });
+    };
+
+    // Map react-grid-layout breakpoints back to our breakpoint names
+    const breakpointMap: Record<string, keyof ResponsiveLayouts> = {
+      xs: 'mobile',
+      sm: 'tablet',
+      lg: 'desktop',
+      xl: 'wide',
+      xxl: 'ultrawide'
+    };
+
+    // Phase 5: Preserve identity for ACTIVE breakpoint only to avoid legacy/blank flash
+    // The 'layout' parameter contains the active breakpoint's updated layout during drag/resize
+    if (layout && currentBreakpoint) {
+      const ourBreakpoint = breakpointMap[currentBreakpoint];
+      if (ourBreakpoint) {
+        // Build a lookup of existing items so we can copy identity/config
+        const source = (workingLayoutsRef.current || canonicalLayoutsRef.current || currentLayouts) as ResponsiveLayouts;
+        const existing: LayoutItem[] = (source?.[ourBreakpoint] as LayoutItem[]) || [];
+        const existingMap = new Map(existing.map(it => [it.i, it]));
+
+        convertedLayouts[ourBreakpoint] = (layout as any[]).map((it: any) => {
+          const id = it?.i ?? '';
+          const pos = { x: it?.x ?? 0, y: it?.y ?? 0, w: it?.w ?? 2, h: it?.h ?? 2 };
+          const base = existingMap.get(id);
+          // Keep identity/config from base; only update position/size
+          return base ? ({ ...base, ...pos } as LayoutItem) : normalizeItems([it])[0];
+        });
+        
+        // RECODE V2 BLOCK: Enhanced item-level dimension tracking
+        if (isResizing || operationId?.includes('resize')) {
+          console.log('[RECODE_V2_BLOCK] onLayoutChange during resize - item dimensions', {
+            operationId,
+            breakpoint: ourBreakpoint,
+            isResizing,
+            itemDimensions: layout.map((item: any) => ({
+              id: item.i,
+              dimensions: { w: item.w, h: item.h, x: item.x, y: item.y }
+            }))
+          });
+        }
+        
+        // Enhanced debugging to understand what dimensions we're getting
+        if (isDebugMode) {
+          console.log(`[LayoutEngine] Using current breakpoint layout for ${ourBreakpoint}`, {
+            operationId,
+            isResizing,
+            isDragging,
+            itemCount: layout.length,
+            layoutItems: layout.map((item: any) => ({
+              i: item.i,
+              x: item.x,
+              y: item.y,
+              w: item.w,
+              h: item.h
+            }))
+          });
+        }
+      }
+    }
+
+    // Fill in other breakpoints from allLayouts (no merge to avoid display regressions)
+    Object.entries(allLayouts).forEach(([gridBreakpoint, gridLayout]: [string, any]) => {
+      const ourBp = breakpointMap[gridBreakpoint];
+      if (ourBp && Array.isArray(gridLayout)) {
+        if (gridBreakpoint !== currentBreakpoint || !layout) {
+          convertedLayouts[ourBp] = normalizeItems(gridLayout as any[]);
+        }
+      }
+    });
+
+    // PHASE B: Determine the origin with version information
+    const origin: LayoutChangeOrigin = {
+      source: isDragging ? 'user-drag' : isResizing ? 'user-resize' : 'external-sync',
+      timestamp: Date.now(),
+      operationId: currentOperationId.current || `late-${Date.now()}`,
+      version: ENABLE_LAYOUT_CONTROLLER_V2 ? lastVersionRef.current : undefined
+    };
+
+    debugLog(`Processing layout change from ${origin.source}`, {
+      operationId,
+      convertedLayouts: Object.keys(convertedLayouts).map(bp => ({
+        breakpoint: bp,
+        itemCount: convertedLayouts[bp as keyof ResponsiveLayouts]?.length || 0
+      }))
+    });
+    
+    // Update through unified state management
+    unifiedLayoutState.updateLayouts(convertedLayouts, origin);
+    
+    // Mark operation as processed
+    if (operationId) {
+      processedOperations.current.add(operationId);
+      debugLog('Marked operation as processed', { operationId });
+      
+      // CAPTURE INTENDED POSITIONS: Store the final positions from user operations
+      if (origin.source === 'user-resize' || origin.source === 'user-drag') {
+        layout?.forEach(item => {
+          const itemKey = `${item.i}`;
+          const intendedPos = { x: item.x, y: item.y, w: item.w, h: item.h, timestamp: Date.now() };
+          intendedPositionsRef.current.set(itemKey, intendedPos);
+          
+          debugLog('💾 CAPTURED INTENDED POSITION', {
+            itemId: item.i,
+            operationId,
+            operationType: origin.source,
+            intendedPosition: intendedPos
+          });
+        });
+      }
+    }
+  }, [isDragging, isResizing, unifiedLayoutState, debugLog]);
+
+  // ========== PHASE C3: Enhanced Drag Operation Support ==========
+  // Handle drag start - Enhanced with controller V2 and Phase C improvements
+  const handleDragStart = useCallback(() => {
+    const operationId = `drag-${Date.now()}`;
+    currentOperationId.current = operationId;
+    setIsDragging(true);
+    
+    // Controller V2: Use state transition function
+    if (ENABLE_LAYOUT_CONTROLLER_V2) {
+      transitionToState('dragging', { operationId });
+      workingLayoutsRef.current = JSON.parse(JSON.stringify(canonicalLayoutsRef.current || currentLayouts));
+      logControllerState('DRAG_OPERATION_STARTED', {
+        operationId,
+        copiedCanonicalToWorking: true,
+        version: lastVersionRef.current
+      });
+    }
+    
+    unifiedLayoutState.startOperation(operationId);
+  }, [unifiedLayoutState, ENABLE_LAYOUT_CONTROLLER_V2, logControllerState, currentLayouts, transitionToState]);
+
+  // Handle drag stop - Enhanced with controller V2 and Phase C improvements
+  const handleDragStop = useCallback((layout: any[], oldItem: any, newItem: any) => {
+    if (currentOperationId.current) {
+      const operationId = currentOperationId.current;
+      
+      // Controller V2: Use unified commit process
+      if (ENABLE_LAYOUT_CONTROLLER_V2) {
+        lastVersionRef.current += 1;
+        transitionToState('grace', {
+          operationId,
+          newVersion: lastVersionRef.current
+        });
+        
+        // RECODE V2 BLOCK: Pass the final layout data to scheduleCommit for accurate positions
+        // Build allLayouts object with current breakpoint's layout (include alias)
+        const allLayouts: any = {};
+        const toGridAlias = (name: string): string => {
+          const m: Record<string, string> = { mobile: 'xs', tablet: 'sm', desktop: 'lg', wide: 'xl', ultrawide: 'xxl' };
+          return m[name] || name;
+        };
+        if (currentBreakpoint) {
+          allLayouts[currentBreakpoint] = layout;
+          const semanticToGrid: Record<string, string> = { mobile: 'xs', tablet: 'sm', desktop: 'lg', wide: 'xl', ultrawide: 'xxl' };
+          const gridKey = semanticToGrid[currentBreakpoint];
+          if (gridKey) {
+            allLayouts[gridKey] = layout;
+          }
+        }
+        
+        // Update working buffer for the active breakpoint with final drag positions
+        if (layout && currentBreakpoint) {
+          const toOurBreakpoint = (bp: string): keyof ResponsiveLayouts | undefined => {
+            const map: Record<string, keyof ResponsiveLayouts> = {
+              xs: 'mobile', sm: 'tablet', lg: 'desktop', xl: 'wide', xxl: 'ultrawide',
+              mobile: 'mobile', tablet: 'tablet', desktop: 'desktop', wide: 'wide', ultrawide: 'ultrawide'
+            };
+            return map[bp];
+          };
+          const ourBreakpoint = toOurBreakpoint(currentBreakpoint);
+          if (ourBreakpoint && workingLayoutsRef.current) {
+            workingLayoutsRef.current[ourBreakpoint] = layout as LayoutItem[];
+          }
+        }
+
+        // Schedule debounced commit with final layout data and normalized breakpoint
+        const normalizedBreakpoint = currentBreakpoint ? toGridAlias(currentBreakpoint) : currentBreakpoint;
+        const activeItemId = newItem?.i || oldItem?.i || null;
+        scheduleCommit(userCommitDelayMs, layout, allLayouts, normalizedBreakpoint, activeItemId || undefined);
+      }
+      
+      unifiedLayoutState.stopOperation(currentOperationId.current);
+      
+      // Delay clearing operation ID to catch late events
+      setTimeout(() => {
+        if (currentOperationId.current === operationId) {
+          currentOperationId.current = null;
+        }
+      }, 200);
+    }
+    setIsDragging(false);
+  }, [unifiedLayoutState, ENABLE_LAYOUT_CONTROLLER_V2, transitionToState, scheduleCommit, userCommitDelayMs]);
+
+  // Handle resize start - Enhanced with controller V2 and Phase C improvements
+  const handleResizeStart = useCallback(() => {
+    const operationId = `resize-${Date.now()}`;
+    currentOperationId.current = operationId;
+    setIsResizing(true);
+    
+    // Controller V2: Use state transition function
+    if (ENABLE_LAYOUT_CONTROLLER_V2) {
+      transitionToState('resizing', { operationId });
+      // RECODE V2 BLOCK: Ensure proper initialization with all breakpoints including ultrawide
+      const sourceLayouts = canonicalLayoutsRef.current || currentLayouts || {
+        mobile: [],
+        tablet: [],
+        desktop: [],
+        wide: [],
+        ultrawide: []
+      };
+      
+      // Ensure ultrawide field exists
+      if (!sourceLayouts.ultrawide) {
+        sourceLayouts.ultrawide = [];
+      }
+      
+      workingLayoutsRef.current = JSON.parse(JSON.stringify(sourceLayouts));
+      
+      console.log('[RECODE_V2_BLOCK] RESIZE START - Working buffer initialized', {
+        operationId,
+        hasCanonical: !!canonicalLayoutsRef.current,
+        hasCurrent: !!currentLayouts,
+        workingBufferBreakpoints: Object.keys(workingLayoutsRef.current || {}),
+        itemCounts: Object.entries(workingLayoutsRef.current || {}).map(([bp, items]) => ({
+          breakpoint: bp,
+          count: (items as any[])?.length || 0
+        }))
+      });
+      
+      logControllerState('RESIZE_OPERATION_STARTED', {
+        operationId,
+        copiedCanonicalToWorking: true,
+        version: lastVersionRef.current
+      });
+    }
+    
+    unifiedLayoutState.startOperation(operationId);
+    debugLog('RESIZE START', { operationId, isResizing: true });
+  }, [unifiedLayoutState, debugLog, ENABLE_LAYOUT_CONTROLLER_V2, logControllerState, currentLayouts, transitionToState]);
+
+  // Handle resize stop - Enhanced with controller V2 and Phase C improvements
+  const handleResizeStop = useCallback((layout: any, oldItem: any, newItem: any, placeholder: any, e: any, element: any) => {
+    if (currentOperationId.current) {
+      const operationId = currentOperationId.current;
+      
+      // RECODE V2 BLOCK: Enhanced resize stop logging
+      console.log('[RECODE_V2_BLOCK] RESIZE STOP - Capturing final dimensions', {
+        operationId,
+        itemId: newItem?.i,
+        oldDimensions: oldItem ? { w: oldItem.w, h: oldItem.h, x: oldItem.x, y: oldItem.y } : null,
+        newDimensions: newItem ? { w: newItem.w, h: newItem.h, x: newItem.x, y: newItem.y } : null,
+        layoutItemCount: layout?.length,
+        currentBreakpoint,
+        timestamp: Date.now()
+      });
+      
+      // Controller V2: Use unified commit process
+      if (ENABLE_LAYOUT_CONTROLLER_V2) {
+        lastVersionRef.current += 1;
+        transitionToState('grace', {
+          operationId,
+          newVersion: lastVersionRef.current
+        });
+        
+        // RECODE V2 BLOCK: Pass the final layout data to scheduleCommit for accurate dimensions
+        // Build allLayouts object with current breakpoint's layout (include both semantic and grid aliases)
+        const allLayouts: any = {};
+        const toGridAlias = (name: string): string => {
+          const m: Record<string, string> = { mobile: 'xs', tablet: 'sm', desktop: 'lg', wide: 'xl', ultrawide: 'xxl' };
+          return m[name] || name;
+        };
+        
+        // Add the current breakpoint's final layout
+        if (currentBreakpoint) {
+          // currentBreakpoint might already be a grid key (xs/sm/lg/xl/xxl) or a semantic key
+          allLayouts[currentBreakpoint] = layout;
+          // Also add alias to ensure commit path can normalize either form
+          const semanticToGrid: Record<string, string> = { mobile: 'xs', tablet: 'sm', desktop: 'lg', wide: 'xl', ultrawide: 'xxl' };
+          const gridKey = semanticToGrid[currentBreakpoint];
+          if (gridKey) {
+            allLayouts[gridKey] = layout;
+          }
+        }
+        
+        // RECODE V2 BLOCK: Immediately update working buffer with final layout
+        // This ensures the commit has the correct data
+        if (layout && currentBreakpoint) {
+          const toOurBreakpoint = (bp: string): keyof ResponsiveLayouts | undefined => {
+            const map: Record<string, keyof ResponsiveLayouts> = {
+              xs: 'mobile', sm: 'tablet', lg: 'desktop', xl: 'wide', xxl: 'ultrawide',
+              mobile: 'mobile', tablet: 'tablet', desktop: 'desktop', wide: 'wide', ultrawide: 'ultrawide'
+            };
+            return map[bp];
+          };
+
+          const ourBreakpoint = toOurBreakpoint(currentBreakpoint);
+          if (ourBreakpoint && workingLayoutsRef.current) {
+            workingLayoutsRef.current[ourBreakpoint] = layout as LayoutItem[];
+            console.log('[RECODE_V2_BLOCK] Updated working buffer with final resize dimensions', {
+              operationId,
+              breakpoint: ourBreakpoint,
+              itemCount: layout.length,
+              dimensions: layout.map((item: any) => ({
+                id: item.i,
+                w: item.w,
+                h: item.h
+              }))
+            });
+          }
+        }
+        
+        // Schedule debounced commit with final layout data
+        // Pass a normalized grid alias for breakpoint to maximize compatibility
+        const normalizedBreakpoint = currentBreakpoint ? toGridAlias(currentBreakpoint) : currentBreakpoint;
+        scheduleCommit(userCommitDelayMs, layout, allLayouts, normalizedBreakpoint, newItem?.i);
+      }
+      
+      unifiedLayoutState.stopOperation(operationId);
+      debugLog('RESIZE STOP - Starting grace period', { operationId });
+      
+      // Schedule cleanup of processed operation tracking
+      const cleanupTimer = setTimeout(() => {
+        processedOperations.current.delete(operationId);
+        operationCleanupTimers.current.delete(operationId);
+        debugLog('Cleaned up processed operation tracking', { operationId });
+      }, 300); // 300ms - longer than grace period to ensure all related processing is complete
+      
+      operationCleanupTimers.current.set(operationId, cleanupTimer);
+      
+      // Keep operation ID active for extended grace period to catch all final layout changes
+      setTimeout(() => {
+        if (currentOperationId.current === operationId) {
+          currentOperationId.current = null;
+          debugLog('GRACE PERIOD ENDED', { operationId });
+        }
+      }, 200); // Extended grace period to catch all React Grid Layout events
+    }
+    setIsResizing(false);
+    debugLog('RESIZE STATE SET TO FALSE');
+  }, [unifiedLayoutState, debugLog, ENABLE_LAYOUT_CONTROLLER_V2, transitionToState, scheduleCommit, currentBreakpoint, userCommitDelayMs]);
+  // ========== END PHASE C3 ==========
+
+  // Handle drag over for drop zone functionality
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    
+    // Check if the dataTransfer contains module data
+    const types = e.dataTransfer.types;
+    const hasModuleData = types.includes('module') || types.includes('text/plain');
+    
+    if (hasModuleData && mode === RenderMode.STUDIO) {
+      setIsDragOver(true);
+    }
+  }, [mode]);
+
+  // Handle drag leave
+  const handleDragLeave = useCallback(() => {
+    setIsDragOver(false);
+  }, []);
+
+  // Handle drop for adding new modules
+  const handleDrop = useCallback(async (e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    
+    if (mode !== RenderMode.STUDIO) return;
+    
+    try {
+      // Try to get the module data from the drag event
+      let moduleDataStr = e.dataTransfer.getData('module');
+      
+      // If module data is not available, try text/plain as fallback
+      if (!moduleDataStr) {
+        moduleDataStr = e.dataTransfer.getData('text/plain');
+      }
+      
+      if (!moduleDataStr) {
+        console.error('No module data found in drop event');
+        return;
+      }
+      
+      // Parse the module data
+      const moduleData = JSON.parse(moduleDataStr);
+      if (isDebugMode) {
+        console.log('[AddTrace] Parsed module data', moduleData);
+      }
+      
+      // DEBUG: Log controller + commit tracker state prior to add
+      if (isDebugMode) {
+        const tracker = getLayoutCommitTracker();
+        const pending = tracker.getPendingCommits();
+        const last = unifiedLayoutState.getLastCommitMeta?.();
+        const committed = unifiedLayoutState.getCommittedLayouts?.();
+        const committedCounts = committed ? Object.fromEntries(Object.entries(committed).map(([bp, arr]) => [bp, (arr as any[])?.length || 0])) : {};
+        console.log('[AddTrace] Pre-Add State', {
+          controllerState: controllerStateRef.current,
+          pendingCommits: pending.length,
+          lastCommit: last,
+          committedCounts
+        });
+      }
+
+      // Phase 3: Commit barrier - await any pending commits before adding
+      if (ENABLE_LAYOUT_CONTROLLER_V2) {
+        const state = controllerStateRef.current;
+        
+        // If we're in grace or commit state, or have pending commits, wait for flush
+        if (state === 'grace' || state === 'commit') {
+          if (isDebugMode) {
+            console.log('[LayoutEngine] Awaiting flush before drop-add', {
+              state,
+              hasPendingCommit: false
+            });
+          }
+          
+          // Await the flush to ensure we're working with committed layouts
+          await unifiedLayoutState.flush();
+          
+          if (isDebugMode) {
+            const committed = unifiedLayoutState.getCommittedLayouts?.();
+            const committedCounts = committed ? Object.fromEntries(Object.entries(committed).map(([bp, arr]) => [bp, (arr as any[])?.length || 0])) : {};
+            const last = unifiedLayoutState.getLastCommitMeta?.();
+            console.log('[AddTrace] Post-Flush State', { lastCommit: last, committedCounts });
+          }
+          
+          if (isDebugMode) {
+            console.log('[LayoutEngine] Flush complete, proceeding with drop-add');
+          }
+        }
+      }
+      
+      // Calculate the drop position relative to the grid
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = Math.floor((e.clientX - rect.left) / 120); // Grid cell width approximation
+      const y = Math.floor((e.clientY - rect.top) / 80);   // Grid cell height approximation
+      
+      // Create a unique ID for the module
+      const uniqueId = `${moduleData.pluginId}_${moduleData.moduleId}_${Date.now()}`;
+      
+      // Default size for new modules
+      const defaultWidth = 4;
+      const defaultHeight = 3;
+      
+      // Create the new layout item
+      const newItem: LayoutItem = {
+        i: uniqueId,
+        x: Math.max(0, x),
+        y: Math.max(0, y),
+        w: defaultWidth,
+        h: defaultHeight,
+        moduleId: moduleData.moduleId, // Use the actual moduleId from drag data, not the unique ID
+        pluginId: moduleData.pluginId,
+        config: {
+          moduleId: moduleData.moduleId,
+          displayName: moduleData.displayName || moduleData.moduleName,
+          ...moduleData.config,
+          // Preserve original item identity for adapter round-trips
+          _originalItem: {
+            i: uniqueId,
+            pluginId: moduleData.pluginId,
+            moduleId: moduleData.moduleId,
+            args: moduleData.config || {}
+          }
+        },
+        isDraggable: true,
+        isResizable: true,
+        static: false
+      };
+      
+      if (isDebugMode) {
+        console.log('[AddTrace] Adding new item to layout', {
+          id: newItem.i,
+          pluginId: newItem.pluginId,
+          moduleId: newItem.moduleId,
+          x: newItem.x,
+          y: newItem.y,
+          w: newItem.w,
+          h: newItem.h
+        });
+      }
+      
+      // Phase 3: Use committed layouts as the base for adding new items
+      // Harden against stale committed state after page change: if currentLayouts is empty
+      // but committed has items, prefer currentLayouts (empty) to avoid cross-page bleed.
+      const committedBase = unifiedLayoutState.getCommittedLayouts();
+      const isEmptyLayouts = (l?: ResponsiveLayouts | null) => {
+        if (!l) return true;
+        const keys: (keyof ResponsiveLayouts)[] = ['mobile','tablet','desktop','wide','ultrawide'];
+        return keys.every(k => !Array.isArray((l as any)[k]) || ((l as any)[k] || []).length === 0);
+      };
+      const layoutsToUpdate = (committedBase && !(isEmptyLayouts(currentLayouts) && !isEmptyLayouts(committedBase)))
+        ? committedBase
+        : currentLayouts;
+      const updatedLayouts = { ...layoutsToUpdate };
+      Object.keys(updatedLayouts).forEach(breakpoint => {
+        const currentLayout = updatedLayouts[breakpoint as keyof ResponsiveLayouts];
+        if (currentLayout) {
+          updatedLayouts[breakpoint as keyof ResponsiveLayouts] = [
+            ...currentLayout,
+            newItem
+          ];
+        }
+      });
+      
+      // Update through unified state management with version tracking
+      const version = lastVersionRef.current + 1;
+      lastVersionRef.current = version;
+      
+      if (isDebugMode) {
+        const counts = Object.fromEntries(Object.entries(updatedLayouts).map(([bp, arr]) => [bp, (arr as any[])?.length || 0]));
+        console.log('[AddTrace] Committing layouts after drop', { counts });
+      }
+
+      unifiedLayoutState.updateLayouts(updatedLayouts, {
+        source: 'drop-add',
+        timestamp: Date.now(),
+        version
+      });
+      
+      onItemAdd?.(newItem);
+      
+      // Select the newly added item (batched to prevent additional renders)
+      setTimeout(() => {
+        setSelectedItem(uniqueId);
+        onItemSelect?.(uniqueId);
+      }, 0);
+      
+    } catch (error) {
+      console.error('Error handling drop:', error);
+    }
+  }, [mode, unifiedLayoutState, onItemAdd, onItemSelect]);
+
+  // Handle item selection
+  const handleItemClick = useCallback((itemId: string) => {
+    if (mode === RenderMode.STUDIO) {
+      // Don't toggle selection during drag or resize operations
+      if (isDragging || isResizing) {
+        return;
+      }
+      setSelectedItem(prev => prev === itemId ? null : itemId);
+      onItemSelect?.(itemId);
+    }
+  }, [mode, onItemSelect, isDragging, isResizing]);
+
+  // Handle item removal
+  const handleItemRemove = useCallback((itemId: string) => {
+    
+    // Use displayedLayouts for consistency with controller V2
+    const layoutsToUpdate = ENABLE_LAYOUT_CONTROLLER_V2 ? displayedLayouts : currentLayouts;
+    
+    // Create new layouts with the item removed from all breakpoints
+    const updatedLayouts: ResponsiveLayouts = {
+      mobile: layoutsToUpdate.mobile?.filter((item: LayoutItem) => item.i !== itemId) || [],
+      tablet: layoutsToUpdate.tablet?.filter((item: LayoutItem) => item.i !== itemId) || [],
+      desktop: layoutsToUpdate.desktop?.filter((item: LayoutItem) => item.i !== itemId) || [],
+      wide: layoutsToUpdate.wide?.filter((item: LayoutItem) => item.i !== itemId) || []
+    };
+
+    // Update through unified state management
+    unifiedLayoutState.updateLayouts(updatedLayouts, {
+      source: 'user-remove',
+      timestamp: Date.now(),
+      operationId: `remove-${itemId}-${Date.now()}`
+    });
+    
+    // Controller V2: Update buffers when removing items
+    if (ENABLE_LAYOUT_CONTROLLER_V2) {
+      canonicalLayoutsRef.current = updatedLayouts;
+      workingLayoutsRef.current = updatedLayouts;
+      logControllerState('ITEM_REMOVED', { itemId });
+    }
+
+    // Clear selection if the removed item was selected
+    if (selectedItem === itemId) {
+      setSelectedItem(null);
+    }
+
+    // Call the external callback if provided
+    onItemRemove?.(itemId);
+  }, [currentLayouts, displayedLayouts, unifiedLayoutState, selectedItem, onItemRemove, ENABLE_LAYOUT_CONTROLLER_V2, logControllerState]);
+
+  // Create ultra-stable module map with deep comparison
+  const stableModuleMapRef = useRef<Record<string, ModuleConfig>>({});
+
+  const moduleMap = useMemo(() => {
+    const nextMap = modules.reduce<Record<string, ModuleConfig>>((map, module) => {
+      map[module.id] = module;
+      return map;
+    }, {});
+
+    stableModuleMapRef.current = nextMap;
+    return nextMap;
+  }, [modules]);
+
+  // Render grid items - Use displayedLayouts instead of currentLayouts
+  const renderGridItems = useCallback(() => {
+    const currentLayout =
+      displayedLayouts[currentBreakpoint as keyof ResponsiveLayouts] ||
+      displayedLayouts.desktop ||
+      displayedLayouts.wide ||
+      [];
+    
+    
+    
+    if (isDebugMode) {
+      const preview = currentLayout.map((i: any) => ({ i: i.i, pluginId: i.pluginId, moduleId: i.moduleId, x: i.x, y: i.y, w: i.w, h: i.h }));
+      console.log('[AddTrace] Render pass items', { breakpoint: currentBreakpoint, count: preview.length, items: preview });
+    }
+
+    return currentLayout.map((item: LayoutItem) => {
+      // Try to find the module by moduleId with multiple strategies
+      let module = moduleMap[item.moduleId];
+      const isCommitHighlighted = commitHighlightId === item.i;
+      
+      // If direct lookup fails, try a conservative fallback only (avoid cross-binding by pluginId)
+      let resolvedVia: 'direct' | 'sanitized' | 'fallback' | 'none' = module ? 'direct' : 'none';
+      if (!module) {
+        // Try without underscores (sanitized id) once
+        if (item.moduleId && typeof item.moduleId === 'string') {
+          const sanitizedModuleId = item.moduleId.replace(/_/g, '');
+          module = moduleMap[sanitizedModuleId];
+          if (module) resolvedVia = 'sanitized';
+        }
+      }
+      
+      if (!module) {
+        
+        
+        // Instead of returning null, try to render with the layout item data directly
+        // This allows the LegacyModuleAdapter to handle the module loading
+        const isSelected = selectedItem === item.i;
+        const isStudioMode = showControls; // Use control visibility instead of just mode check
+
+        // Helper function to extract plugin ID from composite ID
+        const extractPluginIdFromComposite = (compositeId: string): string => {
+          if (!compositeId) return 'unknown';
+          const tokens = compositeId.split('_');
+          if (tokens.length === 1) return tokens[0];
+          const idx = tokens.findIndex(t => /^(?:[0-9a-f]{24,}|\d{12,})$/i.test(t));
+          const boundary = idx > 0 ? idx : 2;
+          return tokens.slice(0, boundary).join('_');
+        };
+
+        // Try to extract pluginId from moduleId if item.pluginId is 'unknown'
+        let fallbackPluginId = item.pluginId;
+        if (!fallbackPluginId || fallbackPluginId === 'unknown') {
+          // Try to extract plugin ID from the module ID pattern
+          // e.g., "BrainDriveChat_1830586da8834501bea1ef1d39c3cbe8_BrainDriveChat_BrainDriveChat_1754404718788"
+          const potentialPluginId = extractPluginIdFromComposite(item.moduleId || '');
+          fallbackPluginId = potentialPluginId || fallbackPluginId;
+        }
+
+        // Extract moduleId more robustly
+        // First check if moduleId is in config (from args in database)
+        let extractedModuleId = (item.config as any)?.moduleId;
+        
+        // CRITICAL FIX: If item.moduleId is just the module name (not composite), use it directly
+        if (item.moduleId && !item.moduleId.includes('_')) {
+          extractedModuleId = item.moduleId;
+          console.log('[LayoutEngine] Using simple moduleId directly:', item.moduleId);
+        }
+        
+        console.log('[LayoutEngine] Module extraction for fallback path:', {
+          itemId: item.i,
+          itemModuleId: item.moduleId,
+          configModuleId: (item.config as any)?.moduleId,
+          config: item.config,
+          pluginId: fallbackPluginId,
+          extractedSoFar: extractedModuleId
+        });
+        
+        // If not in config and item.moduleId looks like a composite ID, try to extract
+        if (!extractedModuleId && item.moduleId && item.moduleId.includes('_')) {
+          const parts = item.moduleId.split('_');
+          const isTimestamp = (s: string) => /^\d{12,}$/.test(s);
+          extractedModuleId = parts.reverse().find(p => p && !isTimestamp(p) && p !== fallbackPluginId);
+        }
+        
+        // Otherwise use item.moduleId as-is
+        if (!extractedModuleId) {
+          extractedModuleId = item.moduleId;
+        }
+        
+        console.log('[LayoutEngine] Final extracted moduleId:', extractedModuleId);
+
+        // Create stable breakpoint object
+        const breakpointConfig = {
+          name: currentBreakpoint,
+          width: 0,
+          height: 0,
+          orientation: 'landscape' as const,
+          pixelRatio: 1,
+          containerWidth: 1200,
+          containerHeight: 800,
+        };
+
+        if (isDebugMode) {
+          console.log('[AddTrace] Resolve item (fallback path)', {
+            itemId: item.i,
+            pluginId: fallbackPluginId,
+            requestedModuleId: item.moduleId,
+            extractedModuleId
+          });
+        }
+
+        return (
+          <Box
+            key={item.i}
+            className={`layout-item react-grid-item ${isSelected ? 'layout-item--selected selected' : ''} ${isStudioMode ? 'layout-item--studio' : ''} ${isCommitHighlighted ? 'layout-item--commit-highlight' : ''}`}
+            onClick={() => handleItemClick(item.i)}
+            data-grid={item}
+            sx={{
+              position: 'relative',
+              backgroundColor: showControls ? theme.palette.background.paper : 'transparent',
+              border: showControls ? `1px solid ${theme.palette.divider}` : 'none',
+              borderRadius: showControls ? 1 : 0,
+              overflow: 'hidden',
+              transition: 'background-color 0.3s ease, border-color 0.3s ease',
+              ...(isCommitHighlighted && {
+                borderColor: theme.palette.success.main,
+                boxShadow: `0 0 0 2px ${theme.palette.success.main}33`
+              }),
+              ...(isSelected && {
+                borderColor: theme.palette.primary.main,
+                boxShadow: `0 0 0 2px ${theme.palette.primary.main}20`
+              })
+            }}
+          >
+            {/* Use the legacy GridItemControls component for consistent behavior */}
+            {showControls && (
+              <GridItemControls
+                isSelected={isSelected}
+                onConfig={() => onItemConfig?.(item.i)}
+                onRemove={() => handleItemRemove(item.i)}
+              />
+            )}
+          {(() => {
+            const activeLayout =
+              displayedLayouts[currentBreakpoint as keyof ResponsiveLayouts] ||
+              displayedLayouts.desktop || displayedLayouts.wide || [];
+            const wantsFullWidth = !showControls && (
+              (Array.isArray(activeLayout) && activeLayout.length === 1) ||
+              (Array.isArray(activeLayout) && activeLayout.some((it: any) => it?.config?.viewportFill || it?.config?.fullWidth))
+            );
+            return (
+              <ModuleRenderer
+                pluginId={fallbackPluginId}
+                moduleId={extractedModuleId}
+                additionalProps={{ ...(item.config || {}), ...(wantsFullWidth ? { viewportFill: true, centerContent: false } : {}) }}
+                fallback={<div style={{ padding: 8 }}>Loading module...</div>}
+              />
+            );
+          })()}
+        </Box>
+      );
+      }
+
+      const isSelected = selectedItem === item.i;
+      const isStudioMode = showControls; // Use control visibility instead of just mode check
+
+      if (isDebugMode) {
+        console.log('[AddTrace] Resolve item', {
+          itemId: item.i,
+          requestedPluginId: item.pluginId,
+          requestedModuleId: item.moduleId,
+          resolvedModuleKey: module?.id || '(legacy)',
+          via: resolvedVia
+        });
+      }
+
+      return (
+        <Box
+          key={item.i}
+          className={`layout-item react-grid-item ${isSelected ? 'layout-item--selected selected' : ''} ${isStudioMode ? 'layout-item--studio' : ''} ${isCommitHighlighted ? 'layout-item--commit-highlight' : ''}`}
+          onClick={() => handleItemClick(item.i)}
+          data-grid={item}
+          sx={{
+            position: 'relative',
+            backgroundColor: showControls ? theme.palette.background.paper : 'transparent',
+            border: showControls ? `1px solid ${theme.palette.divider}` : 'none',
+            borderRadius: showControls ? 1 : 0,
+            overflow: 'hidden',
+            transition: 'background-color 0.3s ease, border-color 0.3s ease',
+            ...(isCommitHighlighted && {
+              borderColor: theme.palette.success.main,
+              boxShadow: `0 0 0 2px ${theme.palette.success.main}33`
+            }),
+            ...(isSelected && {
+              borderColor: theme.palette.primary.main,
+              boxShadow: `0 0 0 2px ${theme.palette.primary.main}20`
+            })
+          }}
+        >
+          {/* Use the legacy GridItemControls component for consistent behavior */}
+          {showControls && (
+            <GridItemControls
+              isSelected={isSelected}
+              onConfig={() => onItemConfig?.(item.i)}
+              onRemove={() => handleItemRemove(item.i)}
+            />
+          )}
+          {(() => {
+            // Helper function to extract plugin ID (local copy)
+            const extractPluginIdLocal = (compositeId: string): string => {
+              if (!compositeId) return 'unknown';
+              const tokens = compositeId.split('_');
+              if (tokens.length === 1) return tokens[0];
+              const idx = tokens.findIndex(t => /^(?:[0-9a-f]{24,}|\d{12,})$/i.test(t));
+              const boundary = idx > 0 ? idx : 2;
+              return tokens.slice(0, boundary).join('_');
+            };
+
+            // Normalize current candidates
+            const candidatePluginId =
+              (item as any)?.config?._originalItem?.pluginId ||
+              (item.pluginId && item.pluginId !== 'unknown' && item.pluginId.includes('_')
+                ? item.pluginId
+                : extractPluginIdLocal(item.moduleId || (item as any)?.config?._originalItem?.moduleId || (item.i || '')));
+            const candidateModuleId = (item.config as any)?.moduleId || (item as any)?.config?._originalItem?.moduleId || item.moduleId;
+
+            // Use last known-good identity if it is more specific/complete
+            const prev = stableIdentityRef.current.get(item.i);
+            let effectivePluginId = candidatePluginId;
+            let effectiveModuleId = candidateModuleId;
+
+            if (prev) {
+              // Prefer composite plugin ids with an underscore
+              const prevIsComposite = prev.pluginId && prev.pluginId.includes('_');
+              const candIsComposite = effectivePluginId && effectivePluginId.includes('_');
+              if (prevIsComposite && !candIsComposite) {
+                effectivePluginId = prev.pluginId;
+              }
+              // Prefer previously known moduleId if current is empty/falsy
+              if (!effectiveModuleId && prev.moduleId) {
+                effectiveModuleId = prev.moduleId;
+              }
+            }
+
+            // Update cache only when both values look usable
+            if (effectivePluginId && effectiveModuleId) {
+              stableIdentityRef.current.set(item.i, {
+                pluginId: effectivePluginId,
+                moduleId: effectiveModuleId,
+              });
+            }
+
+            if (isDebugMode) {
+              console.log('[ModuleRenderTrace] Identity', {
+                id: item.i,
+                candidatePluginId,
+                candidateModuleId,
+                effectivePluginId,
+                effectiveModuleId,
+              });
+            }
+
+            const wantsFullWidth = !showControls && (
+              (Array.isArray(activeLayout) && activeLayout.length === 1) ||
+              (Array.isArray(activeLayout) && activeLayout.some((it: any) => it?.config?.viewportFill || it?.config?.fullWidth))
+            );
+            return (
+              <ModuleRenderer
+                pluginId={effectivePluginId}
+                moduleId={effectiveModuleId}
+                additionalProps={{ ...item.config, ...(wantsFullWidth ? { viewportFill: true, centerContent: false } : {}) }}
+                fallback={<div style={{ padding: 8 }}>Loading module...</div>}
+              />
+            );
+          })()}
+        </Box>
+      );
+    });
+  }, [
+    displayedLayouts,  // Changed from unifiedLayoutState.layouts
+    currentBreakpoint,
+    moduleMap,
+    selectedItem,
+    mode,
+    lazyLoading,
+    preloadPlugins,
+    handleItemClick,
+    handleItemRemove,
+    onItemConfig,
+  ]);
+
+  // Grid layout props - A4: Use displayedLayouts instead of currentLayouts
+  const gridProps = useMemo(() => {
+    // Convert ResponsiveLayouts to the format expected by react-grid-layout
+    const reactGridLayouts: any = {};
+    // Determine if we should present a full-width experience (published mode, single item or explicit flag)
+    const bpMap: Record<string, string> = { mobile: 'xs', tablet: 'sm', desktop: 'lg', wide: 'xl', ultrawide: 'xxl' };
+    const activeLayout =
+      displayedLayouts[currentBreakpoint as keyof ResponsiveLayouts] ||
+      displayedLayouts.desktop || displayedLayouts.wide || [];
+    const wantsFullWidth = !showControls && (
+      (Array.isArray(activeLayout) && activeLayout.length === 1) ||
+      (Array.isArray(activeLayout) && activeLayout.some((it: any) => it?.config?.viewportFill || it?.config?.fullWidth))
+    );
+
+    const adjustForFullWidth = (items: any[], gridBp: string) => {
+      if (!wantsFullWidth || !Array.isArray(items) || items.length === 0) return items;
+      const cols = (defaultGridConfig.cols as any)[gridBp] || 12;
+      // Expand the first item to full width
+      return items.map((it: any, idx: number) => idx === 0 ? { ...it, x: 0, w: cols } : it);
+    };
+
+    Object.entries(displayedLayouts).forEach(([breakpoint, layout]) => {
+      if (layout && Array.isArray(layout) && layout.length > 0) {
+        // Map breakpoint names to react-grid-layout breakpoint names
+        const breakpointMap: Record<string, string> = {
+          mobile: 'xs',
+          tablet: 'sm',
+          desktop: 'lg',
+          wide: 'xl',
+          ultrawide: 'xxl'
+        };
+        const gridBreakpoint = breakpointMap[breakpoint] || breakpoint;
+        reactGridLayouts[gridBreakpoint] = adjustForFullWidth(layout, gridBreakpoint);
+      }
+    });
+
+    return {
+      className: `layout-engine layout-engine--${mode}`,
+      layouts: reactGridLayouts,
+      onLayoutChange: handleLayoutChange,
+      onDragStart: handleDragStart,
+      onDragStop: handleDragStop,
+      onResizeStart: handleResizeStart,
+      onResizeStop: handleResizeStop,
+      isDraggable: showControls, // Use control visibility instead of mode
+      isResizable: showControls, // Use control visibility instead of mode
+      resizeHandles: showControls ? ['se' as const] : [], // Only show resize handles when controls are visible
+      draggableHandle: '.react-grid-dragHandleExample',
+      compactType: 'vertical' as const,
+      useCSSTransforms: true,
+      preventCollision: false,
+      allowOverlap: false,
+      measureBeforeMount: false,
+      transformScale: 1,
+      ...defaultGridConfig,
+      rowHeight: computedRowHeight,
+      containerPadding: wantsFullWidth
+        ? ([0, defaultGridConfig.containerPadding[1]] as [number, number])
+        : defaultGridConfig.containerPadding,
+      margin: wantsFullWidth
+        ? ([4, defaultGridConfig.margin[1]] as [number, number])
+        : defaultGridConfig.margin,
+      autoSize: false,
+      style: { height: '100%' },
+    };
+  }, [displayedLayouts, mode, showControls, handleLayoutChange, handleDragStart, handleDragStop, handleResizeStart, handleResizeStop, computedRowHeight, currentBreakpoint]);
+
+  // Memoize the rendered grid items with minimal stable dependencies
+  const gridItems = useMemo(() => {
+    
+    return renderGridItems();
+  }, [
+    // Only include the most essential dependencies that should trigger re-render
+    displayedLayouts,  // Changed from currentLayouts
+    currentBreakpoint,
+    moduleMap,
+    selectedItem,
+    mode,
+    commitHighlightId
+    // Removed volatile dependencies: lazyLoading, preloadPlugins, callbacks
+    // These don't affect the core rendering logic and cause unnecessary recalculations
+  ]);
+
+  return (
+    <div
+      className={`layout-engine-container ${isDragging ? 'layout-engine-container--dragging' : ''} ${isResizing ? 'layout-engine-container--resizing' : ''} ${isDragOver ? 'layout-engine-container--drag-over' : ''}`}
+      ref={containerRef}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+      style={{ position: 'relative' }}
+    >
+      {isAwaitingCommit && (
+        <Box
+          sx={{
+            position: 'absolute',
+            top: 12,
+            right: 12,
+            zIndex: 1200,
+            pointerEvents: 'none',
+            display: 'flex'
+          }}
+        >
+          <Chip
+            label="Saving layout…"
+            size="small"
+            color="info"
+            sx={{ fontWeight: 600, boxShadow: 2, opacity: 0.9 }}
+          />
+        </Box>
+      )}
+      {/* Centering wrapper to keep the grid balanced on wide screens */}
+      {(() => {
+        const activeLayout =
+          displayedLayouts[currentBreakpoint as keyof ResponsiveLayouts] ||
+          displayedLayouts.desktop || displayedLayouts.wide || [];
+        const wantsFullWidth = !showControls && (
+          (Array.isArray(activeLayout) && activeLayout.length === 1) ||
+          (Array.isArray(activeLayout) && activeLayout.some((it: any) => it?.config?.viewportFill || it?.config?.fullWidth))
+        );
+        return (
+          <div className="layout-engine-center">
+            <div className={`layout-engine-inner ${wantsFullWidth ? 'layout-engine-inner--full' : ''}`}>
+              <ResponsiveGridLayout {...gridProps}>
+                {gridItems}
+              </ResponsiveGridLayout>
+            </div>
+          </div>
+        );
+      })()}
+    </div>
+  );
+}, (prevProps, nextProps) => {
+  // Custom comparison function for React.memo
+  
+  
+  // Compare primitive props
+  if (
+    prevProps.mode !== nextProps.mode ||
+    prevProps.lazyLoading !== nextProps.lazyLoading ||
+    prevProps.pageId !== nextProps.pageId
+  ) {
+    
+    return false;
+  }
+  
+  // Compare arrays by length and content
+  if (prevProps.modules.length !== nextProps.modules.length) {
+    
+    return false;
+  }
+  
+  if ((prevProps.preloadPlugins?.length || 0) !== (nextProps.preloadPlugins?.length || 0)) {
+    
+    return false;
+  }
+  
+  // Compare layouts using JSON stringify for deep comparison
+  const prevLayoutsStr = JSON.stringify(prevProps.layouts);
+  const nextLayoutsStr = JSON.stringify(nextProps.layouts);
+  
+  if (prevLayoutsStr !== nextLayoutsStr) {
+    
+    return false;
+  }
+  
+  // Compare modules by ID (assuming modules have stable IDs)
+  for (let i = 0; i < prevProps.modules.length; i++) {
+    if (prevProps.modules[i].id !== nextProps.modules[i].id) {
+      
+      return false;
+    }
+  }
+  
+  // Skip callback function comparison - they change frequently but don't affect rendering
+  // This is the key optimization: ignore callback prop changes
+  
+  
+  
+  return true; // Props are equal, prevent re-render
+});
+
+export default DisplayLayoutEngineImpl;

--- a/frontend/src/features/unified-dynamic-page-renderer/components/LayoutEngineBase.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/LayoutEngineBase.tsx
@@ -1,0 +1,881 @@
+import React, { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { Responsive, WidthProvider } from 'react-grid-layout';
+import { RenderMode, ResponsiveLayouts, LayoutItem, ModuleConfig } from '../types';
+import { LegacyModuleAdapter } from '../adapters/LegacyModuleAdapter';
+import { useBreakpoint } from '../hooks/useBreakpoint';
+import { GridItemControls } from '../../plugin-studio/components/canvas/GridItemControls';
+import { useUnifiedLayoutState } from '../hooks/useUnifiedLayoutState';
+import { LayoutChangeOrigin } from '../utils/layoutChangeManager';
+
+const ResponsiveGridLayout = WidthProvider(Responsive);
+
+export interface LayoutEngineBaseProps {
+  layouts: ResponsiveLayouts;
+  modules: ModuleConfig[];
+  mode: RenderMode;
+  lazyLoading?: boolean;
+  preloadPlugins?: string[];
+  pageId?: string; // Add pageId to detect page changes
+  onLayoutChange?: (layouts: ResponsiveLayouts) => void;
+  onItemAdd?: (item: LayoutItem) => void;
+  onItemRemove?: (itemId: string) => void;
+  onItemSelect?: (itemId: string) => void;
+  onItemConfig?: (itemId: string) => void;
+}
+
+const defaultGridConfig = {
+  cols: { xxl: 12, xl: 12, lg: 12, sm: 8, xs: 4 },
+  rowHeight: 60,
+  margin: [10, 10] as [number, number],
+  containerPadding: [10, 10] as [number, number],
+  breakpoints: { xxl: 1600, xl: 1400, lg: 1024, sm: 768, xs: 0 },
+};
+
+export const LayoutEngineBase: React.FC<LayoutEngineBaseProps> = React.memo(({
+  layouts,
+  modules,
+  mode,
+  lazyLoading = true,
+  preloadPlugins = [],
+  pageId,
+  onLayoutChange,
+  onItemAdd,
+  onItemRemove,
+  onItemSelect,
+  onItemConfig,
+}) => {
+  // Debug: Track component re-renders
+  const layoutEngineRenderCount = useRef(0);
+  layoutEngineRenderCount.current++;
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log(`[LayoutEngine] COMPONENT RENDER #${layoutEngineRenderCount.current}`, {
+      layoutsKeys: Object.keys(layouts),
+      modulesLength: modules.length,
+      mode,
+      lazyLoading,
+      preloadPluginsLength: preloadPlugins.length,
+    });
+  }
+
+  // Use unified layout state management with stable reference
+  const unifiedLayoutState = useUnifiedLayoutState({
+    initialLayouts: layouts,
+    debounceMs: 200, // Increase debounce to prevent rapid updates
+    onLayoutPersist: (persistedLayouts, origin) => {
+      console.log(`[LayoutEngine] Persisting layout change from ${origin.source}`);
+      onLayoutChange?.(persistedLayouts);
+    },
+    onError: (error) => {
+      console.error('[LayoutEngine] Layout state error:', error);
+    }
+  });
+
+  // Create ultra-stable layouts reference using JSON comparison
+  const stableLayoutsRef = useRef<ResponsiveLayouts>({
+    mobile: [],
+    tablet: [],
+    desktop: [],
+    wide: [],
+    ultrawide: []
+  });
+  
+  const currentLayouts = useMemo(() => {
+    const newLayouts = unifiedLayoutState.layouts || {
+      mobile: [],
+      tablet: [],
+      desktop: [],
+      wide: [],
+      ultrawide: []
+    };
+    
+    // Only update if the actual content has changed (deep comparison)
+    const currentHash = JSON.stringify(stableLayoutsRef.current);
+    const newHash = JSON.stringify(newLayouts);
+    
+    if (currentHash !== newHash) {
+      stableLayoutsRef.current = newLayouts;
+    }
+    
+    return stableLayoutsRef.current;
+  }, [unifiedLayoutState.layouts]);
+
+  // Local UI state
+  const [selectedItem, setSelectedItem] = useState<string | null>(null);
+  const [isDragging, setIsDragging] = useState(false);
+  const [isResizing, setIsResizing] = useState(false);
+  const [isDragOver, setIsDragOver] = useState(false);
+
+  // Bounce tracking to keep Studio zero-bounce without controller V2
+  const previousPositionsRef = useRef<
+    Map<string, { x: number; y: number; w: number; h: number; timestamp: number }>
+  >(new Map());
+  const intendedPositionsRef = useRef<
+    Map<string, { x: number; y: number; w: number; h: number; timestamp: number }>
+  >(new Map());
+  const bounceWindowMs = 1000;
+
+  const debugLog = useCallback((message: string, details?: Record<string, unknown>) => {
+    if (process.env.NODE_ENV !== 'development') {
+      return;
+    }
+    const payload = details ? JSON.stringify(details) : '';
+    console.log(`[LayoutEngineBase] ${message}${payload ? ` :: ${payload}` : ''}`);
+  }, []);
+
+  const { currentBreakpoint } = useBreakpoint();
+  
+  // Track operation IDs for proper state management
+  const currentOperationId = useRef<string | null>(null);
+  const pageIdRef = useRef<string | undefined>(pageId);
+
+  // Handle external layout changes (from props)
+  useEffect(() => {
+    // Reset layouts when page changes
+    if (pageId !== pageIdRef.current) {
+      console.log('[LayoutEngineBase] Page changed, resetting layouts');
+      unifiedLayoutState.resetLayouts(layouts);
+      pageIdRef.current = pageId;
+      previousPositionsRef.current.clear();
+      intendedPositionsRef.current.clear();
+      return;
+    }
+
+    // Skip if layouts are semantically identical
+    if (unifiedLayoutState.compareWithCurrent(layouts)) {
+      return;
+    }
+
+    // Skip during active operations to prevent interference
+    if (isDragging || isResizing) {
+      console.log('[LayoutEngine] Skipping external sync during active operation');
+      return;
+    }
+
+    // Update from external source
+    console.log('[LayoutEngine] Syncing external layout change');
+    unifiedLayoutState.updateLayouts(layouts, {
+      source: 'external-sync',
+      timestamp: Date.now()
+    });
+  }, [layouts, pageId, isDragging, isResizing, unifiedLayoutState]);
+
+  // Handle layout change - convert from react-grid-layout format to our format
+  const handleLayoutChange = useCallback((layout: any[] = [], allLayouts: any = {}) => {
+    const operationId = currentOperationId.current;
+    const items = Array.isArray(layout) ? layout : [];
+    const now = Date.now();
+
+    // Guard against bounce regressions by ignoring rapid post-operation flips
+    if (!operationId && !isDragging && !isResizing && items.length > 0) {
+      const bounceDetected = items.some(item => {
+        const key = `${item.i}`;
+        const intended = intendedPositionsRef.current.get(key);
+        if (!intended) {
+          return false;
+        }
+        const moved = intended.x !== item.x || intended.y !== item.y ||
+                      intended.w !== item.w || intended.h !== item.h;
+        const withinWindow = now - intended.timestamp < bounceWindowMs;
+        if (moved && withinWindow) {
+          debugLog('Bounce suppressed', {
+            itemId: item.i,
+            intended,
+            next: { x: item.x, y: item.y, w: item.w, h: item.h },
+            deltaMs: now - intended.timestamp
+          });
+          return true;
+        }
+        return false;
+      });
+
+      if (bounceDetected) {
+        return;
+      }
+    }
+
+    const recordPositions = () => {
+      items.forEach(item => {
+        const key = `${item.i}`;
+        const prev = previousPositionsRef.current.get(key);
+        const current = { x: item.x, y: item.y, w: item.w, h: item.h, timestamp: now };
+
+        if (prev) {
+          const deltaX = current.x - prev.x;
+          const deltaY = current.y - prev.y;
+          const deltaW = current.w - prev.w;
+          const deltaH = current.h - prev.h;
+          if (deltaX || deltaY || deltaW || deltaH) {
+            debugLog('Position changed', {
+              itemId: item.i,
+              deltaX,
+              deltaY,
+              deltaW,
+              deltaH
+            });
+          }
+        }
+
+        previousPositionsRef.current.set(key, current);
+      });
+    };
+
+    recordPositions();
+
+    const normalizeItems = (itemsToNormalize: any[] = []): LayoutItem[] => {
+      return (itemsToNormalize || []).map((it: any) => {
+        const draft: LayoutItem = {
+          i: it?.i ?? '',
+          x: it?.x ?? 0,
+          y: it?.y ?? 0,
+          w: it?.w ?? 2,
+          h: it?.h ?? 2,
+          moduleId: it?.moduleId || it?.i || '',
+          pluginId: it?.pluginId || 'unknown',
+          minW: it?.minW,
+          minH: it?.minH,
+          isDraggable: it?.isDraggable ?? true,
+          isResizable: it?.isResizable ?? true,
+          static: it?.static ?? false,
+          config: it?.config
+        };
+        return draft;
+      });
+    };
+
+    const convertedLayouts: ResponsiveLayouts = {
+      mobile: [],
+      tablet: [],
+      desktop: [],
+      wide: [],
+      ultrawide: []
+    };
+
+    const breakpointMap: Record<string, keyof ResponsiveLayouts> = {
+      xs: 'mobile',
+      sm: 'tablet',
+      lg: 'desktop',
+      xl: 'wide',
+      xxl: 'ultrawide',
+      mobile: 'mobile',
+      tablet: 'tablet',
+      desktop: 'desktop',
+      wide: 'wide',
+      ultrawide: 'ultrawide'
+    };
+
+    Object.entries(allLayouts).forEach(([gridBreakpoint, gridLayout]: [string, any]) => {
+      const ourBreakpoint = breakpointMap[gridBreakpoint];
+      if (ourBreakpoint && Array.isArray(gridLayout)) {
+        convertedLayouts[ourBreakpoint] = normalizeItems(gridLayout as any[]);
+      }
+    });
+
+    if (items.length > 0 && currentBreakpoint) {
+      const ourBreakpoint = breakpointMap[currentBreakpoint];
+      if (ourBreakpoint) {
+        convertedLayouts[ourBreakpoint] = normalizeItems(items);
+      }
+    }
+
+    const origin: LayoutChangeOrigin = {
+      source: isDragging ? 'user-drag' : isResizing ? 'user-resize' : 'external-sync',
+      timestamp: now,
+      operationId: operationId || undefined
+    };
+
+    unifiedLayoutState.updateLayouts(convertedLayouts, origin);
+
+    if (operationId && (origin.source === 'user-drag' || origin.source === 'user-resize') && items.length > 0) {
+      items.forEach(item => {
+        intendedPositionsRef.current.set(`${item.i}`, {
+          x: item.x,
+          y: item.y,
+          w: item.w,
+          h: item.h,
+          timestamp: now
+        });
+      });
+    }
+  }, [
+    bounceWindowMs,
+    currentBreakpoint,
+    debugLog,
+    intendedPositionsRef,
+    isDragging,
+    isResizing,
+    previousPositionsRef,
+    unifiedLayoutState
+  ]);
+
+  // Handle drag start
+  const handleDragStart = useCallback(() => {
+    const operationId = `drag-${Date.now()}`;
+    currentOperationId.current = operationId;
+    setIsDragging(true);
+    unifiedLayoutState.startOperation(operationId);
+    console.log('[LayoutEngine] Started drag operation:', operationId);
+  }, [unifiedLayoutState]);
+
+  // Handle drag stop
+  const handleDragStop = useCallback((layout: any[], ..._args: any[]) => {
+    if (currentOperationId.current) {
+      unifiedLayoutState.stopOperation(currentOperationId.current);
+      console.log('[LayoutEngine] Stopped drag operation:', currentOperationId.current);
+      currentOperationId.current = null;
+    }
+    setIsDragging(false);
+
+    if (Array.isArray(layout)) {
+      const now = Date.now();
+      layout.forEach(item => {
+        intendedPositionsRef.current.set(`${item.i}`, {
+          x: item.x,
+          y: item.y,
+          w: item.w,
+          h: item.h,
+          timestamp: now
+        });
+      });
+    }
+  }, [unifiedLayoutState]);
+
+  // Handle resize start
+  const handleResizeStart = useCallback(() => {
+    const operationId = `resize-${Date.now()}`;
+    currentOperationId.current = operationId;
+    setIsResizing(true);
+    unifiedLayoutState.startOperation(operationId);
+    console.log('[LayoutEngine] Started resize operation:', operationId);
+  }, [unifiedLayoutState]);
+
+  // Handle resize stop
+  const handleResizeStop = useCallback((layout: any[], ..._args: any[]) => {
+    if (currentOperationId.current) {
+      unifiedLayoutState.stopOperation(currentOperationId.current);
+      console.log('[LayoutEngine] Stopped resize operation:', currentOperationId.current);
+      currentOperationId.current = null;
+    }
+    setIsResizing(false);
+
+    if (Array.isArray(layout)) {
+      const now = Date.now();
+      layout.forEach(item => {
+        intendedPositionsRef.current.set(`${item.i}`, {
+          x: item.x,
+          y: item.y,
+          w: item.w,
+          h: item.h,
+          timestamp: now
+        });
+      });
+    }
+  }, [unifiedLayoutState]);
+
+  // Handle drag over for drop zone functionality
+  const handleDragOver = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    e.dataTransfer.dropEffect = 'copy';
+    
+    // Check if the dataTransfer contains module data
+    const types = e.dataTransfer.types;
+    const hasModuleData = types.includes('module') || types.includes('text/plain');
+    
+    if (hasModuleData && mode === RenderMode.STUDIO) {
+      setIsDragOver(true);
+    }
+  }, [mode]);
+
+  // Handle drag leave
+  const handleDragLeave = useCallback(() => {
+    setIsDragOver(false);
+  }, []);
+
+  // Handle drop for adding new modules
+  const handleDrop = useCallback((e: React.DragEvent<HTMLDivElement>) => {
+    e.preventDefault();
+    setIsDragOver(false);
+    
+    if (mode !== RenderMode.STUDIO) return;
+    
+    try {
+      // Try to get the module data from the drag event
+      let moduleDataStr = e.dataTransfer.getData('module');
+      
+      // If module data is not available, try text/plain as fallback
+      if (!moduleDataStr) {
+        moduleDataStr = e.dataTransfer.getData('text/plain');
+      }
+      
+      if (!moduleDataStr) {
+        console.error('No module data found in drop event');
+        return;
+      }
+      
+      // Parse the module data
+      const moduleData = JSON.parse(moduleDataStr);
+      console.log('Parsed module data:', moduleData);
+      
+      // Calculate the drop position relative to the grid
+      const rect = e.currentTarget.getBoundingClientRect();
+      const x = Math.floor((e.clientX - rect.left) / 120); // Grid cell width approximation
+      const y = Math.floor((e.clientY - rect.top) / 80);   // Grid cell height approximation
+      
+      // Create a unique ID for the module
+      const uniqueId = `${moduleData.pluginId}_${moduleData.moduleId}_${Date.now()}`;
+      
+      // Default size for new modules
+      const defaultWidth = 4;
+      const defaultHeight = 3;
+      
+      // Create the new layout item
+      const newItem: LayoutItem = {
+        i: uniqueId,
+        x: Math.max(0, x),
+        y: Math.max(0, y),
+        w: defaultWidth,
+        h: defaultHeight,
+        moduleId: moduleData.moduleId, // Use the actual moduleId from drag data, not the unique ID
+        pluginId: moduleData.pluginId,
+        config: {
+          moduleId: moduleData.moduleId,
+          displayName: moduleData.displayName || moduleData.moduleName,
+          ...moduleData.config
+        },
+        isDraggable: true,
+        isResizable: true,
+        static: false
+      };
+      
+      console.log('Adding new item to layout:', newItem);
+      
+      // Add the item to the current layouts
+      const updatedLayouts = { ...currentLayouts };
+      Object.keys(updatedLayouts).forEach(breakpoint => {
+        const currentLayout = updatedLayouts[breakpoint as keyof ResponsiveLayouts];
+        if (currentLayout) {
+          updatedLayouts[breakpoint as keyof ResponsiveLayouts] = [
+            ...currentLayout,
+            newItem
+          ];
+        }
+      });
+      
+      // Update through unified state management
+      unifiedLayoutState.updateLayouts(updatedLayouts, {
+        source: 'drop-add',
+        timestamp: Date.now()
+      });
+      
+      onItemAdd?.(newItem);
+      
+      // Select the newly added item (batched to prevent additional renders)
+      setTimeout(() => {
+        setSelectedItem(uniqueId);
+        onItemSelect?.(uniqueId);
+      }, 0);
+      
+    } catch (error) {
+      console.error('Error handling drop:', error);
+    }
+  }, [mode, unifiedLayoutState, onItemAdd, onItemSelect]);
+
+  // Handle item selection
+  const handleItemClick = useCallback((itemId: string) => {
+    if (mode === RenderMode.STUDIO) {
+      // Don't toggle selection during drag or resize operations
+      if (isDragging || isResizing) {
+        return;
+      }
+      setSelectedItem(prev => prev === itemId ? null : itemId);
+      onItemSelect?.(itemId);
+    }
+  }, [mode, onItemSelect, isDragging, isResizing]);
+
+  // Handle item removal
+  const handleItemRemove = useCallback((itemId: string) => {
+    console.log(`[LayoutEngine] Removing item: ${itemId}`);
+    
+    // Create new layouts with the item removed from all breakpoints
+    const updatedLayouts: ResponsiveLayouts = {
+      mobile: currentLayouts.mobile?.filter((item: LayoutItem) => item.i !== itemId) || [],
+      tablet: currentLayouts.tablet?.filter((item: LayoutItem) => item.i !== itemId) || [],
+      desktop: currentLayouts.desktop?.filter((item: LayoutItem) => item.i !== itemId) || [],
+      wide: currentLayouts.wide?.filter((item: LayoutItem) => item.i !== itemId) || [],
+      ultrawide: currentLayouts.ultrawide?.filter((item: LayoutItem) => item.i !== itemId) || []
+    };
+
+    // Update through unified state management
+    unifiedLayoutState.updateLayouts(updatedLayouts, {
+      source: 'user-remove',
+      timestamp: Date.now(),
+      operationId: `remove-${itemId}-${Date.now()}`
+    });
+
+    // Clear selection if the removed item was selected
+    if (selectedItem === itemId) {
+      setSelectedItem(null);
+    }
+
+    // Call the external callback if provided
+    onItemRemove?.(itemId);
+  }, [currentLayouts, unifiedLayoutState, selectedItem, onItemRemove]);
+
+  // Create ultra-stable module map with deep comparison
+  const stableModuleMapRef = useRef<Record<string, ModuleConfig>>({});
+  
+  const moduleMap = useMemo(() => {
+    const newModuleMap = modules.reduce((map, module) => {
+      map[module.id] = module;
+      return map;
+    }, {} as Record<string, ModuleConfig>);
+    
+    // Only update if the actual content has changed (deep comparison)
+    const currentHash = JSON.stringify(stableModuleMapRef.current);
+    const newHash = JSON.stringify(newModuleMap);
+    
+    if (currentHash !== newHash) {
+      stableModuleMapRef.current = newModuleMap;
+    }
+    
+    return stableModuleMapRef.current;
+  }, [modules]);
+
+  // Render grid items
+  const renderGridItems = useCallback(() => {
+    const currentLayout = currentLayouts[currentBreakpoint as keyof ResponsiveLayouts] || currentLayouts.desktop || [];
+    
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`[LayoutEngine] RENDER TRIGGERED - Rendering ${currentLayout.length} items for breakpoint: ${currentBreakpoint}`, {
+        availableModules: Object.keys(moduleMap),
+        availableModuleDetails: Object.entries(moduleMap).map(([id, mod]) => ({ id, pluginId: mod.pluginId })),
+        layoutItems: currentLayout.map((item: LayoutItem) => ({ i: item.i, moduleId: item.moduleId, pluginId: item.pluginId })),
+        currentLayouts: Object.keys(currentLayouts),
+        currentBreakpoint,
+        stackTrace: new Error().stack?.split('\n').slice(0, 5).join('\n')
+      });
+    }
+    
+    return currentLayout.map((item: LayoutItem) => {
+      // Try to find the module by moduleId with multiple strategies
+      let module = moduleMap[item.moduleId];
+      
+      // If direct lookup fails, try alternative matching strategies
+      if (!module) {
+        // Strategy 1: Try without underscores (sanitized version)
+        const sanitizedModuleId = item.moduleId.replace(/_/g, '');
+        module = moduleMap[sanitizedModuleId];
+        
+        if (module) {
+          if (process.env.NODE_ENV === 'development') {
+            console.log(`[LayoutEngine] Found module using sanitized ID: ${sanitizedModuleId} for original: ${item.moduleId}`);
+          }
+        } else {
+          // Strategy 2: Try finding by pluginId match
+          for (const [moduleId, moduleConfig] of Object.entries(moduleMap)) {
+            if (moduleConfig.pluginId === item.pluginId) {
+              module = moduleConfig;
+              if (process.env.NODE_ENV === 'development') {
+                console.log(`[LayoutEngine] Found module by pluginId match: ${moduleId} for ${item.moduleId}`);
+              }
+              break;
+            }
+          }
+        }
+      }
+      
+      if (!module) {
+        if (process.env.NODE_ENV === 'development') {
+          console.warn(`[LayoutEngine] Module not found for moduleId: ${item.moduleId}`, {
+            availableModules: Object.keys(moduleMap),
+            availableModuleDetails: Object.entries(moduleMap).map(([id, mod]) => ({ id, pluginId: mod.pluginId })),
+            layoutItem: item,
+            searchedModuleId: item.moduleId,
+            itemPluginId: item.pluginId
+          });
+        }
+        
+        // Instead of returning null, try to render with the layout item data directly
+        // This allows the LegacyModuleAdapter to handle the module loading
+        const isSelected = selectedItem === item.i;
+        const isStudioMode = mode === RenderMode.STUDIO;
+
+        // Try to extract pluginId from moduleId if item.pluginId is 'unknown'
+        let fallbackPluginId = item.pluginId;
+        if (!fallbackPluginId || fallbackPluginId === 'unknown') {
+          // Try to extract plugin ID from the module ID pattern
+          // e.g., "BrainDriveChat_1830586da8834501bea1ef1d39c3cbe8_BrainDriveChat_BrainDriveChat_1754404718788"
+          const moduleIdParts = item.moduleId.split('_');
+          if (moduleIdParts.length > 0) {
+            const potentialPluginId = moduleIdParts[0];
+            // Check if this matches any available plugin
+            const availablePluginIds = ['BrainDriveBasicAIChat', 'BrainDriveChat', 'BrainDriveSettings'];
+            if (availablePluginIds.includes(potentialPluginId)) {
+              fallbackPluginId = potentialPluginId;
+              if (process.env.NODE_ENV === 'development') {
+                console.log(`[LayoutEngine] Extracted pluginId '${fallbackPluginId}' from moduleId '${item.moduleId}'`);
+              }
+            }
+          }
+        }
+
+        // Extract simple module ID from complex ID - calculate directly to avoid useMemo in render loop
+        // Pattern: BrainDriveBasicAIChat_59898811a4b34d9097615ed6698d25f6_1754507768265
+        // We want: 59898811a4b34d9097615ed6698d25f6
+        const parts = item.moduleId.split('_');
+        const extractedModuleId = parts.length >= 2 ? parts[1] : item.moduleId;
+
+        // Create stable breakpoint object
+        const breakpointConfig = {
+          name: currentBreakpoint,
+          width: 0,
+          height: 0,
+          orientation: 'landscape' as const,
+          pixelRatio: 1,
+          containerWidth: 1200,
+          containerHeight: 800,
+        };
+
+        return (
+          <div
+            key={item.i}
+            className={`layout-item react-grid-item ${isSelected ? 'layout-item--selected selected' : ''} ${isStudioMode ? 'layout-item--studio' : ''}`}
+            onClick={() => handleItemClick(item.i)}
+            data-grid={item}
+            style={{ position: 'relative' }}
+          >
+            {/* Use the legacy GridItemControls component for consistent behavior */}
+            {isStudioMode && (
+              <GridItemControls
+                isSelected={isSelected}
+                onConfig={() => onItemConfig?.(item.i)}
+                onRemove={() => handleItemRemove(item.i)}
+              />
+            )}
+            <LegacyModuleAdapter
+              pluginId={fallbackPluginId}
+              moduleId={extractedModuleId}
+              moduleName={undefined}
+              moduleProps={item.config || {}}
+              useUnifiedRenderer={true}
+              mode={mode === RenderMode.STUDIO ? 'studio' : 'published'}
+              breakpoint={breakpointConfig}
+              lazyLoading={lazyLoading}
+              priority={preloadPlugins.includes(item.pluginId) ? 'high' : 'normal'}
+              enableMigrationWarnings={false}
+              fallbackStrategy="on-error"
+              performanceMonitoring={process.env.NODE_ENV === 'development'}
+            />
+          </div>
+        );
+      }
+
+      const isSelected = selectedItem === item.i;
+      const isStudioMode = mode === RenderMode.STUDIO;
+
+      return (
+        <div
+          key={item.i}
+          className={`layout-item react-grid-item ${isSelected ? 'layout-item--selected selected' : ''} ${isStudioMode ? 'layout-item--studio' : ''}`}
+          onClick={() => handleItemClick(item.i)}
+          data-grid={item}
+          style={{ position: 'relative' }}
+        >
+          {/* Use the legacy GridItemControls component for consistent behavior */}
+          {isStudioMode && (
+            <GridItemControls
+              isSelected={isSelected}
+              onConfig={() => onItemConfig?.(item.i)}
+              onRemove={() => handleItemRemove(item.i)}
+            />
+          )}
+          
+          <LegacyModuleAdapter
+            pluginId={item.pluginId}
+            moduleId={module._legacy?.moduleId || (() => {
+              // Extract simple module ID from complex ID
+              // Pattern: BrainDriveBasicAIChat_59898811a4b34d9097615ed6698d25f6_1754507768265
+              // We want: 59898811a4b34d9097615ed6698d25f6
+              const parts = item.moduleId.split('_');
+              if (parts.length >= 2) {
+                // The module ID is typically the second part (after plugin name)
+                return parts[1];
+              }
+              return item.moduleId; // fallback to original if pattern doesn't match
+            })()}
+            moduleName={module._legacy?.moduleName}
+            moduleProps={module._legacy?.originalConfig || item.config}
+            useUnifiedRenderer={true}
+            mode={mode === RenderMode.STUDIO ? 'studio' : 'published'}
+            breakpoint={{
+              name: currentBreakpoint,
+              width: 0,
+              height: 0,
+              orientation: 'landscape',
+              pixelRatio: 1,
+              containerWidth: 1200,
+              containerHeight: 800,
+            }}
+            lazyLoading={lazyLoading}
+            priority={preloadPlugins.includes(item.pluginId) ? 'high' : 'normal'}
+            enableMigrationWarnings={false}
+            fallbackStrategy="on-error"
+            performanceMonitoring={process.env.NODE_ENV === 'development'}
+          />
+        </div>
+      );
+    });
+  }, [
+    unifiedLayoutState.layouts,
+    currentBreakpoint,
+    moduleMap,
+    selectedItem,
+    mode,
+    lazyLoading,
+    preloadPlugins,
+    handleItemClick,
+    handleItemRemove,
+    onItemConfig,
+  ]);
+
+  // Grid layout props - convert ResponsiveLayouts to react-grid-layout Layouts format
+  const gridProps = useMemo(() => {
+    // Convert ResponsiveLayouts to the format expected by react-grid-layout
+    const reactGridLayouts: any = {};
+    Object.entries(currentLayouts).forEach(([breakpoint, layout]) => {
+      if (layout && Array.isArray(layout) && layout.length > 0) {
+        // Map breakpoint names to react-grid-layout breakpoint names
+        const breakpointMap: Record<string, string> = {
+          mobile: 'xs',
+          tablet: 'sm',
+          desktop: 'lg',
+          wide: 'xl',
+          ultrawide: 'xxl'
+        };
+        const gridBreakpoint = breakpointMap[breakpoint] || breakpoint;
+        reactGridLayouts[gridBreakpoint] = layout;
+      }
+    });
+
+    return {
+      className: `layout-engine layout-engine--${mode}`,
+      layouts: reactGridLayouts,
+      onLayoutChange: handleLayoutChange,
+      onDragStart: handleDragStart,
+      onDragStop: handleDragStop,
+      onResizeStart: handleResizeStart,
+      onResizeStop: handleResizeStop,
+      isDraggable: mode === RenderMode.STUDIO,
+      isResizable: mode === RenderMode.STUDIO,
+      draggableHandle: '.react-grid-dragHandleExample',
+      compactType: 'vertical' as const,
+      useCSSTransforms: true,
+      preventCollision: false,
+      allowOverlap: false,
+      measureBeforeMount: false,
+      transformScale: 1,
+      ...defaultGridConfig,
+    };
+  }, [currentLayouts, mode, handleLayoutChange, handleDragStart, handleDragStop, handleResizeStart, handleResizeStop]);
+
+  // Memoize the rendered grid items with minimal stable dependencies
+  const gridItems = useMemo(() => {
+    if (process.env.NODE_ENV === 'development') {
+      console.log(`[LayoutEngine] MEMO RECALCULATION - gridItems being recalculated`, {
+        currentLayoutsKeys: Object.keys(currentLayouts),
+        currentBreakpoint,
+        moduleMapSize: Object.keys(moduleMap).length,
+        selectedItem,
+        mode,
+        lazyLoading,
+        preloadPluginsLength: preloadPlugins.length,
+        stackTrace: new Error().stack?.split('\n').slice(0, 3).join('\n')
+      });
+    }
+    return renderGridItems();
+  }, [
+    // Only include the most essential dependencies that should trigger re-render
+    currentLayouts,
+    currentBreakpoint,
+    moduleMap,
+    selectedItem,
+    mode
+    // Removed volatile dependencies: lazyLoading, preloadPlugins, callbacks
+    // These don't affect the core rendering logic and cause unnecessary recalculations
+  ]);
+
+  return (
+    <div
+      className={`layout-engine-container ${isDragging ? 'layout-engine-container--dragging' : ''} ${isResizing ? 'layout-engine-container--resizing' : ''} ${isDragOver ? 'layout-engine-container--drag-over' : ''}`}
+      onDragOver={handleDragOver}
+      onDragLeave={handleDragLeave}
+      onDrop={handleDrop}
+    >
+      <ResponsiveGridLayout {...gridProps}>
+        {gridItems}
+      </ResponsiveGridLayout>
+    </div>
+  );
+}, (prevProps, nextProps) => {
+  // Custom comparison function for React.memo
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[LayoutEngine] MEMO COMPARISON - Checking if props are equal');
+  }
+  
+  // Compare primitive props
+  if (
+    prevProps.mode !== nextProps.mode ||
+    prevProps.lazyLoading !== nextProps.lazyLoading ||
+    prevProps.pageId !== nextProps.pageId
+  ) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[LayoutEngine] MEMO COMPARISON - Primitive props changed, re-rendering');
+    }
+    return false;
+  }
+  
+  // Compare arrays by length and content
+  if (prevProps.modules.length !== nextProps.modules.length) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[LayoutEngine] MEMO COMPARISON - Modules length changed, re-rendering');
+    }
+    return false;
+  }
+  
+  if ((prevProps.preloadPlugins?.length || 0) !== (nextProps.preloadPlugins?.length || 0)) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[LayoutEngine] MEMO COMPARISON - PreloadPlugins length changed, re-rendering');
+    }
+    return false;
+  }
+  
+  // Compare layouts using JSON stringify for deep comparison
+  const prevLayoutsStr = JSON.stringify(prevProps.layouts);
+  const nextLayoutsStr = JSON.stringify(nextProps.layouts);
+  
+  if (prevLayoutsStr !== nextLayoutsStr) {
+    if (process.env.NODE_ENV === 'development') {
+      console.log('[LayoutEngine] MEMO COMPARISON - Layouts changed, re-rendering');
+    }
+    return false;
+  }
+  
+  // Compare modules by ID (assuming modules have stable IDs)
+  for (let i = 0; i < prevProps.modules.length; i++) {
+    if (prevProps.modules[i].id !== nextProps.modules[i].id) {
+      if (process.env.NODE_ENV === 'development') {
+        console.log('[LayoutEngine] MEMO COMPARISON - Module IDs changed, re-rendering');
+      }
+      return false;
+    }
+  }
+  
+  // Skip callback function comparison - they change frequently but don't affect rendering
+  // This is the key optimization: ignore callback prop changes
+  
+  if (process.env.NODE_ENV === 'development') {
+    console.log('[LayoutEngine] MEMO COMPARISON - Props are equal, preventing re-render');
+  }
+  
+  return true; // Props are equal, prevent re-render
+});

--- a/frontend/src/features/unified-dynamic-page-renderer/components/StudioLayoutEngine.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/StudioLayoutEngine.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { RenderMode } from '../types';
+import { LayoutEngineBase, LayoutEngineBaseProps } from './LayoutEngineBase';
+
+export type StudioLayoutEngineProps = Omit<LayoutEngineBaseProps, 'mode'>;
+
+export const StudioLayoutEngine: React.FC<StudioLayoutEngineProps> = (props) => {
+  return <LayoutEngineBase {...props} mode={RenderMode.STUDIO} />;
+};
+
+export default StudioLayoutEngine;

--- a/frontend/src/features/unified-dynamic-page-renderer/components/UnifiedPageRenderer.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/UnifiedPageRenderer.tsx
@@ -1,7 +1,8 @@
 import React, { useState, useEffect, useCallback, useMemo } from 'react';
 import { RenderMode, PageData, BreakpointConfig } from '../types';
 import { ResponsiveContainer } from './ResponsiveContainer';
-import { LayoutEngine } from './LayoutEngine';
+import { StudioLayoutEngine } from './StudioLayoutEngine';
+import { DisplayLayoutEngine } from './DisplayLayoutEngine';
 import { ModeController } from './ModeController';
 import { ErrorBoundary } from './ErrorBoundary';
 import { PageProvider } from '../contexts/PageContext';
@@ -187,6 +188,20 @@ export const UnifiedPageRenderer: React.FC<UnifiedPageRendererProps> = ({
     );
   }
 
+  const engineKey = pageData?.id || pageId || route;
+  const engineCommonProps = {
+    key: engineKey,
+    layouts: pageData.layouts,
+    modules: pageData.modules,
+    lazyLoading,
+    preloadPlugins,
+    pageId: pageData.id || pageId,
+    onLayoutChange,
+    onItemSelect,
+    onItemConfig,
+    onItemRemove,
+  } as const;
+
 
   return (
     <ErrorBoundary
@@ -224,34 +239,18 @@ export const UnifiedPageRenderer: React.FC<UnifiedPageRendererProps> = ({
                   breakpoints={breakpoints}
                   containerQueries={containerQueries}
                 >
-                  <LayoutEngine
-                    key={pageData?.id || pageId || route}
-                    layouts={pageData.layouts}
-                    modules={pageData.modules}
-                    mode={currentMode}
-                    lazyLoading={lazyLoading}
-                    preloadPlugins={preloadPlugins}
-                    pageId={pageData.id || pageId}
-                    onLayoutChange={onLayoutChange}
-                    onItemSelect={onItemSelect}
-                    onItemConfig={onItemConfig}
-                    onItemRemove={onItemRemove}
-                  />
+                  {currentMode === RenderMode.STUDIO ? (
+                    <StudioLayoutEngine {...engineCommonProps} />
+                  ) : (
+                    <DisplayLayoutEngine {...engineCommonProps} mode={currentMode} />
+                  )}
                 </ResponsiveContainer>
               ) : (
-                <LayoutEngine
-                  key={pageData?.id || pageId || route}
-                  layouts={pageData.layouts}
-                  modules={pageData.modules}
-                  mode={currentMode}
-                  lazyLoading={lazyLoading}
-                  preloadPlugins={preloadPlugins}
-                  pageId={pageData.id || pageId}
-                  onLayoutChange={onLayoutChange}
-                  onItemSelect={onItemSelect}
-                  onItemConfig={onItemConfig}
-                  onItemRemove={onItemRemove}
-                />
+                currentMode === RenderMode.STUDIO ? (
+                  <StudioLayoutEngine {...engineCommonProps} />
+                ) : (
+                  <DisplayLayoutEngine {...engineCommonProps} mode={currentMode} />
+                )
               )}
             </>
           )}

--- a/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/README.md
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/README.md
@@ -1,0 +1,7 @@
+# Display Layout Controller Hooks
+
+- `useDisplayLayoutController` wraps the V2 controller state machine and buffer logic, exposing `displayedLayouts`, shared refs, and logging helpers to display-only components.
+- `useGuardedCommitQueue` encapsulates the guarded commit pipeline (version tracking, queue flushing, highlight state) so Studio code paths remain synchronous.
+- `useDisplayLayoutState` is a thin wrapper over `useUnifiedLayoutState` to keep display-specific state wiring in one module.
+
+These hooks are intentionally isolated from Studio bundles—`StudioLayoutEngine` should never import from this directory.

--- a/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/__tests__/useGuardedCommitQueue.test.ts
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/__tests__/useGuardedCommitQueue.test.ts
@@ -1,0 +1,108 @@
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { useGuardedCommitQueue } from '../useGuardedCommitQueue';
+import type { ResponsiveLayouts } from '../../../types';
+import type { UnifiedLayoutState } from '../../../hooks/useUnifiedLayoutState';
+
+const recordCommitMock = jest.fn();
+
+jest.mock('../../../utils/layoutCommitTracker', () => ({
+  getLayoutCommitTracker: () => ({
+    recordCommit: recordCommitMock,
+    hasPendingCommits: () => false,
+    trackPending: () => Promise.resolve(),
+  }),
+}));
+
+describe('useGuardedCommitQueue', () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    recordCommitMock.mockClear();
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  it('flushes pending commit state when safe setters register late', async () => {
+    const flushResolvers: { resolve?: () => void } = {};
+
+    const unifiedLayoutState = {
+      layouts: {
+        mobile: [],
+        tablet: [],
+        desktop: [],
+        wide: [],
+        ultrawide: [],
+      },
+      isLayoutChanging: false,
+      updateLayouts: jest.fn(),
+      resetLayouts: jest.fn(),
+      startOperation: jest.fn(),
+      stopOperation: jest.fn(),
+      getLayoutHash: jest.fn(() => 'hash'),
+      compareWithCurrent: jest.fn(() => false),
+      getLastCommitMeta: jest.fn(() => null),
+      getCommittedLayouts: jest.fn(() => null),
+      flush: jest.fn(() => new Promise<void>((resolve) => {
+        flushResolvers.resolve = resolve;
+      })),
+    } as unknown as UnifiedLayoutState;
+
+    const workingLayoutsRef = { current: null } as React.MutableRefObject<ResponsiveLayouts | null>;
+    const canonicalLayoutsRef = { current: null } as React.MutableRefObject<ResponsiveLayouts | null>;
+    const lastVersionRef = { current: 1 } as React.MutableRefObject<number>;
+    const controllerStateRef = { current: 'dragging' as const } as React.MutableRefObject<'dragging'>;
+    const currentOperationIdRef = { current: 'drag-1' } as React.MutableRefObject<string | null>;
+
+    const finalLayout = [{
+      i: 'item-1',
+      x: 0,
+      y: 0,
+      w: 2,
+      h: 2,
+      moduleId: 'item-1',
+      pluginId: 'plugin-1',
+    }];
+    const finalAllLayouts = { lg: finalLayout } as Record<string, any>;
+
+    const { result } = renderHook(() =>
+      useGuardedCommitQueue({
+        ENABLE_LAYOUT_CONTROLLER_V2: true,
+        layoutGracePeriod: 150,
+        userCommitDelayMs: 10,
+        isDebugMode: false,
+        logControllerState: jest.fn(),
+        transitionToState: jest.fn(),
+        unifiedLayoutState,
+        workingLayoutsRef,
+        canonicalLayoutsRef,
+        lastVersionRef,
+        controllerStateRef,
+        currentOperationIdRef,
+        useSafeCommitSetters: true,
+      })
+    );
+
+    await act(async () => {
+      result.current.scheduleCommit(0, finalLayout, finalAllLayouts, 'lg', 'item-1');
+      jest.advanceTimersByTime(0);
+      await Promise.resolve();
+    });
+
+    await waitFor(() => expect(result.current.isAwaitingCommit).toBe(true));
+
+    act(() => {
+      flushResolvers.resolve?.();
+    });
+
+    await waitFor(() => expect(result.current.isAwaitingCommit).toBe(false));
+
+    act(() => {
+      jest.advanceTimersByTime(400);
+    });
+
+    expect(unifiedLayoutState.updateLayouts).toHaveBeenCalled();
+    expect(recordCommitMock).toHaveBeenCalled();
+    expect(result.current.commitHighlightId).toBeNull();
+  });
+});

--- a/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/useDisplayLayoutController.ts
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/useDisplayLayoutController.ts
@@ -1,0 +1,194 @@
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
+import { ResponsiveLayouts } from '../../types';
+import { useDisplayLayoutState } from './useDisplayLayoutState';
+import { UnifiedLayoutState } from '../../hooks/useUnifiedLayoutState';
+
+export type ControllerState = 'idle' | 'resizing' | 'dragging' | 'grace' | 'commit';
+
+export interface UseDisplayLayoutControllerArgs {
+  layouts: ResponsiveLayouts;
+  onLayoutChange?: (layouts: ResponsiveLayouts) => void;
+  debounceMs?: number;
+  onError?: (error: Error) => void;
+}
+
+export interface UseDisplayLayoutControllerResult {
+  unifiedLayoutState: UnifiedLayoutState;
+  currentLayouts: ResponsiveLayouts;
+  displayedLayouts: ResponsiveLayouts;
+  ENABLE_LAYOUT_CONTROLLER_V2: boolean;
+  isDebugMode: boolean;
+  layoutGracePeriod: number;
+  userCommitDelayMs: number;
+  controllerStateRef: React.MutableRefObject<ControllerState>;
+  workingLayoutsRef: React.MutableRefObject<ResponsiveLayouts | null>;
+  canonicalLayoutsRef: React.MutableRefObject<ResponsiveLayouts | null>;
+  lastVersionRef: React.MutableRefObject<number>;
+  transitionToState: (newState: ControllerState, data?: any) => void;
+  logControllerState: (action: string, data?: any) => void;
+}
+
+export const useDisplayLayoutController = ({
+  layouts,
+  onLayoutChange,
+  debounceMs,
+  onError,
+}: UseDisplayLayoutControllerArgs): UseDisplayLayoutControllerResult => {
+  const ENABLE_LAYOUT_CONTROLLER_V2 = import.meta.env.VITE_LAYOUT_CONTROLLER_V2 === 'true' || false;
+  const isDebugMode = import.meta.env.VITE_LAYOUT_DEBUG === 'true';
+  const layoutGracePeriod = Number(import.meta.env.VITE_LAYOUT_GRACE_PERIOD ?? 150);
+  const userCommitDelayMs = Math.min(layoutGracePeriod, 40);
+
+  const workingLayoutsRef = useRef<ResponsiveLayouts | null>(null);
+  const canonicalLayoutsRef = useRef<ResponsiveLayouts | null>(null);
+  const controllerStateRef = useRef<ControllerState>('idle');
+  const lastVersionRef = useRef<number>(0);
+
+  const [, forceUpdate] = useState({});
+  const triggerUpdate = useCallback(() => forceUpdate({}), []);
+
+  const logControllerState = useCallback((action: string, data?: any) => {
+    if (import.meta.env.MODE === 'development' && ENABLE_LAYOUT_CONTROLLER_V2) {
+      console.log(`[LayoutController V2] ${action}`, {
+        state: controllerStateRef.current,
+        version: lastVersionRef.current,
+        workingLayouts: !!workingLayoutsRef.current,
+        canonicalLayouts: !!canonicalLayoutsRef.current,
+        timestamp: performance.now().toFixed(2),
+        ...data
+      });
+    }
+  }, [ENABLE_LAYOUT_CONTROLLER_V2]);
+
+  const transitionToState = useCallback((newState: ControllerState, data?: any) => {
+    if (!ENABLE_LAYOUT_CONTROLLER_V2) return;
+
+    const oldState = controllerStateRef.current;
+    const validTransitions: Record<ControllerState, ControllerState[]> = {
+      idle: ['resizing', 'dragging'],
+      resizing: ['grace', 'idle'],
+      dragging: ['grace', 'idle'],
+      grace: ['commit', 'idle'],
+      commit: ['idle']
+    };
+
+    if (!validTransitions[oldState].includes(newState)) {
+      logControllerState('INVALID_STATE_TRANSITION', {
+        from: oldState,
+        to: newState,
+        allowed: validTransitions[oldState],
+        ...data
+      });
+      return;
+    }
+
+    controllerStateRef.current = newState;
+    logControllerState(`STATE_TRANSITION: ${oldState} -> ${newState}`, data);
+    triggerUpdate();
+  }, [ENABLE_LAYOUT_CONTROLLER_V2, logControllerState, triggerUpdate]);
+
+  useEffect(() => {
+    if (ENABLE_LAYOUT_CONTROLLER_V2) {
+      logControllerState('CONTROLLER_INITIALIZED', {
+        featureFlag: ENABLE_LAYOUT_CONTROLLER_V2,
+        environment: import.meta.env.MODE
+      });
+    }
+  }, [ENABLE_LAYOUT_CONTROLLER_V2, logControllerState]);
+
+  const unifiedLayoutState = useDisplayLayoutState({
+    initialLayouts: layouts,
+    debounceMs,
+    onLayoutPersist: (persistedLayouts, origin) => {
+      onLayoutChange?.(persistedLayouts);
+    },
+    onError,
+  });
+
+  const stableLayoutsRef = useRef<ResponsiveLayouts>({
+    mobile: [],
+    tablet: [],
+    desktop: [],
+    wide: [],
+    ultrawide: []
+  });
+
+  const currentLayouts = useMemo(() => {
+    const nextLayouts = unifiedLayoutState.layouts || {
+      mobile: [],
+      tablet: [],
+      desktop: [],
+      wide: [],
+      ultrawide: []
+    };
+
+    const currentHash = JSON.stringify(stableLayoutsRef.current);
+    const newHash = JSON.stringify(nextLayouts);
+
+    if (currentHash !== newHash) {
+      stableLayoutsRef.current = nextLayouts;
+    }
+
+    return stableLayoutsRef.current;
+  }, [unifiedLayoutState.layouts]);
+
+  const displayedLayouts = useMemo(() => {
+    if (!ENABLE_LAYOUT_CONTROLLER_V2) {
+      return currentLayouts;
+    }
+
+    const state = controllerStateRef.current;
+    if (state === 'resizing' || state === 'dragging' || state === 'grace') {
+      logControllerState('DISPLAY_WORKING_BUFFER', { state });
+      return workingLayoutsRef.current || currentLayouts;
+    }
+
+    logControllerState('DISPLAY_CANONICAL_BUFFER', {
+      state,
+      usingCurrentLayouts: true
+    });
+    return currentLayouts;
+  }, [ENABLE_LAYOUT_CONTROLLER_V2, currentLayouts, logControllerState]);
+
+  useEffect(() => {
+    if (!ENABLE_LAYOUT_CONTROLLER_V2) {
+      return;
+    }
+
+    if (controllerStateRef.current === 'idle') {
+      const layoutsWithUltrawide = {
+        ...currentLayouts,
+        ultrawide: currentLayouts.ultrawide || []
+      };
+      canonicalLayoutsRef.current = layoutsWithUltrawide;
+      workingLayoutsRef.current = layoutsWithUltrawide;
+      logControllerState('BUFFERS_SYNCED', {
+        source: 'external_update',
+        state: controllerStateRef.current,
+        itemCount: currentLayouts?.desktop?.length || 0,
+        hasUltrawide: !!layoutsWithUltrawide.ultrawide
+      });
+    } else {
+      logControllerState('BUFFER_SYNC_SKIPPED', {
+        reason: 'operation_in_progress',
+        state: controllerStateRef.current
+      });
+    }
+  }, [ENABLE_LAYOUT_CONTROLLER_V2, currentLayouts, logControllerState]);
+
+  return {
+    unifiedLayoutState,
+    currentLayouts,
+    displayedLayouts,
+    ENABLE_LAYOUT_CONTROLLER_V2,
+    isDebugMode,
+    layoutGracePeriod,
+    userCommitDelayMs,
+    controllerStateRef,
+    workingLayoutsRef,
+    canonicalLayoutsRef,
+    lastVersionRef,
+    transitionToState,
+    logControllerState
+  };
+};

--- a/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/useDisplayLayoutState.ts
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/useDisplayLayoutState.ts
@@ -1,0 +1,7 @@
+import { useUnifiedLayoutState, UnifiedLayoutState, UnifiedLayoutStateOptions } from '../../hooks/useUnifiedLayoutState';
+
+export interface DisplayLayoutStateOptions extends UnifiedLayoutStateOptions {}
+
+export const useDisplayLayoutState = (options: DisplayLayoutStateOptions = {}): UnifiedLayoutState => {
+  return useUnifiedLayoutState(options);
+};

--- a/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/useGuardedCommitQueue.ts
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/display-controller/useGuardedCommitQueue.ts
@@ -1,0 +1,404 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { ResponsiveLayouts, LayoutItem } from '../../types';
+import { generateLayoutHash } from '../../utils/layoutChangeManager';
+import { getLayoutCommitTracker } from '../../utils/layoutCommitTracker';
+import { ControllerState } from './useDisplayLayoutController';
+import { UnifiedLayoutState } from '../../hooks/useUnifiedLayoutState';
+
+interface UseGuardedCommitQueueArgs {
+  ENABLE_LAYOUT_CONTROLLER_V2: boolean;
+  layoutGracePeriod: number;
+  userCommitDelayMs: number;
+  isDebugMode: boolean;
+  logControllerState: (action: string, data?: any) => void;
+  transitionToState: (newState: ControllerState, data?: any) => void;
+  unifiedLayoutState: UnifiedLayoutState;
+  workingLayoutsRef: React.MutableRefObject<ResponsiveLayouts | null>;
+  canonicalLayoutsRef: React.MutableRefObject<ResponsiveLayouts | null>;
+  lastVersionRef: React.MutableRefObject<number>;
+  controllerStateRef: React.MutableRefObject<ControllerState>;
+  currentOperationIdRef: React.MutableRefObject<string | null>;
+  useSafeCommitSetters: boolean;
+}
+
+interface UseGuardedCommitQueueResult {
+  scheduleCommit: (delayMs?: number, finalLayout?: any, finalAllLayouts?: any, breakpoint?: string, activeItemId?: string) => void;
+  isAwaitingCommit: boolean;
+  commitHighlightId: string | null;
+}
+
+export const useGuardedCommitQueue = ({
+  ENABLE_LAYOUT_CONTROLLER_V2,
+  layoutGracePeriod,
+  userCommitDelayMs,
+  isDebugMode,
+  logControllerState,
+  transitionToState,
+  unifiedLayoutState,
+  workingLayoutsRef,
+  canonicalLayoutsRef,
+  lastVersionRef,
+  controllerStateRef,
+  currentOperationIdRef,
+  useSafeCommitSetters,
+}: UseGuardedCommitQueueArgs): UseGuardedCommitQueueResult => {
+  const commitTimerRef = useRef<NodeJS.Timeout | null>(null);
+  const awaitingCommitSetterRef = useRef<React.Dispatch<React.SetStateAction<boolean>> | null>(null);
+  const commitHighlightSetterRef = useRef<React.Dispatch<React.SetStateAction<string | null>> | null>(null);
+  const pendingAwaitingCommitRef = useRef<boolean | null>(null);
+  const pendingHighlightRef = useRef<string | null>(null);
+  const commitHighlightTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const tracker = getLayoutCommitTracker();
+
+  const [isAwaitingCommit, setIsAwaitingCommit] = useState(false);
+  const [commitHighlightId, setCommitHighlightId] = useState<string | null>(null);
+
+  const setIsAwaitingCommitSafe = useCallback((value: boolean) => {
+    if (!useSafeCommitSetters) {
+      setIsAwaitingCommit(value);
+      return;
+    }
+
+    if (awaitingCommitSetterRef.current) {
+      awaitingCommitSetterRef.current(value);
+    } else {
+      pendingAwaitingCommitRef.current = value;
+    }
+  }, [useSafeCommitSetters]);
+
+  const setCommitHighlightSafe = useCallback((value: string | null) => {
+    if (!useSafeCommitSetters) {
+      setCommitHighlightId(value);
+      return;
+    }
+
+    if (commitHighlightSetterRef.current) {
+      commitHighlightSetterRef.current(value);
+    } else {
+      pendingHighlightRef.current = value;
+    }
+  }, [useSafeCommitSetters]);
+
+  useEffect(() => {
+    if (!useSafeCommitSetters) {
+      awaitingCommitSetterRef.current = null;
+      commitHighlightSetterRef.current = null;
+      pendingAwaitingCommitRef.current = null;
+      pendingHighlightRef.current = null;
+      return;
+    }
+
+    awaitingCommitSetterRef.current = setIsAwaitingCommit;
+    commitHighlightSetterRef.current = setCommitHighlightId;
+
+    if (pendingAwaitingCommitRef.current !== null) {
+      setIsAwaitingCommit(pendingAwaitingCommitRef.current);
+      pendingAwaitingCommitRef.current = null;
+    }
+
+    if (pendingHighlightRef.current !== null) {
+      setCommitHighlightId(pendingHighlightRef.current);
+      pendingHighlightRef.current = null;
+    }
+
+    return () => {
+      if (awaitingCommitSetterRef.current === setIsAwaitingCommit) {
+        awaitingCommitSetterRef.current = null;
+      }
+      if (commitHighlightSetterRef.current === setCommitHighlightId) {
+        commitHighlightSetterRef.current = null;
+      }
+    };
+  }, [useSafeCommitSetters]);
+
+  useEffect(() => () => {
+    if (commitHighlightTimeoutRef.current) {
+      clearTimeout(commitHighlightTimeoutRef.current);
+    }
+  }, []);
+
+  const commitLayoutChanges = useCallback(async (
+    finalLayout?: any,
+    finalAllLayouts?: any,
+    breakpoint?: string,
+    activeItemId?: string
+  ) => {
+    if (!ENABLE_LAYOUT_CONTROLLER_V2) {
+      logControllerState('COMMIT_SKIPPED', {
+        reason: 'Controller disabled'
+      });
+      return;
+    }
+
+    const version = lastVersionRef.current;
+    let layouts: ResponsiveLayouts;
+
+    if (finalLayout && finalAllLayouts) {
+      const convertedLayouts: ResponsiveLayouts = {
+        mobile: [],
+        tablet: [],
+        desktop: [],
+        wide: [],
+        ultrawide: []
+      };
+      const toOurBreakpoint = (bp: string): keyof ResponsiveLayouts | undefined => {
+        const map: Record<string, keyof ResponsiveLayouts> = {
+          xs: 'mobile', sm: 'tablet', lg: 'desktop', xl: 'wide', xxl: 'ultrawide',
+          mobile: 'mobile', tablet: 'tablet', desktop: 'desktop', wide: 'wide', ultrawide: 'ultrawide'
+        };
+        return map[bp];
+      };
+
+      const normalizeItems = (items: any[] = []): LayoutItem[] => {
+        return (items || []).map((it: any) => {
+          const id = it?.i ?? '';
+          let pluginId = it?.pluginId;
+          if (!pluginId && typeof id === 'string' && id.includes('_')) {
+            pluginId = id.split('_')[0];
+          }
+          return {
+            i: id,
+            x: it?.x ?? 0,
+            y: it?.y ?? 0,
+            w: it?.w ?? 2,
+            h: it?.h ?? 2,
+            moduleId: it?.moduleId || id,
+            pluginId: pluginId || 'unknown',
+            minW: it?.minW,
+            minH: it?.minH,
+            isDraggable: it?.isDraggable ?? true,
+            isResizable: it?.isResizable ?? true,
+            static: it?.static ?? false,
+            config: it?.config
+          } as LayoutItem;
+        });
+      };
+
+      if (finalLayout && breakpoint) {
+        const ourBreakpoint = toOurBreakpoint(breakpoint);
+        if (ourBreakpoint) {
+          convertedLayouts[ourBreakpoint] = normalizeItems(finalLayout as any[]);
+
+          console.log('[RECODE_V2_BLOCK] commitLayoutChanges - using finalLayout for commit', {
+            breakpoint: ourBreakpoint,
+            itemDimensions: finalLayout.map((item: any) => ({
+              id: item.i,
+              dimensions: { w: item.w, h: item.h, x: item.x, y: item.y }
+            })),
+            version,
+            timestamp: Date.now()
+          });
+        }
+      }
+
+      Object.entries(finalAllLayouts).forEach(([gridBreakpoint, gridLayout]: [string, any]) => {
+        const ourBreakpoint = toOurBreakpoint(gridBreakpoint);
+        if (ourBreakpoint && Array.isArray(gridLayout)) {
+          if (toOurBreakpoint(gridBreakpoint) !== toOurBreakpoint(breakpoint || '') || !finalLayout) {
+            convertedLayouts[ourBreakpoint] = normalizeItems(gridLayout as any[]);
+          }
+        }
+      });
+
+      layouts = convertedLayouts;
+      workingLayoutsRef.current = convertedLayouts;
+    } else if (workingLayoutsRef.current) {
+      layouts = workingLayoutsRef.current;
+      console.log('[RECODE_V2_BLOCK] commitLayoutChanges - using workingLayoutsRef', {
+        version,
+        hasLayouts: !!workingLayoutsRef.current,
+        breakpoints: Object.keys(workingLayoutsRef.current || {}),
+        itemCounts: Object.entries(workingLayoutsRef.current || {}).map(([bp, items]) => ({
+          breakpoint: bp,
+          count: (items as any[])?.length || 0
+        })),
+        timestamp: Date.now()
+      });
+    } else {
+      console.error('[RECODE_V2_BLOCK] COMMIT SKIPPED - No layouts available!', {
+        hasWorkingBuffer: !!workingLayoutsRef.current,
+        hasCanonicalBuffer: !!canonicalLayoutsRef.current,
+        version
+      });
+      logControllerState('COMMIT_SKIPPED', {
+        reason: 'No layouts available'
+      });
+      return;
+    }
+
+    const hash = generateLayoutHash(layouts);
+
+    console.log('[RECODE_V2_BLOCK] COMMIT - About to persist layouts', {
+      version,
+      hash,
+      hasLayouts: !!layouts,
+      breakpoints: Object.keys(layouts || {}),
+      itemCounts: Object.entries(layouts || {}).map(([bp, items]) => ({
+        breakpoint: bp,
+        count: (items as any[])?.length || 0,
+        items: (items as any[])?.map((item: any) => ({
+          id: item.i,
+          dimensions: { w: item.w, h: item.h, x: item.x, y: item.y }
+        }))
+      }))
+    });
+
+    if (isDebugMode) {
+      console.log(`[LayoutEngine] Commit v${version} hash:${hash}`, {
+        source: controllerStateRef.current === 'resizing' ? 'user-resize' : 'user-drag',
+        timestamp: Date.now()
+      });
+    }
+
+    logControllerState('COMMIT_START', {
+      version,
+      hash,
+      layoutsPresent: !!layouts,
+      currentState: controllerStateRef.current
+    });
+
+    if (activeItemId) {
+      setCommitHighlightSafe(activeItemId);
+      if (commitHighlightTimeoutRef.current) {
+        clearTimeout(commitHighlightTimeoutRef.current);
+      }
+      commitHighlightTimeoutRef.current = setTimeout(() => {
+        setCommitHighlightSafe(null);
+        commitHighlightTimeoutRef.current = null;
+      }, 400);
+    }
+
+    transitionToState('commit', { version });
+
+    const originSource = controllerStateRef.current === 'resizing' ? 'user-resize' : 'user-drag';
+    const origin = {
+      source: originSource,
+      version,
+      timestamp: Date.now(),
+      operationId: currentOperationIdRef.current || `commit-${Date.now()}`
+    };
+
+    const debounceMs = originSource.startsWith('user-') ? Math.min(userCommitDelayMs, 20) : undefined;
+
+    unifiedLayoutState.updateLayouts(layouts, origin, { debounceMs });
+
+    canonicalLayoutsRef.current = JSON.parse(JSON.stringify(layouts));
+
+    const commitStart = performance.now();
+    const flushPromise = unifiedLayoutState.flush();
+    const safetyWindowMs = Math.max(layoutGracePeriod * 2, 600);
+
+    setIsAwaitingCommitSafe(true);
+
+    let flushTimedOut = false;
+    let flushError: unknown = null;
+    let timeoutHandle: ReturnType<typeof setTimeout> | null = null;
+
+    const timeoutPromise = new Promise<void>((resolve) => {
+      timeoutHandle = setTimeout(() => {
+        flushTimedOut = true;
+        resolve();
+      }, safetyWindowMs);
+    });
+
+    try {
+      await Promise.race([
+        flushPromise.catch(error => {
+          flushError = error;
+          return Promise.reject(error);
+        }),
+        timeoutPromise
+      ]);
+
+      if (!flushTimedOut) {
+        try {
+          await flushPromise;
+        } catch (error) {
+          flushError = error;
+        }
+      }
+    } catch (error) {
+      flushError = error;
+    } finally {
+      if (timeoutHandle) {
+        clearTimeout(timeoutHandle);
+      }
+      setIsAwaitingCommitSafe(false);
+
+      const flushDuration = Math.round(performance.now() - commitStart);
+      const transitionSource = flushTimedOut ? 'flush_timeout' : flushError ? 'flush_error' : 'commit_complete';
+      transitionToState('idle', { version, source: transitionSource });
+
+      if (flushTimedOut) {
+        console.warn('[LayoutEngine] Commit flush window exceeded, falling back to idle', {
+          version,
+          hash,
+          safetyWindowMs
+        });
+        logControllerState('COMMIT_FLUSH_TIMEOUT', { version, hash, safetyWindowMs });
+      } else if (flushError) {
+        console.error('[LayoutEngine] Commit flush failed', flushError);
+        logControllerState('COMMIT_FLUSH_ERROR', { version, hash, error: (flushError as Error)?.message });
+      } else {
+        logControllerState('COMMIT_COMPLETE', { version, hash, flushDuration });
+      }
+
+      if (isDebugMode) {
+        console.log(`[LayoutEngine] Commit ${transitionSource} v${version} hash:${hash}`, {
+          flushDuration,
+          flushTimedOut,
+          hasError: !!flushError,
+          debounceMs
+        });
+      }
+
+      tracker.recordCommit({
+        version,
+        hash,
+        timestamp: Date.now()
+      });
+    }
+  }, [
+    ENABLE_LAYOUT_CONTROLLER_V2,
+    canonicalLayoutsRef,
+    commitHighlightTimeoutRef,
+    isDebugMode,
+    layoutGracePeriod,
+    logControllerState,
+    setCommitHighlightSafe,
+    setIsAwaitingCommitSafe,
+    tracker,
+    transitionToState,
+    unifiedLayoutState,
+    userCommitDelayMs,
+    workingLayoutsRef,
+    lastVersionRef,
+    controllerStateRef,
+    currentOperationIdRef
+  ]);
+
+  const scheduleCommit = useCallback((delayMs: number = userCommitDelayMs, finalLayout?: any, finalAllLayouts?: any, breakpoint?: string, activeItemId?: string) => {
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current);
+    }
+
+    commitTimerRef.current = setTimeout(() => {
+      commitTimerRef.current = null;
+      void commitLayoutChanges(finalLayout, finalAllLayouts, breakpoint, activeItemId);
+    }, delayMs);
+
+    logControllerState('COMMIT_SCHEDULED', { delayMs, activeItemId });
+  }, [commitLayoutChanges, logControllerState, userCommitDelayMs]);
+
+  useEffect(() => () => {
+    if (commitTimerRef.current) {
+      clearTimeout(commitTimerRef.current);
+    }
+  }, []);
+
+  return {
+    scheduleCommit,
+    isAwaitingCommit,
+    commitHighlightId
+  };
+};

--- a/frontend/src/features/unified-dynamic-page-renderer/hooks/useUnifiedLayoutState.ts
+++ b/frontend/src/features/unified-dynamic-page-renderer/hooks/useUnifiedLayoutState.ts
@@ -23,7 +23,7 @@ export interface UnifiedLayoutState {
   isLayoutChanging: boolean;
   
   // Layout operations
-  updateLayouts: (layouts: ResponsiveLayouts, origin: LayoutChangeOrigin) => void;
+  updateLayouts: (layouts: ResponsiveLayouts, origin: LayoutChangeOrigin, options?: { debounceMs?: number }) => void;
   resetLayouts: (layouts: ResponsiveLayouts | null) => void;
   
   // Operation tracking
@@ -210,7 +210,7 @@ export function useUnifiedLayoutState(options: UnifiedLayoutStateOptions = {}): 
   }, [initialLayouts]);
 
   // Update layouts function - now stable!
-  const updateLayouts = useCallback((newLayouts: ResponsiveLayouts, origin: LayoutChangeOrigin) => {
+  const updateLayouts = useCallback((newLayouts: ResponsiveLayouts, origin: LayoutChangeOrigin, options?: { debounceMs?: number }) => {
     if (!layoutChangeManagerRef.current) {
       console.warn('[useUnifiedLayoutState] Layout change manager not initialized');
       return;
@@ -238,7 +238,7 @@ export function useUnifiedLayoutState(options: UnifiedLayoutStateOptions = {}): 
     
     // Queue the layout change with appropriate debounce key
     const debounceKey = origin.operationId || origin.source;
-    layoutChangeManagerRef.current.queueLayoutChange(newLayouts, origin, debounceKey);
+    layoutChangeManagerRef.current.queueLayoutChange(newLayouts, origin, debounceKey, options?.debounceMs);
   }, []); // Now has no dependencies - completely stable!
 
   // Reset layouts function (for page changes, etc.)

--- a/frontend/src/features/unified-dynamic-page-renderer/index.ts
+++ b/frontend/src/features/unified-dynamic-page-renderer/index.ts
@@ -1,7 +1,9 @@
 // Main exports for Unified Dynamic Page Renderer
 export { UnifiedPageRenderer } from './components/UnifiedPageRenderer';
 export { ResponsiveContainer } from './components/ResponsiveContainer';
-export { LayoutEngine } from './components/LayoutEngine';
+export { LayoutEngineBase } from './components/LayoutEngineBase';
+export { StudioLayoutEngine } from './components/StudioLayoutEngine';
+export { DisplayLayoutEngine } from './components/DisplayLayoutEngine';
 export { ModuleRenderer } from './components/ModuleRenderer';
 export { ModeController } from './components/ModeController';
 export { ErrorBoundary } from './components/ErrorBoundary';

--- a/frontend/src/features/unified-dynamic-page-renderer/styles/index.css
+++ b/frontend/src/features/unified-dynamic-page-renderer/styles/index.css
@@ -195,6 +195,12 @@
   box-shadow: 0 0 0 2px rgba(59, 130, 246, 0.1);
 }
 
+.layout-item--commit-highlight {
+  border-color: var(--mui-palette-success-main, #22c55e);
+  box-shadow: 0 0 0 2px rgba(34, 197, 94, 0.25);
+  transition: box-shadow 0.2s ease, border-color 0.2s ease;
+}
+
 .layout-item--studio {
   /* Studio mode item styles */
 }
@@ -1253,12 +1259,15 @@
 
 /* React Grid Layout Overrides */
 .react-grid-item {
-  transition: all 200ms ease;
-  transition-property: left, top, width, height;
+  transition-property: left, top, width, height, transform;
+  transition-duration: 120ms;
+  transition-timing-function: cubic-bezier(0.2, 0.8, 0.4, 1);
 }
 
 .react-grid-item.cssTransforms {
   transition-property: transform, width, height;
+  transition-duration: 120ms;
+  transition-timing-function: cubic-bezier(0.2, 0.8, 0.4, 1);
 }
 
 .react-grid-item > .react-resizable-handle {


### PR DESCRIPTION
# 📋 Pull Request: Improve Plugin Studio Layout Handling & Default Plugins

## Summary

This PR introduces several improvements across both the **backend user initializer** and the **frontend Plugin Studio / Unified Dynamic Page Renderer**:

* **Backend (GitHub Plugin Initializer)**

  * Updated default plugin repository URLs to point to the new organization repos:

    * `BrainDrive-Settings-Plugin`
    * `BrainDrive-Chat-Plugin`

* **Frontend (Plugin Studio & Unified Renderer)**

  * Simplified `DropZone` by removing redundant state and moving `addItem` into `usePluginStudio`.
  * Enhanced `GridContainer` with interaction source tracking (`user-drag`, `user-resize`, `drop-add`) and metadata propagation through `onLayoutChange`.
  * Refactored `PluginCanvas` to remove unnecessary forced re-render logic.
  * Standardized layout margins/padding to `0` across mobile, tablet, desktop, and custom breakpoints.
  * Expanded `PluginStudioContext` and `PluginStudioProvider` to include `addItem` support in context.
  * Added unit tests for `useLayout` ensuring layout changes are applied and deduplicated correctly.
  * Improved `useLayout` hook with metadata-aware persistence, debouncing, and page-level persistence logic.
  * Updated `useViewMode` for more accurate desktop width handling.
  * Replaced legacy `LayoutEngine` with new **`StudioLayoutEngine`** and **`DisplayLayoutEngine`** variants for clearer separation of Studio vs Display rendering modes.
  * Introduced new **`LayoutEngineBase`** for shared logic and **commit-safe mechanisms** (`useGuardedCommitQueue`, commit highlighting, flush handling).
  * Added CSS improvements for smoother transitions, commit highlighting, and updated grid animations.

---

## Motivation

* Ensure new users automatically receive the **correct default plugins** from the organization namespace.
* Improve **Plugin Studio stability and responsiveness** during drag, resize, and drop operations.
* Provide **better separation of concerns** between Studio (interactive editing) and Display (rendering/published mode).
* Fix long-standing layout "bounce" issues and streamline persistence for user-driven layout changes.

---

## Testing

* ✅ Verified default plugins install correctly for new users.
* ✅ Confirmed drag/resize operations in Plugin Studio now include metadata for origin tracking.
* ✅ Added unit tests (`useLayout.test.tsx`) validating deduplication of layout updates.
* ✅ Checked Unified Page Renderer correctly swaps engines depending on mode (`STUDIO` vs others).
* ✅ Verified CSS transitions for commit highlighting and grid updates.

---

## Checklist

* [x] Backend initializer URLs updated
* [x] Frontend components refactored for maintainability
* [x] New tests for `useLayout`
* [x] Verified in Studio + Unified Renderer flows

