### PR TITLE
Refactor persona prompt and model settings injection into utility function

### DIFF
--- a/backend/app/utils/persona_utils.py
+++ b/backend/app/utils/persona_utils.py
@@ -1,0 +1,31 @@
+from typing import List, Dict, Any, Optional, Tuple
+
+
+def apply_persona_prompt_and_params(
+    messages: List[Dict[str, Any]],
+    params: Optional[Dict[str, Any]],
+    persona_system_prompt: Optional[str],
+    persona_model_settings: Optional[Dict[str, Any]],
+    max_history: Optional[int] = None
+) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+    """
+    Ensure the persona system prompt is the leading system message and merge persona model settings into params.
+    Optionally trims history (removing oldest non-system messages) while preserving the system prompt and the latest turns.
+    """
+    params = params.copy() if params else {}
+    if persona_model_settings:
+        params.update(persona_model_settings)
+
+    # Remove existing system messages; we'll re-insert persona system prompt if provided
+    non_system_messages = [m for m in messages if m.get("role") != "system"]
+    updated_messages: List[Dict[str, Any]] = []
+
+    if persona_system_prompt:
+        updated_messages.append({"role": "system", "content": persona_system_prompt})
+
+    # Apply optional trimming on history (non-system only)
+    if max_history is not None and max_history > 0 and len(non_system_messages) > max_history:
+        non_system_messages = non_system_messages[-max_history:]
+
+    updated_messages.extend(non_system_messages)
+    return updated_messages, params


### PR DESCRIPTION
### Overview of Changes
This PR refactors the logic for applying persona system prompts and model settings during chat completions. It moves the related logic into a new utility function to reduce duplication, improve clarity, and support future reuse. The application of persona metadata now occurs after message history merging to ensure accurate placement and parameter merging.

### Details
- **Refactor: Moved persona prompt/params logic to utility**
  - Introduced `apply_persona_prompt_and_params()` in `persona_utils.py`.
  - Centralizes logic for injecting the persona system prompt and merging persona model settings into the request parameters.
  - Supports optional trimming of historical non-system messages for more control over message length.

- **Simplification: Cleaned up chat completion logic**
  - Removed in-place logic for handling persona system prompt injection and model param merging from `chat_completion()`.
  - Replaced it with a single call to `apply_persona_prompt_and_params()` after message history and persona sample greeting are processed.
  - Updated the import to use the new utility function from `app.utils.persona_utils`.

- **Cleanup: Removed redundant try/except blocks**
  - Eliminated deeply nested exception handling inside `chat_completion()`, reducing complexity and improving readability.
  - Retained outer exception handling for proper HTTP error propagation.

### Motivation
The original inline logic for applying persona prompts and model parameters was verbose, duplicated, and fragile. Centralizing this logic improves maintainability, encourages reuse, and makes the chat flow easier to reason about, especially when considering future enhancements (e.g., dynamic prompt strategies or token management).

### Impact
- Improves developer experience by consolidating persona logic into a single utility function.
- Reduces risk of inconsistencies in how personas are applied across the codebase.
- Lays groundwork for future enhancements like prompt token management or global message validation.
- Removes redundant code and improves readability in the primary chat flow.

### Testing
- Verified that chat completions still function correctly with and without persona metadata.
- Confirmed that:
  - Persona system prompts are correctly prepended as system messages.
  - Model settings are merged as expected into request parameters.
  - Message history trimming behaves as intended when `max_history` is applied.

### Additional Notes
- Consider applying this utility in other areas where persona prompts or settings may be used.
- Future improvements might include test coverage for the utility and more robust error handling/logging.
