### PR TITLE
Refactor persona injection logic and centralize into reusable utility

### DIFF
--- a/backend/app/utils/persona_utils.py
+++ b/backend/app/utils/persona_utils.py
@@ -1,0 +1,31 @@
+from typing import List, Dict, Any, Optional, Tuple
+
+
+def apply_persona_prompt_and_params(
+    messages: List[Dict[str, Any]],
+    params: Optional[Dict[str, Any]],
+    persona_system_prompt: Optional[str],
+    persona_model_settings: Optional[Dict[str, Any]],
+    max_history: Optional[int] = None
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Ensure the persona system prompt is the leading system message and merge persona model settings into params.
+    Optionally trims history (removing oldest non-system messages) while preserving the system prompt and the latest turns.
+    """
+    params = params.copy() if params else {}
+    if persona_model_settings:
+        params.update(persona_model_settings)
+
+    # Remove existing system messages; we'll re-insert persona system prompt if provided
+    non_system_messages = [m for m in messages if m.get("role") != "system"]
+    updated_messages: List[Dict[str, Any]] = []
+
+    if persona_system_prompt:
+        updated_messages.append({"role": "system", "content": persona_system_prompt})
+
+    # Apply optional trimming on history (non-system only)
+    if max_history is not None and max_history > 0 and len(non_system_messages) > max_history:
+        non_system_messages = non_system_messages[-max_history:]
+
+    updated_messages.extend(non_system_messages)
+    return updated_messages, params


### PR DESCRIPTION
Description:
### Overview of Changes
This PR refactors the logic for injecting persona system prompts and model settings in the chat completion endpoint. The core functionality has been moved into a new utility function to improve modularity, testability, and maintainability.

### Details
- **Refactor: Simplify persona handling in chat completion endpoint**
  - Removed inlined logic that injected persona system prompts and merged model settings.
  - Eliminated redundant code for managing persona-related messages and parameters.
  - Preserved debug logging and user/conversation extraction logic.

- **Feature: Add `apply_persona_prompt_and_params` utility**
  - Introduced a new utility function in `persona_utils.py` that:
    - Ensures the persona system prompt is the leading system message.
    - Merges persona model settings into request parameters.
    - Optionally trims message history while preserving the system prompt.
  - Used this function to replace the old persona-handling logic in `chat_completion`.

- **Cleanup: Remove legacy error-handling block**
  - Removed overly broad exception handler that duplicated HTTP error logic.
  - Preserved top-level HTTPException handling to avoid losing error context.

### Motivation
The previous implementation of persona handling was tightly coupled with the endpoint logic, resulting in a large, hard-to-maintain function. Extracting this logic into a utility promotes code reuse and clarity while making it easier to test and extend persona behavior in the future.

### Impact
- **Developer Experience**: Simplifies the chat completion handler, reducing cognitive load and improving maintainability.
- **Code Reusability**: Persona logic is now centralized and reusable across different contexts or endpoints.
- **Reliability**: Cleaner handling of message history and model parameters should reduce subtle bugs and configuration errors.

### Testing
- Manual testing was performed to confirm that:
  - Persona prompts are injected as intended.
  - Model settings are properly merged.
  - Message history is trimmed when `max_history` is set.
- Verified that chat flows continue to work with and without persona settings.

### Additional Notes
- Future work may involve unit tests for `apply_persona_prompt_and_params` to further ensure robustness.
- This utility opens up the potential for configurable history trimming strategies.
