### PR TITLE
fix(docker): make service installation idempotent to avoid container …

### DIFF
--- a/backend/app/plugins/service_installler/docker_manager.py
+++ b/backend/app/plugins/service_installler/docker_manager.py
@@ -113,10 +113,16 @@ async def build_and_start_docker_service(
     # Write environment file
     write_env_file(target_dir, env_vars, required_vars)
 
+    # Clean up previous containers to avoid name conflicts
+    await _run_docker_compose_command("docker compose down --remove-orphans", target_dir)
+
     # Rnu the docker compose build command
     await _run_docker_compose_command(install_command, target_dir)
 
     # Run the docker compose run command
+    # Start containers with force recreate
+    if "up" in start_command and "--force-recreate" not in start_command:
+        start_command += " --force-recreate"
     await _run_docker_compose_command(start_command, target_dir)
 
     # Wait for the service to become healthy


### PR DESCRIPTION
This update ensures Docker-based plugin services are installed and restarted idempotently.
It prevents container name conflicts during re-imports by cleaning up existing containers
within the plugin’s own compose scope before rebuild and start.

- Added `docker compose down --remove-orphans` before build/start
- Appended `--force-recreate` to start command to ensure clean container recreation
- Prevents container name conflicts when re-importing plugins multiple times
- Keeps other running plugin containers intact by scoping to per-plugin directory

Fixes #136 
Closes #136 