### PR TITLE
Use dark mode logo in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
-![BrainDrive Logo](./images/Logo-Light-Mode.png)
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="./images/Logo Dark Mode (1).png" />
+  <source media="(prefers-color-scheme: light)" srcset="./images/Logo-Light-Mode.png" />
+  <img alt="BrainDrive Logo" src="./images/Logo-Light-Mode.png" />
+</picture>
 
 BrainDrive is the open source ChatGPT alternative you fully own and control. Use, customize, and monetize your BrainDrive however you want. No Big Tech overlords. Just your AI. Your rules.
 


### PR DESCRIPTION
## Summary
- update README hero logo to support light and dark color schemes via a picture element
- point the dark-mode source to `images/Logo Dark Mode (1).png`

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d5c736075083209d5ea7a918225587