### PR TITLE
feat(mcp-runtime): add MCP tool registry, dynamic plugin API loading, and tool-call orchestration

### DIFF
--- a/backend/app/ai_providers/openrouter.py
+++ b/backend/app/ai_providers/openrouter.py
@@ -307,10 +307,27 @@ class OpenRouterProvider(AIProvider):
         try:
             # Call the OpenRouter API
             response = await self.client.chat.completions.create(**api_params)
+
+            message = response.choices[0].message
+            content = message.content or ""
+            raw_tool_calls = getattr(message, "tool_calls", None) or []
+            tool_calls = []
+            for tool_call in raw_tool_calls:
+                function = getattr(tool_call, "function", None)
+                tool_calls.append(
+                    {
+                        "id": getattr(tool_call, "id", None),
+                        "type": getattr(tool_call, "type", "function"),
+                        "function": {
+                            "name": getattr(function, "name", None),
+                            "arguments": getattr(function, "arguments", None),
+                        },
+                    }
+                )
             
             return {
-                "content": response.choices[0].message.content,
-                "role": response.choices[0].message.role,
+                "content": content,
+                "role": message.role,
                 "provider": "openrouter",
                 "model": model,
                 "finish_reason": response.choices[0].finish_reason,
@@ -321,7 +338,18 @@ class OpenRouterProvider(AIProvider):
                         "completion_tokens": response.usage.completion_tokens,
                         "total_tokens": response.usage.total_tokens
                     } if response.usage else None
-                }
+                },
+                "tool_calls": tool_calls,
+                "choices": [
+                    {
+                        "message": {
+                            "role": message.role,
+                            "content": content,
+                            "tool_calls": tool_calls,
+                        },
+                        "finish_reason": response.choices[0].finish_reason,
+                    }
+                ],
             }
         except Exception as e:
             raise RuntimeError(f"OpenRouter chat completion failed: {e}") from e
@@ -379,15 +407,30 @@ class OpenRouterProvider(AIProvider):
                 content = getattr(delta, "content", None) or ""
                 role = getattr(delta, "role", None) or "assistant"
                 finish_reason = choice.finish_reason
+                delta_tool_calls = []
+                raw_delta_tool_calls = getattr(delta, "tool_calls", None) or []
+                for tool_call in raw_delta_tool_calls:
+                    function = getattr(tool_call, "function", None)
+                    delta_tool_calls.append(
+                        {
+                            "id": getattr(tool_call, "id", None),
+                            "type": getattr(tool_call, "type", "function"),
+                            "function": {
+                                "name": getattr(function, "name", None),
+                                "arguments": getattr(function, "arguments", None),
+                            },
+                        }
+                    )
 
                 # Emit terminal finish chunks even when content is empty.
-                if content or finish_reason is not None:
+                if content or finish_reason is not None or delta_tool_calls:
                     yield {
                         "choices": [
                             {
                                 "delta": {
                                     "content": content,
-                                    "role": role
+                                    "role": role,
+                                    "tool_calls": delta_tool_calls,
                                 },
                                 "finish_reason": finish_reason
                             }

--- a/backend/app/ai_providers/openrouter.py
+++ b/backend/app/ai_providers/openrouter.py
@@ -1,6 +1,7 @@
 """
 OpenRouter provider implementation.
 """
+import re
 from typing import Dict, List, Any, AsyncGenerator
 from openai import AsyncOpenAI
 from .base import AIProvider
@@ -8,6 +9,21 @@ from .base import AIProvider
 
 class OpenRouterProvider(AIProvider):
     """OpenRouter provider implementation."""
+
+    @staticmethod
+    def _normalize_model_id(model: str) -> str:
+        normalized = str(model or "").strip()
+        if not normalized:
+            return normalized
+
+        lowered = normalized.lower()
+        if lowered in {"openai/gpt-4o-mini-2024-11-20", "gpt-4o-mini-2024-11-20"}:
+            return "openai/gpt-4o-mini"
+
+        if re.fullmatch(r"openai/gpt-4o-mini-\d{4}-\d{2}-\d{2}", lowered):
+            return "openai/gpt-4o-mini"
+
+        return normalized
     
     @property
     def provider_name(self) -> str:
@@ -147,7 +163,7 @@ class OpenRouterProvider(AIProvider):
         
         # Build the API parameters
         api_params = {
-            "model": model,
+            "model": self._normalize_model_id(model),
             **payload_params
         }
         
@@ -212,7 +228,7 @@ class OpenRouterProvider(AIProvider):
         
         # Build the API parameters
         api_params = {
-            "model": model,
+            "model": self._normalize_model_id(model),
             **payload_params
         }
         
@@ -291,7 +307,7 @@ class OpenRouterProvider(AIProvider):
         
         # Build the API parameters
         api_params = {
-            "model": model,
+            "model": self._normalize_model_id(model),
             "messages": messages,
             **payload_params
         }
@@ -381,7 +397,7 @@ class OpenRouterProvider(AIProvider):
         
         # Build the API parameters
         api_params = {
-            "model": model,
+            "model": self._normalize_model_id(model),
             "messages": messages,
             **payload_params
         }

--- a/backend/app/api/v1/api.py
+++ b/backend/app/api/v1/api.py
@@ -1,5 +1,5 @@
 from fastapi import APIRouter
-from app.api.v1.endpoints import auth, settings, ollama, ai_providers, ai_provider_settings, navigation_routes, components, conversations, tags, personas, plugin_state, demo, searxng, documents, jobs, diagnostics
+from app.api.v1.endpoints import auth, settings, ollama, ai_providers, ai_provider_settings, navigation_routes, components, conversations, tags, personas, plugin_state, demo, searxng, documents, jobs, diagnostics, mcp_registry
 from app.api.v1.internal import internal_router
 from app.routers import plugins
 from app.routes.pages import router as pages_router
@@ -10,6 +10,7 @@ api_router.include_router(settings.router, tags=["settings"])
 api_router.include_router(ollama.router, prefix="/ollama", tags=["ollama"])  # Keep for backward compatibility
 api_router.include_router(ai_providers.router, prefix="/ai/providers", tags=["ai"])
 api_router.include_router(ai_provider_settings.router, prefix="/ai/settings", tags=["ai", "settings"])
+api_router.include_router(mcp_registry.router)
 api_router.include_router(navigation_routes.router, prefix="/navigation-routes", tags=["navigation"])
 api_router.include_router(components.router, prefix="/components", tags=["components"])
 api_router.include_router(conversations.router, tags=["conversations"])

--- a/backend/app/api/v1/endpoints/ai_providers.py
+++ b/backend/app/api/v1/endpoints/ai_providers.py
@@ -3,16 +3,23 @@ API endpoints for AI providers.
 """
 import os
 import json
+import copy
 import time
 import asyncio
 import logging
+import re
 import traceback
-from datetime import datetime, timezone
+from datetime import datetime, timezone, timedelta
+from pathlib import Path
 from typing import List, Dict, Any, Optional
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+from urllib.parse import urlsplit, urlunsplit
 from fastapi import APIRouter, HTTPException, Depends, Body, Query
 from fastapi.responses import StreamingResponse
 from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy import text, select
+from sqlalchemy.orm.attributes import flag_modified
 from app.core.database import get_db
 from app.core.auth_deps import require_user, optional_user
 from app.core.auth_context import AuthContext
@@ -23,22 +30,473 @@ from app.ai_providers.registry import provider_registry
 from app.ai_providers.ollama import OllamaProvider
 from app.utils.json_parsing import safe_encrypted_json_parse, validate_ollama_settings_format, create_default_ollama_settings
 from app.core.encryption import encryption_service, EncryptionError
+from app.core.user_initializer.library_template import resolve_library_root_path
 from app.schemas.ai_providers import (
     TextGenerationRequest,
     ChatCompletionRequest,
     ValidationRequest,
 )
 from app.utils.persona_utils import apply_persona_prompt_and_params
-from app.services.mcp_registry_service import MCPRegistryService
+from app.services.mcp_registry_service import MCPRegistryService, infer_safety_class
 
 # Flag to enable/disable test routes (set to False in production)
 TEST_ROUTES_ENABLED = os.getenv("ENABLE_TEST_ROUTES", "True").lower() == "true"
 
 router = APIRouter()
+MODULE_LOGGER = logging.getLogger(__name__)
 
 DEFAULT_AUTO_CONTINUE_PROMPT = "Continue exactly where you left off. Do not repeat prior text."
 DEFAULT_AUTO_CONTINUE_MAX_PASSES = 2
 DEFAULT_AUTO_CONTINUE_MIN_PROGRESS_CHARS = 1
+LIFE_ONBOARDING_TOPICS: Dict[str, str] = {
+    "finances": "Finances",
+    "fitness": "Fitness",
+    "relationships": "Relationships",
+    "career": "Career",
+    "whyfinder": "WhyFinder",
+}
+DEFAULT_LIBRARY_MCP_PLUGIN_SLUG = "BrainDriveLibraryPlugin"
+MAX_LIFE_ONBOARDING_OPENING_QUESTIONS = 6
+
+LIFE_ONBOARDING_DEFAULT_QUESTIONS: Dict[str, List[str]] = {
+    "finances": [
+        "What matters most to you in finances over the next 90 days?",
+        "What currently feels most stressful or unclear about your money situation?",
+        "What income, expense, or debt patterns are affecting your progress the most?",
+        "What savings or safety buffer are you aiming for first?",
+        "If you could improve one financial habit this month, what would it be?",
+        "What would make the next 30 days feel like a financial win?",
+    ],
+    "fitness": [
+        "What fitness outcome matters most to you over the next 90 days?",
+        "What does your current weekly routine look like?",
+        "What gets in the way of consistency for you right now?",
+        "What does success in the next 30 days look like for your health?",
+    ],
+    "relationships": [
+        "What relationship area do you want to improve first?",
+        "Where are things currently going well, and where do you feel tension?",
+        "What boundaries or communication patterns need the most attention?",
+        "What would meaningful progress look like in the next 30 days?",
+    ],
+    "career": [
+        "What career outcome matters most to you over the next 90 days?",
+        "Where do you feel stuck in your current work direction?",
+        "What skills, opportunities, or constraints are shaping your next move?",
+        "What would progress in the next 30 days look like?",
+    ],
+    "whyfinder": [
+        "What values feel most important to you right now?",
+        "Which life areas feel most out of alignment with those values?",
+        "What priorities do you want to protect over the next 90 days?",
+        "What would a meaningful next month look like if you stayed aligned?",
+    ],
+}
+
+LIFE_ONBOARDING_KEYWORD_QUESTION_MAP: Dict[str, Dict[str, str]] = {
+    "finances": {
+        "income": "How stable is your current income, and what changes do you expect soon?",
+        "budget": "How are you currently managing your budget, and where does it break down?",
+        "spending": "Which spending categories are hardest to control right now?",
+        "debt": "Which debts or liabilities feel most urgent to address first?",
+        "save": "What savings target feels both meaningful and realistic right now?",
+        "emergency": "Do you have an emergency cushion today, and what target would help you feel safer?",
+        "invest": "How are you currently handling investing, if at all?",
+        "retire": "How important is retirement planning in your current priorities?",
+        "cash flow": "How predictable is your monthly cash flow right now?",
+        "goal": "Which financial goal would create the biggest immediate momentum?",
+    }
+}
+
+CAPTURE_LIFE_TOPIC_ALIASES: Dict[str, str] = {
+    "finance": "finances",
+    "finances": "finances",
+    "fitness": "fitness",
+    "relationship": "relationships",
+    "relationships": "relationships",
+    "career": "career",
+    "whyfinder": "whyfinder",
+    "why finder": "whyfinder",
+}
+CROSS_POLLINATION_TOPIC_KEYWORDS: Dict[str, tuple[str, ...]] = {
+    "relationships": (
+        "kid",
+        "kids",
+        "child",
+        "children",
+        "daughter",
+        "son",
+        "spouse",
+        "partner",
+        "wife",
+        "husband",
+        "family",
+        "parent",
+    ),
+    "fitness": (
+        "workout",
+        "exercise",
+        "injury",
+        "knee",
+        "run",
+        "running",
+        "gym",
+        "sleep",
+        "nutrition",
+        "diet",
+        "steps",
+    ),
+    "finances": (
+        "budget",
+        "spending",
+        "debt",
+        "loan",
+        "credit",
+        "savings",
+        "cash flow",
+        "income",
+        "expense",
+        "mortgage",
+        "retirement",
+    ),
+    "career": (
+        "career",
+        "job",
+        "promotion",
+        "manager",
+        "interview",
+        "resume",
+        "salary",
+        "work transition",
+        "team lead",
+    ),
+    "whyfinder": (
+        "values",
+        "purpose",
+        "mission",
+        "meaning",
+        "identity",
+        "priority",
+        "priorities",
+    ),
+}
+CROSS_POLLINATION_CONTEXT_SOURCE_FILE = "AGENT.md"
+CROSS_POLLINATION_CONTEXT_MAX_CHARS = 800
+
+APPROVAL_MODE_POLICY = "explicit_approval_required"
+MUTATION_CONTEXT_REMEDIATION_TOOLS = {
+    "bootstrap_user_library",
+    "create_project_scaffold",
+    "create_project",
+    "ensure_scope_scaffold",
+}
+ONBOARDING_CONTEXT_REQUIRED_TOOLS = {
+    "start_topic_onboarding",
+    "save_topic_onboarding_context",
+}
+OWNER_PROFILE_RELATIVE_PATH = "me/profile.md"
+OWNER_PROFILE_MAX_CHARS = 4000
+TOOL_PROFILE_FULL = "full"
+TOOL_PROFILE_READ_ONLY = "read_only"
+TOOL_PROFILE_DIGEST = "digest"
+TOOL_PROFILE_NONE = "none"
+NATIVE_TOOL_CALLING_PROVIDERS = {"openai", "claude", "openrouter", "groq"}
+NATIVE_TOOL_MODEL_HINTS = (
+    "gpt",
+    "o1",
+    "o3",
+    "claude",
+    "gemini",
+    "qwen",
+    "granite",
+    "llama3",
+    "llama-3",
+    "mistral",
+    "mixtral",
+    "phi",
+    "command-r",
+    "deepseek",
+)
+DIGEST_TOOL_ALLOWLIST = {
+    "digest_snapshot",
+    "score_digest_tasks",
+    "rollup_digest_period",
+    "read_activity_log",
+    "list_tasks",
+}
+DEFAULT_DIGEST_SECTIONS = (
+    "top_priorities",
+    "yesterday_wins",
+    "needs_attention",
+    "library_improvement",
+)
+ALLOWED_DIGEST_SECTIONS = set(DEFAULT_DIGEST_SECTIONS)
+CAPTURE_PRIORITY_TOOL_NAMES = (
+    "rollup_digest_period",
+    "digest_snapshot",
+    "score_digest_tasks",
+    "create_markdown",
+    "write_markdown",
+    "create_task",
+    "list_tasks",
+    "update_task",
+    "complete_task",
+    "reopen_task",
+)
+DIGEST_PRIORITY_TOOL_NAMES = (
+    "rollup_digest_period",
+    "digest_snapshot",
+    "score_digest_tasks",
+    "read_activity_log",
+    "list_tasks",
+)
+DUAL_PATH_LIFE_SCOPE_COMPAT_TOOL_ALLOWLIST = {
+    "read_markdown",
+    "search_markdown",
+    "read_file_metadata",
+    "list_tasks",
+    "read_activity_log",
+    "get_onboarding_state",
+    "start_topic_onboarding",
+    "save_topic_onboarding_context",
+    "create_markdown",
+    "write_markdown",
+    "create_task",
+    "update_task",
+    "complete_task",
+    "reopen_task",
+    "ensure_scope_scaffold",
+}
+DUAL_PATH_PROJECT_SCOPE_COMPAT_TOOL_ALLOWLIST = {
+    "read_markdown",
+    "search_markdown",
+    "read_file_metadata",
+    "list_tasks",
+    "read_activity_log",
+    "create_markdown",
+    "write_markdown",
+    "edit_markdown",
+    "create_task",
+    "update_task",
+    "complete_task",
+    "reopen_task",
+    "preview_markdown_change",
+    "ensure_scope_scaffold",
+}
+DUAL_PATH_CAPTURE_SCOPE_COMPAT_TOOL_ALLOWLIST = {
+    "read_markdown",
+    "search_markdown",
+    "read_file_metadata",
+    "list_tasks",
+    "read_activity_log",
+    "create_markdown",
+    "write_markdown",
+    "create_task",
+    "update_task",
+    "complete_task",
+    "reopen_task",
+    "digest_snapshot",
+    "score_digest_tasks",
+    "rollup_digest_period",
+    "ensure_scope_scaffold",
+}
+DUAL_PATH_NEW_PAGE_COMPAT_TOOL_ALLOWLIST = {
+    "read_file_metadata",
+    "read_markdown",
+    "search_markdown",
+    "project_exists",
+    "create_project",
+    "create_project_scaffold",
+    "ensure_scope_scaffold",
+    "create_markdown",
+    "write_markdown",
+    "preview_markdown_change",
+}
+DUAL_PATH_NEW_PAGE_INTERVIEW_COMPAT_TOOL_ALLOWLIST = {
+    "read_file_metadata",
+    "read_markdown",
+    "search_markdown",
+    "preview_markdown_change",
+    "edit_markdown",
+    "write_markdown",
+}
+DUAL_PATH_OWNER_PROFILE_COMPAT_TOOL_ALLOWLIST = {
+    "read_markdown",
+    "search_markdown",
+    "read_file_metadata",
+    "preview_markdown_change",
+    "create_markdown",
+    "write_markdown",
+}
+GROUNDING_SOURCE_TOOL_NAMES = {"read_markdown", "search_markdown"}
+GROUNDING_PATH_KEYS = {"path", "file_path", "source_path"}
+QUESTION_INTENT_PREFIXES = (
+    "what",
+    "when",
+    "where",
+    "who",
+    "why",
+    "how",
+    "which",
+    "did",
+    "do",
+    "does",
+    "is",
+    "are",
+    "was",
+    "were",
+    "can",
+    "could",
+    "should",
+    "would",
+    "tell me",
+    "show me",
+    "find",
+    "search",
+)
+MAX_RESPONSE_CITATIONS = 6
+APPROVAL_PREVIEW_MAX_DIFF_CHARS = 6_000
+APPROVAL_PREVIEW_TRUNCATED_NOTICE = "Diff truncated for approval preview."
+APPROVAL_REQUIRED_RESPONSE_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS = 6
+NEW_PAGE_ENGINE_FIRST_FOLLOWUP_DAYS = 3
+NEW_PAGE_INTERVIEW_STATE_KEY = "new_page_interview_deterministic"
+NEW_PAGE_INTERVIEW_MAX_QUESTIONS = 6
+NEW_PAGE_INTERVIEW_PREVIEW_MAX_ITEMS = 3
+NEW_PAGE_INTERVIEW_APPROVAL_TEXT = (
+    "Reply `approve` to apply these scoped updates, or `reject` to revise your answer."
+)
+COMPOUND_EDIT_SYNTHETIC_REASON = "compound_edit_followthrough"
+COMPOUND_EDIT_MAX_OPERATIONS = 4
+DIGEST_DELIVERY_HANDOFF_MAX_CHARS = 12_000
+ENV_DIGEST_DELIVERY_OUTBOX_PATH = "BRAINDRIVE_DIGEST_DELIVERY_OUTBOX_PATH"
+DIGEST_DELIVERY_SEND_TIMEOUT_SECONDS = 8.0
+DIGEST_DELIVERY_SEND_MAX_ERROR_CHARS = 1_200
+ENV_DIGEST_DELIVERY_SEND_ENABLED = "BRAINDRIVE_DIGEST_DELIVERY_SEND_ENABLED"
+ENV_DIGEST_DELIVERY_ENDPOINT = "BRAINDRIVE_DIGEST_DELIVERY_ENDPOINT"
+ENV_DIGEST_DELIVERY_TIMEOUT_SECONDS = "BRAINDRIVE_DIGEST_DELIVERY_TIMEOUT_SECONDS"
+ENV_DIGEST_DELIVERY_AUTH_TOKEN = "BRAINDRIVE_DIGEST_DELIVERY_AUTH_TOKEN"
+ENV_DIGEST_DELIVERY_HEADERS_JSON = "BRAINDRIVE_DIGEST_DELIVERY_HEADERS_JSON"
+OWNER_PROFILE_UPDATE_WRITE_REASON = "owner_profile_update_write"
+OWNER_PROFILE_UPDATE_CREATE_REASON = "owner_profile_update_create"
+OWNER_PROFILE_UPDATE_REASONS = {
+    OWNER_PROFILE_UPDATE_WRITE_REASON,
+    OWNER_PROFILE_UPDATE_CREATE_REASON,
+}
+CAPTURE_SCOPE_FANOUT_MAX_TARGETS = 3
+NEW_PAGE_ENGINE_LIFE_KEYWORDS = (
+    "finance",
+    "finances",
+    "fitness",
+    "health",
+    "relationship",
+    "relationships",
+    "career",
+    "whyfinder",
+    "habit",
+    "family",
+    "wellness",
+    "budget",
+    "debt",
+    "relationship",
+    "values",
+)
+PRE_COMPACTION_FLUSH_PROMPT_TEMPLATE = (
+    "[pre_compaction_flush_event:{event_id}] Context usage is near the configured limit. "
+    "Before any summarization/truncation step, run one silent persistence sweep: identify any "
+    "important unsaved context and propose minimal library writes via tool calls. If nothing "
+    "new needs persistence, continue without tool calls. Do not run this flush twice for the same event."
+)
+DIGEST_SCHEDULE_PROMPT_TEMPLATE = (
+    "[digest_schedule_event:{event_id}] Scheduled digest run is due. "
+    "Sections requested: {sections}. "
+    "Produce a concise digest summary for this run, including one actionable library-improvement suggestion. "
+    "Use tools to ground the output: call digest_snapshot first, then score_digest_tasks using snapshot tasks, "
+    "then rollup_digest_period for week when writes/checkpoints are needed. "
+    "If no persistence is needed, continue without mutating calls."
+)
+
+
+def _normalize_page_id(page_id: Any) -> Optional[str]:
+    if not isinstance(page_id, str):
+        return None
+    normalized = page_id.strip()
+    return normalized if normalized else None
+
+
+def _normalize_library_user_id(raw_user_id: Any) -> Optional[str]:
+    if raw_user_id is None:
+        return None
+    normalized = str(raw_user_id).strip().replace("-", "")
+    if not normalized:
+        return None
+    if not re.fullmatch(r"[A-Za-z0-9_]{3,128}", normalized):
+        return None
+    return normalized
+
+
+def _build_owner_profile_system_message(
+    user_id: Optional[str],
+) -> tuple[Optional[Dict[str, str]], Dict[str, Any]]:
+    metadata: Dict[str, Any] = {
+        "owner_profile_loaded": False,
+        "owner_profile_path": OWNER_PROFILE_RELATIVE_PATH,
+    }
+
+    normalized_user_id = _normalize_library_user_id(user_id)
+    if not normalized_user_id:
+        metadata["owner_profile_status"] = "invalid_user_id"
+        return None, metadata
+
+    try:
+        library_root = resolve_library_root_path()
+    except Exception:
+        metadata["owner_profile_status"] = "library_root_unavailable"
+        return None, metadata
+
+    profile_path: Path = library_root / "users" / normalized_user_id / OWNER_PROFILE_RELATIVE_PATH
+    if not profile_path.is_file():
+        metadata["owner_profile_status"] = "missing"
+        return None, metadata
+
+    try:
+        raw_content = profile_path.read_text(encoding="utf-8")
+    except Exception:
+        metadata["owner_profile_status"] = "read_error"
+        return None, metadata
+
+    content = raw_content.strip()
+    if not content:
+        metadata["owner_profile_status"] = "empty"
+        return None, metadata
+
+    truncated = False
+    if len(content) > OWNER_PROFILE_MAX_CHARS:
+        content = content[:OWNER_PROFILE_MAX_CHARS].rstrip()
+        content = f"{content}\n\n[Profile context truncated for prompt budget.]"
+        truncated = True
+
+    metadata.update(
+        {
+            "owner_profile_loaded": True,
+            "owner_profile_status": "loaded",
+            "owner_profile_chars": len(content),
+            "owner_profile_truncated": truncated,
+        }
+    )
+
+    system_message = {
+        "role": "system",
+        "content": (
+            "Owner profile context (from me/profile.md). "
+            "Use this as concise background context when relevant.\n\n"
+            f"{content}"
+        ),
+    }
+    return system_message, metadata
 
 
 def extract_finish_reason(chunk: Dict[str, Any]) -> Optional[str]:
@@ -123,6 +581,248 @@ def extract_response_content(result: Dict[str, Any]) -> str:
             return content
 
     return ""
+
+
+def _set_result_primary_content(result: Dict[str, Any], content: str) -> Dict[str, Any]:
+    if not isinstance(result, dict):
+        result = {}
+
+    choices = result.get("choices")
+    if not isinstance(choices, list) or not choices:
+        choices = [{"message": {"role": "assistant", "content": content}, "finish_reason": "stop"}]
+        result["choices"] = choices
+        return result
+
+    first_choice = choices[0] if isinstance(choices[0], dict) else {}
+    message = first_choice.get("message") if isinstance(first_choice.get("message"), dict) else {}
+    message["role"] = message.get("role") or "assistant"
+    message["content"] = content
+    first_choice["message"] = message
+    choices[0] = first_choice
+    result["choices"] = choices
+    return result
+
+
+def _is_likely_question_request(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+    normalized = message_text.strip().lower()
+    if not normalized:
+        return False
+    if "?" in normalized:
+        return True
+    return any(normalized.startswith(prefix + " ") for prefix in QUESTION_INTENT_PREFIXES)
+
+
+def _normalize_grounding_path(
+    value: Any,
+    *,
+    default_scope_path: Optional[str] = None,
+) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().replace("\\", "/")
+    if not normalized:
+        return None
+    while normalized.startswith("./"):
+        normalized = normalized[2:]
+    if normalized.startswith("/"):
+        normalized = normalized.lstrip("/")
+    if re.match(r"^(life|projects|capture|digest|me)/", normalized):
+        return normalized
+
+    scope_path = _normalize_project_scope_path(default_scope_path)
+    if not isinstance(scope_path, str) or not scope_path.strip():
+        return None
+    scoped = _normalize_scoped_tool_path(normalized, scope_path)
+    if not isinstance(scoped, str):
+        return None
+    scoped_normalized = scoped.strip().replace("\\", "/")
+    scoped_normalized = re.sub(r"^\./+", "", scoped_normalized)
+    if scoped_normalized.startswith("/"):
+        scoped_normalized = scoped_normalized.lstrip("/")
+    if not re.match(r"^(life|projects|capture|digest|me)/", scoped_normalized):
+        return None
+    return scoped_normalized
+
+
+def _extract_grounding_paths_from_payload(
+    payload: Any,
+    *,
+    default_scope_path: Optional[str] = None,
+) -> List[str]:
+    extracted: List[str] = []
+
+    def _walk(value: Any) -> None:
+        if len(extracted) >= 64:
+            return
+        if isinstance(value, dict):
+            for key, item in value.items():
+                if isinstance(key, str) and key.strip().lower() in GROUNDING_PATH_KEYS:
+                    normalized_path = _normalize_grounding_path(
+                        item,
+                        default_scope_path=default_scope_path,
+                    )
+                    if normalized_path:
+                        extracted.append(normalized_path)
+                if isinstance(item, (dict, list)):
+                    _walk(item)
+        elif isinstance(value, list):
+            for item in value:
+                if isinstance(item, (dict, list)):
+                    _walk(item)
+
+    _walk(payload)
+    return extracted
+
+
+def _collect_grounding_source_paths(
+    executed_tool_calls: List[Dict[str, Any]],
+    *,
+    default_scope_path: Optional[str] = None,
+) -> List[str]:
+    deduped: List[str] = []
+    seen: set[str] = set()
+
+    for call in executed_tool_calls:
+        if not isinstance(call, dict):
+            continue
+        if str(call.get("status") or "").strip().lower() != "success":
+            continue
+        tool_name = str(call.get("name") or "").strip()
+        if tool_name not in GROUNDING_SOURCE_TOOL_NAMES:
+            continue
+
+        call_paths = _extract_grounding_paths_from_payload(
+            call.get("arguments"),
+            default_scope_path=default_scope_path,
+        )
+        call_paths.extend(
+            _extract_grounding_paths_from_payload(
+                call.get("result"),
+                default_scope_path=default_scope_path,
+            )
+        )
+        for path in call_paths:
+            lowered = path.lower()
+            if lowered in seen:
+                continue
+            seen.add(lowered)
+            deduped.append(path)
+
+    return deduped
+
+
+def _response_already_references_grounding_path(
+    response_content: str,
+    grounded_paths: List[str],
+) -> bool:
+    if not isinstance(response_content, str) or not response_content.strip():
+        return False
+    lowered = response_content.lower()
+    return any(path.lower() in lowered for path in grounded_paths)
+
+
+def _build_grounding_citation_suffix(grounded_paths: List[str]) -> Optional[str]:
+    if not grounded_paths:
+        return None
+    lines = ["Sources:"]
+    for path in grounded_paths[:MAX_RESPONSE_CITATIONS]:
+        lines.append(f"- `{path}`")
+    return "\n\n" + "\n".join(lines)
+
+
+def _apply_grounding_citations_if_needed(
+    *,
+    response_content: str,
+    executed_tool_calls: List[Dict[str, Any]],
+    latest_user_message: Optional[str],
+    tool_loop_stop_reason: str,
+    default_scope_path: Optional[str] = None,
+) -> tuple[str, Optional[str], List[str], bool]:
+    if (
+        not isinstance(response_content, str)
+        or not response_content.strip()
+        or str(tool_loop_stop_reason or "").strip() != "provider_final_response"
+        or not _is_likely_question_request(latest_user_message)
+    ):
+        return response_content, None, [], False
+
+    grounded_paths = _collect_grounding_source_paths(
+        executed_tool_calls,
+        default_scope_path=default_scope_path,
+    )
+    if not grounded_paths:
+        return response_content, None, [], False
+
+    if _response_already_references_grounding_path(response_content, grounded_paths):
+        return response_content, None, grounded_paths, False
+
+    citation_suffix = _build_grounding_citation_suffix(grounded_paths)
+    if not citation_suffix:
+        return response_content, None, grounded_paths, False
+
+    merged = response_content.rstrip() + citation_suffix
+    return merged, citation_suffix, grounded_paths, True
+
+
+async def iter_provider_stream_with_timeout(
+    stream_iterable: Any,
+    *,
+    timeout_seconds: float,
+):
+    """Iterate provider stream chunks with a hard per-pass timeout budget."""
+    iterator = stream_iterable.__aiter__()
+    deadline = time.monotonic() + max(0.1, float(timeout_seconds))
+    while True:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise asyncio.TimeoutError()
+        try:
+            chunk = await asyncio.wait_for(iterator.__anext__(), timeout=remaining)
+        except StopAsyncIteration:
+            break
+        yield chunk
+
+
+def _provider_timeout_fallback_response(conversation_type: str) -> str:
+    normalized = str(conversation_type or "").strip().lower()
+    if _is_capture_intake_conversation(normalized):
+        return (
+            "I hit a response timeout while processing this capture request. "
+            "Please resend the same note or split it into shorter steps."
+        )
+    if _is_digest_conversation(normalized):
+        return (
+            "I hit a response timeout while preparing the digest flow. "
+            "Please retry the digest request."
+        )
+    return (
+        "I hit a response timeout while generating that reply. "
+        "Please retry the request."
+    )
+
+
+def _build_provider_timing_metadata(
+    *,
+    provider_timeout_seconds: float,
+    provider_call_latencies_ms: List[int],
+    provider_timeout_count: int,
+) -> Dict[str, Any]:
+    call_count = len(provider_call_latencies_ms)
+    total_latency_ms = int(sum(provider_call_latencies_ms))
+    avg_latency_ms = round((total_latency_ms / call_count), 1) if call_count else 0.0
+    max_latency_ms = int(max(provider_call_latencies_ms)) if provider_call_latencies_ms else 0
+    last_latency_ms = int(provider_call_latencies_ms[-1]) if provider_call_latencies_ms else 0
+    return {
+        "provider_timeout_seconds": round(float(provider_timeout_seconds), 3),
+        "provider_call_count": call_count,
+        "provider_timeout_count": int(provider_timeout_count),
+        "provider_latency_ms_total": total_latency_ms,
+        "provider_latency_ms_avg": avg_latency_ms,
+        "provider_latency_ms_max": max_latency_ms,
+        "provider_latency_ms_last": last_latency_ms,
+    }
 
 
 def _decode_tool_arguments(raw_arguments: Any) -> Dict[str, Any]:
@@ -369,6 +1069,21 @@ def _as_bool(value: Any, default: bool) -> bool:
     return bool(value)
 
 
+def _as_optional_bool(value: Any) -> Optional[bool]:
+    """Parse optional bool values and preserve None when not provided/parsable."""
+    if isinstance(value, bool):
+        return value
+    if value is None:
+        return None
+    if isinstance(value, str):
+        lowered = value.strip().lower()
+        if lowered in {"false", "0", "no", "off"}:
+            return False
+        if lowered in {"true", "1", "yes", "on"}:
+            return True
+    return None
+
+
 def _as_int(value: Any, default: int, minimum: int, maximum: int) -> int:
     """Parse bounded int values from request params."""
     try:
@@ -376,6 +1091,639 @@ def _as_int(value: Any, default: int, minimum: int, maximum: int) -> int:
     except (TypeError, ValueError):
         parsed = default
     return max(minimum, min(maximum, parsed))
+
+
+def _as_float(value: Any, default: float, minimum: float, maximum: float) -> float:
+    """Parse bounded float values from request params."""
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        parsed = default
+    return max(minimum, min(maximum, parsed))
+
+
+def _coerce_tool_profile(value: Any, *, default: str, allow_auto: bool = False) -> str:
+    allowed = {
+        TOOL_PROFILE_FULL,
+        TOOL_PROFILE_READ_ONLY,
+        TOOL_PROFILE_DIGEST,
+        TOOL_PROFILE_NONE,
+    }
+    if allow_auto:
+        allowed.add("auto")
+
+    if isinstance(value, str):
+        normalized = value.strip().lower().replace("-", "_")
+        if normalized in allowed:
+            return normalized
+    return default
+
+
+def _is_model_likely_native_tool_capable(provider: Any, model: Any) -> tuple[bool, str]:
+    provider_normalized = str(provider or "").strip().lower()
+    model_normalized = str(model or "").strip().lower()
+
+    if provider_normalized in NATIVE_TOOL_CALLING_PROVIDERS:
+        return True, "provider_default"
+
+    if provider_normalized == "ollama":
+        # Default local Ollama models to compatibility mode unless explicitly overridden.
+        return False, "provider_default_non_native"
+
+    if any(hint in model_normalized for hint in NATIVE_TOOL_MODEL_HINTS):
+        return True, "model_hint"
+
+    return False, "unknown"
+
+
+def _resolve_tool_routing_decision(
+    *,
+    provider: Any,
+    model: Any,
+    provider_params: Dict[str, Any],
+) -> Dict[str, Any]:
+    force_single_path = _as_bool(provider_params.pop("mcp_force_single_path", False), False)
+    force_dual_path = _as_bool(provider_params.pop("mcp_force_dual_path", False), False)
+    requested_tool_profile = _coerce_tool_profile(
+        provider_params.pop("mcp_tool_profile", None),
+        default="auto",
+        allow_auto=True,
+    )
+    native_tool_override = _as_optional_bool(provider_params.pop("mcp_native_tool_calling", None))
+
+    if native_tool_override is None:
+        native_tool_calling, capability_source = _is_model_likely_native_tool_capable(
+            provider,
+            model,
+        )
+    else:
+        native_tool_calling = native_tool_override
+        capability_source = "request_override"
+
+    dual_path_requested = False
+    route_mode = "single_path_compat"
+    if force_single_path and force_dual_path:
+        force_dual_path = False
+    if force_single_path:
+        route_mode = "single_path_forced"
+    elif force_dual_path:
+        dual_path_requested = True
+        route_mode = "dual_path_fallback"
+    elif native_tool_calling:
+        route_mode = "single_path_native"
+    else:
+        dual_path_requested = True
+        route_mode = "dual_path_fallback"
+
+    if requested_tool_profile != "auto":
+        tool_profile = requested_tool_profile
+        tool_profile_source = "request"
+    elif route_mode == "single_path_native":
+        tool_profile = TOOL_PROFILE_FULL
+        tool_profile_source = "routing_default"
+    elif route_mode == "single_path_forced":
+        tool_profile = TOOL_PROFILE_FULL
+        tool_profile_source = "routing_forced"
+    else:
+        tool_profile = TOOL_PROFILE_READ_ONLY
+        tool_profile_source = "routing_default"
+
+    allowed_safety_classes: Optional[List[str]] = None
+    tool_name_allowlist: Optional[List[str]] = None
+    disable_tools = False
+    if tool_profile == TOOL_PROFILE_READ_ONLY:
+        allowed_safety_classes = [TOOL_PROFILE_READ_ONLY]
+    elif tool_profile == TOOL_PROFILE_DIGEST:
+        allowed_safety_classes = [TOOL_PROFILE_READ_ONLY, "mutating"]
+        tool_name_allowlist = sorted(DIGEST_TOOL_ALLOWLIST)
+    elif tool_profile == TOOL_PROFILE_NONE:
+        disable_tools = True
+
+    dual_path_fallback_reason = None
+    execution_mode = route_mode
+    if route_mode == "dual_path_fallback":
+        dual_path_fallback_reason = "dual_path_runtime_unavailable_using_single_path_compat"
+        execution_mode = "single_path_compat"
+
+    return {
+        "route_mode": route_mode,
+        "execution_mode": execution_mode,
+        "dual_path_requested": dual_path_requested,
+        "dual_path_fallback_reason": dual_path_fallback_reason,
+        "native_tool_calling": native_tool_calling,
+        "capability_source": capability_source,
+        "tool_profile": tool_profile,
+        "tool_profile_source": tool_profile_source,
+        "disable_tools": disable_tools,
+        "allowed_safety_classes": allowed_safety_classes,
+        "tool_name_allowlist": tool_name_allowlist,
+    }
+
+
+def _resolve_priority_tool_names(
+    *,
+    conversation_type: str,
+    tool_profile: str,
+    tool_name_allowlist: Optional[List[str]],
+) -> List[str]:
+    ordered: List[str] = []
+    seen = set()
+
+    def _append(name: Any) -> None:
+        normalized = str(name or "").strip()
+        if not normalized or normalized in seen:
+            return
+        ordered.append(normalized)
+        seen.add(normalized)
+
+    if _is_capture_intake_conversation(conversation_type):
+        for name in CAPTURE_PRIORITY_TOOL_NAMES:
+            _append(name)
+    if tool_profile == TOOL_PROFILE_DIGEST:
+        for name in DIGEST_PRIORITY_TOOL_NAMES:
+            _append(name)
+    for name in (tool_name_allowlist or []):
+        _append(name)
+    return ordered
+
+
+def _estimate_message_token_count(messages: List[Dict[str, Any]]) -> int:
+    total_chars = 0
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        content = message.get("content")
+        if isinstance(content, str):
+            total_chars += len(content)
+        tool_calls = message.get("tool_calls")
+        if isinstance(tool_calls, list) and tool_calls:
+            try:
+                total_chars += len(json.dumps(tool_calls, ensure_ascii=True))
+            except Exception:
+                total_chars += 0
+    if total_chars <= 0:
+        return 0
+    # Rough conversion that is stable enough for threshold detection.
+    return max(1, int(total_chars / 4))
+
+
+def _extract_pre_compaction_flush_config(provider_params: Dict[str, Any]) -> Dict[str, Any]:
+    enabled = _as_bool(provider_params.pop("mcp_pre_compaction_flush_enabled", True), True)
+    context_window_tokens = _as_int(
+        provider_params.pop("mcp_context_window_tokens", 0),
+        default=0,
+        minimum=0,
+        maximum=2_000_000,
+    )
+    threshold = _as_float(
+        provider_params.pop("mcp_pre_compaction_flush_threshold", 0.9),
+        default=0.9,
+        minimum=0.5,
+        maximum=0.99,
+    )
+    event_id_raw = provider_params.pop("mcp_pre_compaction_event_id", None)
+    event_id = str(event_id_raw).strip() if isinstance(event_id_raw, str) else ""
+
+    return {
+        "enabled": enabled,
+        "context_window_tokens": context_window_tokens,
+        "threshold": threshold,
+        "event_id": event_id,
+    }
+
+
+def _normalize_digest_section_name(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+    normalized = value.strip().lower().replace("-", "_").replace(" ", "_")
+    alias_map = {
+        "priorities": "top_priorities",
+        "top3": "top_priorities",
+        "top_3": "top_priorities",
+        "yesterday": "yesterday_wins",
+        "wins": "yesterday_wins",
+        "needs_attention": "needs_attention",
+        "attention": "needs_attention",
+        "blocked_overdue": "needs_attention",
+        "library_improvement": "library_improvement",
+        "improvement": "library_improvement",
+    }
+    normalized = alias_map.get(normalized, normalized)
+    if normalized in ALLOWED_DIGEST_SECTIONS:
+        return normalized
+    return None
+
+
+def _coerce_digest_sections(value: Any) -> List[str]:
+    raw_values: List[Any]
+    if isinstance(value, list):
+        raw_values = value
+    elif isinstance(value, str):
+        raw_values = [item for item in value.split(",")]
+    else:
+        raw_values = list(DEFAULT_DIGEST_SECTIONS)
+
+    sections: List[str] = []
+    seen = set()
+    for raw in raw_values:
+        normalized = _normalize_digest_section_name(raw)
+        if not normalized or normalized in seen:
+            continue
+        sections.append(normalized)
+        seen.add(normalized)
+    return sections or list(DEFAULT_DIGEST_SECTIONS)
+
+
+def _parse_utc_datetime(value: Any) -> Optional[datetime]:
+    if not isinstance(value, str) or not value.strip():
+        return None
+    candidate = value.strip()
+    if candidate.endswith("Z"):
+        candidate = f"{candidate[:-1]}+00:00"
+    try:
+        parsed = datetime.fromisoformat(candidate)
+    except ValueError:
+        return None
+    if parsed.tzinfo is None:
+        parsed = parsed.replace(tzinfo=timezone.utc)
+    else:
+        parsed = parsed.astimezone(timezone.utc)
+    return parsed
+
+
+def _extract_digest_schedule_config(
+    provider_params: Dict[str, Any],
+    *,
+    conversation_type: str,
+) -> Dict[str, Any]:
+    normalized_type = _normalize_conversation_type(conversation_type)
+    digest_conversation = _is_digest_conversation(normalized_type) and not _is_digest_reply_conversation(
+        normalized_type
+    )
+    enabled_default = True if digest_conversation else False
+    enabled = _as_bool(provider_params.pop("mcp_digest_schedule_enabled", enabled_default), enabled_default)
+    cadence_hours = _as_int(
+        provider_params.pop("mcp_digest_cadence_hours", 24),
+        default=24,
+        minimum=1,
+        maximum=168,
+    )
+    sections = _coerce_digest_sections(
+        provider_params.pop("mcp_digest_sections", list(DEFAULT_DIGEST_SECTIONS))
+    )
+    force_run = _as_bool(provider_params.pop("mcp_digest_force_run", False), False)
+    next_due_raw = provider_params.pop(
+        "mcp_digest_next_due_at_utc",
+        provider_params.pop("mcp_digest_due_at_utc", None),
+    )
+    next_due_dt = _parse_utc_datetime(next_due_raw)
+    event_id_raw = provider_params.pop("mcp_digest_schedule_event_id", None)
+    event_id = str(event_id_raw).strip() if isinstance(event_id_raw, str) else ""
+    reply_to_capture_enabled = _as_bool(
+        provider_params.pop("mcp_digest_reply_to_capture_enabled", True),
+        True,
+    )
+    now_utc = datetime.now(timezone.utc)
+
+    due_now = False
+    if enabled:
+        due_now = force_run or next_due_dt is None or next_due_dt <= now_utc
+
+    projected_next_due = next_due_dt
+    if enabled and due_now:
+        projected_next_due = now_utc + timedelta(hours=cadence_hours)
+
+    return {
+        "enabled": enabled,
+        "due_now": due_now,
+        "force_run": force_run,
+        "cadence_hours": cadence_hours,
+        "sections": sections,
+        "next_due_at_utc": projected_next_due.isoformat() if projected_next_due else None,
+        "event_id": event_id,
+        "reply_to_capture_enabled": reply_to_capture_enabled,
+    }
+
+
+def _sanitize_delivery_endpoint_for_metadata(raw_endpoint: Any) -> Optional[str]:
+    if not isinstance(raw_endpoint, str):
+        return None
+    endpoint = raw_endpoint.strip()
+    if not endpoint:
+        return None
+    try:
+        parts = urlsplit(endpoint)
+    except Exception:
+        return endpoint
+    if not parts.scheme or not parts.netloc:
+        return endpoint
+    if parts.username or parts.password:
+        host = parts.hostname or ""
+        if parts.port:
+            host = f"{host}:{parts.port}"
+        netloc = host
+    else:
+        netloc = parts.netloc
+    return urlunsplit((parts.scheme, netloc, parts.path, "", ""))
+
+
+def _coerce_digest_delivery_headers(raw_value: Any) -> Dict[str, str]:
+    if isinstance(raw_value, dict):
+        source = raw_value
+    elif isinstance(raw_value, str) and raw_value.strip():
+        try:
+            parsed = json.loads(raw_value)
+        except Exception:
+            parsed = None
+        source = parsed if isinstance(parsed, dict) else {}
+    else:
+        source = {}
+
+    headers: Dict[str, str] = {}
+    for key, value in source.items():
+        if not isinstance(key, str):
+            continue
+        key_normalized = key.strip()
+        if not key_normalized:
+            continue
+        if isinstance(value, str):
+            value_normalized = value.strip()
+        else:
+            value_normalized = str(value).strip() if value is not None else ""
+        if not value_normalized:
+            continue
+        headers[key_normalized] = value_normalized
+    return headers
+
+
+def _extract_digest_delivery_send_config(provider_params: Dict[str, Any]) -> Dict[str, Any]:
+    env_enabled_default = _as_bool(
+        os.getenv(ENV_DIGEST_DELIVERY_SEND_ENABLED, "false"),
+        False,
+    )
+    enabled = _as_bool(
+        provider_params.pop("mcp_digest_delivery_send_enabled", env_enabled_default),
+        env_enabled_default,
+    )
+    endpoint_value = provider_params.pop(
+        "mcp_digest_delivery_endpoint",
+        os.getenv(ENV_DIGEST_DELIVERY_ENDPOINT, ""),
+    )
+    endpoint = str(endpoint_value).strip() if isinstance(endpoint_value, str) else ""
+    timeout_default = _as_float(
+        os.getenv(
+            ENV_DIGEST_DELIVERY_TIMEOUT_SECONDS,
+            str(DIGEST_DELIVERY_SEND_TIMEOUT_SECONDS),
+        ),
+        default=DIGEST_DELIVERY_SEND_TIMEOUT_SECONDS,
+        minimum=0.5,
+        maximum=60.0,
+    )
+    timeout_seconds = _as_float(
+        provider_params.pop("mcp_digest_delivery_timeout_seconds", timeout_default),
+        default=timeout_default,
+        minimum=0.5,
+        maximum=60.0,
+    )
+    headers_raw = provider_params.pop(
+        "mcp_digest_delivery_headers",
+        os.getenv(ENV_DIGEST_DELIVERY_HEADERS_JSON, ""),
+    )
+    headers = _coerce_digest_delivery_headers(headers_raw)
+    token_value = provider_params.pop(
+        "mcp_digest_delivery_auth_token",
+        os.getenv(ENV_DIGEST_DELIVERY_AUTH_TOKEN, ""),
+    )
+    token = str(token_value).strip() if isinstance(token_value, str) else ""
+    lower_header_keys = {key.lower() for key in headers.keys()}
+    if token and "authorization" not in lower_header_keys:
+        auth_value = token if " " in token else f"Bearer {token}"
+        headers["Authorization"] = auth_value
+
+    if "Content-Type" not in headers:
+        headers["Content-Type"] = "application/json"
+    if "Accept" not in headers:
+        headers["Accept"] = "application/json"
+
+    return {
+        "enabled": enabled,
+        "endpoint": endpoint,
+        "endpoint_sanitized": _sanitize_delivery_endpoint_for_metadata(endpoint),
+        "timeout_seconds": timeout_seconds,
+        "headers": headers,
+    }
+
+
+def _collect_mcp_event_ids_from_history(
+    messages: List[Any],
+    *,
+    event_key: str,
+) -> set[str]:
+    event_ids: set[str] = set()
+    for message in messages:
+        metadata = getattr(message, "message_metadata", None)
+        if not isinstance(metadata, dict):
+            continue
+        mcp_meta = metadata.get("mcp")
+        if not isinstance(mcp_meta, dict):
+            continue
+        event_id = str(mcp_meta.get(event_key) or "").strip()
+        if event_id:
+            event_ids.add(event_id)
+    return event_ids
+
+
+def _apply_digest_schedule_prompt(
+    *,
+    messages: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    conversation_id: str,
+    tooling_metadata: Dict[str, Any],
+    seen_event_ids: Optional[set[str]] = None,
+) -> List[Dict[str, Any]]:
+    enabled = bool(config.get("enabled"))
+    due_now = bool(config.get("due_now"))
+    sections = config.get("sections") if isinstance(config.get("sections"), list) else list(DEFAULT_DIGEST_SECTIONS)
+    cadence_hours = _as_int(config.get("cadence_hours"), default=24, minimum=1, maximum=168)
+
+    tooling_metadata.update(
+        {
+            "digest_schedule_enabled": enabled,
+            "digest_schedule_due_now": due_now,
+            "digest_sections": sections,
+            "digest_cadence_hours": cadence_hours,
+            "digest_next_due_at_utc": config.get("next_due_at_utc"),
+            "digest_reply_to_capture_enabled": bool(config.get("reply_to_capture_enabled")),
+            "digest_schedule_triggered": False,
+        }
+    )
+
+    if not enabled:
+        tooling_metadata["digest_schedule_status"] = "disabled"
+        return messages
+    if not due_now:
+        tooling_metadata["digest_schedule_status"] = "not_due"
+        return messages
+
+    event_id = str(config.get("event_id") or "").strip()
+    if not event_id:
+        event_id = f"{conversation_id}:digest:{datetime.now(timezone.utc).date().isoformat()}"
+    marker = f"[digest_schedule_event:{event_id}]"
+
+    if seen_event_ids and event_id in seen_event_ids:
+        tooling_metadata["digest_schedule_event_id"] = event_id
+        tooling_metadata["digest_schedule_triggered"] = False
+        tooling_metadata["digest_schedule_duplicate_guard"] = "history_seen"
+        tooling_metadata["digest_schedule_status"] = "duplicate_guard"
+        config["due_now"] = False
+        return messages
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "system":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and marker in content:
+            tooling_metadata["digest_schedule_event_id"] = event_id
+            tooling_metadata["digest_schedule_triggered"] = False
+            tooling_metadata["digest_schedule_duplicate_guard"] = "already_present"
+            tooling_metadata["digest_schedule_status"] = "duplicate_guard"
+            config["due_now"] = False
+            return messages
+
+    section_text = ", ".join(sections)
+    schedule_system_message = {
+        "role": "system",
+        "content": DIGEST_SCHEDULE_PROMPT_TEMPLATE.format(
+            event_id=event_id,
+            sections=section_text,
+        ),
+    }
+    updated_messages = _insert_orchestration_system_message(messages, schedule_system_message)
+    tooling_metadata["digest_schedule_event_id"] = event_id
+    tooling_metadata["digest_schedule_triggered"] = True
+    tooling_metadata["digest_schedule_status"] = "triggered"
+    config["event_id"] = event_id
+    return updated_messages
+
+
+def _finalize_pre_compaction_flush_status(
+    *,
+    tooling_metadata: Dict[str, Any],
+    tool_loop_stop_reason: str,
+    tool_calls_executed_count: int,
+) -> None:
+    if not bool(tooling_metadata.get("pre_compaction_flush_enabled")):
+        tooling_metadata["pre_compaction_flush_status"] = "disabled"
+        return
+    if tooling_metadata.get("pre_compaction_flush_duplicate_guard"):
+        tooling_metadata["pre_compaction_flush_status"] = "duplicate_guard"
+        return
+    if not bool(tooling_metadata.get("pre_compaction_flush_triggered")):
+        tooling_metadata.setdefault("pre_compaction_flush_status", "not_required")
+        return
+    if tool_loop_stop_reason == "approval_required":
+        tooling_metadata["pre_compaction_flush_status"] = "awaiting_approval"
+    elif tool_calls_executed_count > 0:
+        tooling_metadata["pre_compaction_flush_status"] = "completed_tool_calls"
+    else:
+        tooling_metadata["pre_compaction_flush_status"] = "completed_noop"
+
+
+def _finalize_digest_schedule_status(
+    *,
+    tooling_metadata: Dict[str, Any],
+    tool_loop_stop_reason: str,
+    tool_calls_executed_count: int,
+) -> None:
+    if not bool(tooling_metadata.get("digest_schedule_enabled")):
+        tooling_metadata["digest_schedule_status"] = "disabled"
+        return
+    if tooling_metadata.get("digest_schedule_duplicate_guard"):
+        tooling_metadata["digest_schedule_status"] = "duplicate_guard"
+        return
+    if not bool(tooling_metadata.get("digest_schedule_due_now")):
+        tooling_metadata.setdefault("digest_schedule_status", "not_due")
+        return
+    if not bool(tooling_metadata.get("digest_schedule_triggered")):
+        tooling_metadata.setdefault("digest_schedule_status", "not_triggered")
+        return
+    if tool_loop_stop_reason == "approval_required":
+        tooling_metadata["digest_schedule_status"] = "awaiting_approval"
+    elif tool_calls_executed_count > 0:
+        tooling_metadata["digest_schedule_status"] = "completed_tool_calls"
+    else:
+        tooling_metadata["digest_schedule_status"] = "completed_noop"
+
+
+def _apply_pre_compaction_flush_prompt(
+    *,
+    messages: List[Dict[str, Any]],
+    config: Dict[str, Any],
+    conversation_id: str,
+    tooling_metadata: Dict[str, Any],
+    seen_event_ids: Optional[set[str]] = None,
+) -> List[Dict[str, Any]]:
+    enabled = bool(config.get("enabled"))
+    context_window_tokens = int(config.get("context_window_tokens") or 0)
+    threshold = float(config.get("threshold") or 0.9)
+    estimated_tokens = _estimate_message_token_count(messages)
+    usage_ratio = (
+        (estimated_tokens / context_window_tokens)
+        if context_window_tokens > 0 and estimated_tokens > 0
+        else 0.0
+    )
+
+    tooling_metadata.update(
+        {
+            "pre_compaction_flush_enabled": enabled,
+            "pre_compaction_context_window_tokens": context_window_tokens,
+            "pre_compaction_flush_threshold": round(threshold, 3),
+            "pre_compaction_estimated_tokens": estimated_tokens,
+            "pre_compaction_context_usage_ratio": round(usage_ratio, 4),
+            "pre_compaction_flush_triggered": False,
+            "pre_compaction_flush_status": "not_required",
+        }
+    )
+
+    if not enabled or context_window_tokens <= 0 or usage_ratio < threshold:
+        return messages
+
+    event_id = str(config.get("event_id") or "").strip()
+    if not event_id:
+        event_id = f"{conversation_id}:preflush"
+    marker = f"[pre_compaction_flush_event:{event_id}]"
+
+    if seen_event_ids and event_id in seen_event_ids:
+        tooling_metadata["pre_compaction_flush_event_id"] = event_id
+        tooling_metadata["pre_compaction_flush_triggered"] = False
+        tooling_metadata["pre_compaction_flush_duplicate_guard"] = "history_seen"
+        tooling_metadata["pre_compaction_flush_status"] = "duplicate_guard"
+        return messages
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "system":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and marker in content:
+            tooling_metadata["pre_compaction_flush_event_id"] = event_id
+            tooling_metadata["pre_compaction_flush_triggered"] = False
+            tooling_metadata["pre_compaction_flush_duplicate_guard"] = "already_present"
+            tooling_metadata["pre_compaction_flush_status"] = "duplicate_guard"
+            return messages
+
+    preflush_system_message = {
+        "role": "system",
+        "content": PRE_COMPACTION_FLUSH_PROMPT_TEMPLATE.format(event_id=event_id),
+    }
+    updated_messages = _insert_orchestration_system_message(messages, preflush_system_message)
+    tooling_metadata["pre_compaction_flush_event_id"] = event_id
+    tooling_metadata["pre_compaction_flush_triggered"] = True
+    tooling_metadata["pre_compaction_flush_status"] = "triggered"
+    return updated_messages
 
 
 def _normalize_scope_mode(value: Any) -> str:
@@ -410,6 +1758,6074 @@ def _extract_mcp_scope_params(params: Dict[str, Any]) -> Dict[str, Any]:
         ),
     }
     return extracted
+
+
+def _normalize_conversation_type(value: Any) -> str:
+    if not isinstance(value, str):
+        return "chat"
+    normalized = value.strip().lower()
+    return normalized or "chat"
+
+
+def _is_digest_reply_conversation(conversation_type: str) -> bool:
+    normalized = _normalize_conversation_type(conversation_type)
+    return normalized in {
+        "digest-reply",
+        "digest_reply",
+        "digestreply",
+        "digest_email_reply",
+    }
+
+
+def _is_digest_conversation(conversation_type: str) -> bool:
+    normalized = _normalize_conversation_type(conversation_type)
+    return normalized == "digest" or normalized.startswith("digest-")
+
+
+def _extract_digest_delivery_channel(conversation_type: str) -> Optional[str]:
+    normalized = _normalize_conversation_type(conversation_type)
+    if _is_digest_reply_conversation(normalized):
+        if "email" in normalized:
+            return "email-reply"
+        return "reply"
+    if normalized == "digest":
+        return "chat"
+    if normalized.startswith("digest-"):
+        channel = normalized[len("digest-") :].strip().lower()
+        if not channel:
+            return "chat"
+        return channel.replace("_", "-")
+    return None
+
+
+def _build_digest_delivery_handoff_payload(
+    *,
+    conversation_type: str,
+    response_content: str,
+    conversation_id: str,
+    provider: str,
+    model: str,
+    digest_schedule_config: Optional[Dict[str, Any]],
+    tooling_metadata: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    channel = _extract_digest_delivery_channel(conversation_type)
+    if not channel or channel == "chat":
+        return None
+
+    normalized_content = " ".join(str(response_content or "").split())
+    if not normalized_content:
+        return None
+
+    body = str(response_content or "").strip()
+    truncated = False
+    if len(body) > DIGEST_DELIVERY_HANDOFF_MAX_CHARS:
+        body = body[:DIGEST_DELIVERY_HANDOFF_MAX_CHARS].rstrip() + "\n...[truncated]"
+        truncated = True
+
+    sections = (
+        list(digest_schedule_config.get("sections") or [])
+        if isinstance(digest_schedule_config, dict)
+        else []
+    )
+    deduped_sections: List[str] = []
+    for section in sections:
+        if not isinstance(section, str):
+            continue
+        normalized = section.strip().lower()
+        if not normalized or normalized in deduped_sections:
+            continue
+        deduped_sections.append(normalized)
+
+    event_id = tooling_metadata.get("digest_schedule_event_id")
+    event_id_value = str(event_id).strip() if isinstance(event_id, str) else None
+    utc_today = datetime.now(timezone.utc).date().isoformat()
+    return {
+        "channel": channel,
+        "conversation_type": _normalize_conversation_type(conversation_type),
+        "conversation_id": conversation_id,
+        "event_id": event_id_value,
+        "generated_at_utc": _utc_timestamp(),
+        "subject": f"BrainDrive Digest {utc_today}",
+        "format": "markdown",
+        "sections": deduped_sections,
+        "body": body,
+        "body_truncated": truncated,
+        "provider": provider,
+        "model": model,
+    }
+
+
+def _normalize_user_id_for_path(user_id: Any) -> str:
+    normalized = str(user_id or "").replace("-", "").strip().lower()
+    if not normalized:
+        return "current"
+    return re.sub(r"[^a-z0-9]+", "", normalized) or "current"
+
+
+def _resolve_digest_delivery_outbox_root(user_id: Any) -> Optional[Path]:
+    configured = str(os.getenv(ENV_DIGEST_DELIVERY_OUTBOX_PATH) or "").strip()
+    normalized_user_id = _normalize_user_id_for_path(user_id)
+    if configured:
+        rendered = configured.replace("{user_id}", normalized_user_id)
+        return Path(rendered).expanduser().resolve()
+
+    try:
+        library_root = resolve_library_root_path()
+    except Exception:
+        return None
+    return (
+        library_root
+        / "users"
+        / normalized_user_id
+        / "delivery"
+        / "outbox"
+    )
+
+
+def _persist_digest_delivery_handoff_payload(
+    *,
+    handoff_payload: Dict[str, Any],
+    user_id: Any,
+) -> Dict[str, Any]:
+    if not isinstance(handoff_payload, dict):
+        return {"status": "skipped_invalid_payload"}
+
+    outbox_root = _resolve_digest_delivery_outbox_root(user_id)
+    if not isinstance(outbox_root, Path):
+        return {"status": "skipped_unconfigured"}
+
+    channel_slug = _slugify_capture_fragment(
+        str(handoff_payload.get("channel") or ""),
+        fallback="channel",
+        max_length=32,
+    )
+    event_token = _slugify_capture_fragment(
+        str(
+            handoff_payload.get("event_id")
+            or handoff_payload.get("conversation_id")
+            or "digest"
+        ),
+        fallback="digest",
+        max_length=72,
+    )
+    generated_at = str(handoff_payload.get("generated_at_utc") or "")
+    timestamp_token = re.sub(r"[^0-9]", "", generated_at)[:14]
+    if not timestamp_token:
+        timestamp_token = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
+    day_token = timestamp_token[:8]
+    file_name = f"{timestamp_token}-{event_token}.json"
+
+    output_dir = outbox_root / channel_slug / day_token
+    output_path = output_dir / file_name
+    try:
+        output_dir.mkdir(parents=True, exist_ok=True)
+        output_path.write_text(
+            json.dumps(handoff_payload, ensure_ascii=True, indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        return {"status": "persisted", "path": str(output_path)}
+    except Exception as exc:
+        return {"status": "error", "error": str(exc)}
+
+
+def _dispatch_digest_delivery_handoff_sync(
+    *,
+    endpoint: str,
+    timeout_seconds: float,
+    headers: Dict[str, str],
+    handoff_payload: Dict[str, Any],
+) -> Dict[str, Any]:
+    endpoint_sanitized = _sanitize_delivery_endpoint_for_metadata(endpoint)
+    request_data = json.dumps(handoff_payload, ensure_ascii=True).encode("utf-8")
+    request_obj = urllib_request.Request(
+        url=endpoint,
+        data=request_data,
+        headers=headers,
+        method="POST",
+    )
+    try:
+        with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+            status_code = int(getattr(response, "status", 0) or response.getcode() or 0)
+            raw_body = response.read().decode("utf-8", errors="replace").strip()
+            result: Dict[str, Any] = {
+                "status": "sent" if 200 <= status_code < 300 else "http_error",
+                "http_status": status_code,
+                "endpoint": endpoint_sanitized,
+            }
+            if raw_body:
+                try:
+                    parsed = json.loads(raw_body)
+                except Exception:
+                    parsed = None
+                if isinstance(parsed, dict):
+                    for key in (
+                        "ack_id",
+                        "ackId",
+                        "delivery_id",
+                        "deliveryId",
+                        "message_id",
+                        "messageId",
+                        "id",
+                    ):
+                        value = parsed.get(key)
+                        if isinstance(value, str) and value.strip():
+                            result["ack_id"] = value.strip()
+                            break
+                    if result["status"] != "sent":
+                        result["error"] = raw_body[:DIGEST_DELIVERY_SEND_MAX_ERROR_CHARS]
+                elif result["status"] != "sent":
+                    result["error"] = raw_body[:DIGEST_DELIVERY_SEND_MAX_ERROR_CHARS]
+            return result
+    except urllib_error.HTTPError as exc:
+        body = exc.read().decode("utf-8", errors="replace").strip()
+        return {
+            "status": "http_error",
+            "http_status": int(exc.code),
+            "error": (body or str(exc))[:DIGEST_DELIVERY_SEND_MAX_ERROR_CHARS],
+            "endpoint": endpoint_sanitized,
+        }
+    except urllib_error.URLError as exc:
+        return {
+            "status": "network_error",
+            "error": str(getattr(exc, "reason", exc)),
+            "endpoint": endpoint_sanitized,
+        }
+    except Exception as exc:
+        return {
+            "status": "error",
+            "error": str(exc),
+            "endpoint": endpoint_sanitized,
+        }
+
+
+async def _send_digest_delivery_handoff(
+    *,
+    handoff_payload: Optional[Dict[str, Any]],
+    send_config: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    if not isinstance(handoff_payload, dict):
+        return {"status": "skipped_invalid_payload"}
+    if not isinstance(send_config, dict):
+        return {"status": "skipped_unconfigured"}
+
+    enabled = bool(send_config.get("enabled"))
+    endpoint = str(send_config.get("endpoint") or "").strip()
+    endpoint_sanitized = _sanitize_delivery_endpoint_for_metadata(endpoint)
+    if not enabled:
+        return {
+            "status": "skipped_disabled",
+            "endpoint": endpoint_sanitized,
+        }
+    if not endpoint:
+        return {
+            "status": "skipped_unconfigured_endpoint",
+            "endpoint": endpoint_sanitized,
+        }
+
+    headers = send_config.get("headers") if isinstance(send_config.get("headers"), dict) else {}
+    timeout_seconds = _as_float(
+        send_config.get("timeout_seconds", DIGEST_DELIVERY_SEND_TIMEOUT_SECONDS),
+        default=DIGEST_DELIVERY_SEND_TIMEOUT_SECONDS,
+        minimum=0.5,
+        maximum=60.0,
+    )
+    result = await asyncio.to_thread(
+        _dispatch_digest_delivery_handoff_sync,
+        endpoint=endpoint,
+        timeout_seconds=timeout_seconds,
+        headers={str(k): str(v) for k, v in headers.items() if str(k).strip()},
+        handoff_payload=handoff_payload,
+    )
+    if "endpoint" not in result:
+        result["endpoint"] = endpoint_sanitized
+    return result
+
+
+def _attach_digest_delivery_persistence(
+    *,
+    handoff_payload: Optional[Dict[str, Any]],
+    user_id: Any,
+    tooling_metadata: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(handoff_payload, dict):
+        return handoff_payload
+
+    persistence = _persist_digest_delivery_handoff_payload(
+        handoff_payload=handoff_payload,
+        user_id=user_id,
+    )
+    enriched = dict(handoff_payload)
+    status = str(persistence.get("status") or "").strip() or "unknown"
+    enriched["delivery_record_status"] = status
+    if persistence.get("path"):
+        enriched["delivery_record_path"] = str(persistence["path"])
+    if persistence.get("error"):
+        enriched["delivery_record_error"] = str(persistence["error"])
+
+    if isinstance(tooling_metadata, dict):
+        tooling_metadata["digest_delivery_outbox_status"] = status
+        if persistence.get("path"):
+            tooling_metadata["digest_delivery_outbox_path"] = str(persistence["path"])
+        if persistence.get("error"):
+            tooling_metadata["digest_delivery_outbox_error"] = str(persistence["error"])
+
+    return enriched
+
+
+async def _attach_digest_delivery_delivery_state(
+    *,
+    handoff_payload: Optional[Dict[str, Any]],
+    user_id: Any,
+    tooling_metadata: Optional[Dict[str, Any]] = None,
+    send_config: Optional[Dict[str, Any]] = None,
+) -> Optional[Dict[str, Any]]:
+    enriched = _attach_digest_delivery_persistence(
+        handoff_payload=handoff_payload,
+        user_id=user_id,
+        tooling_metadata=tooling_metadata,
+    )
+    if not isinstance(enriched, dict):
+        return enriched
+
+    send_result = await _send_digest_delivery_handoff(
+        handoff_payload=enriched,
+        send_config=send_config,
+    )
+    send_status = str(send_result.get("status") or "").strip() or "unknown"
+    enriched["delivery_send_status"] = send_status
+    if send_result.get("endpoint"):
+        enriched["delivery_send_endpoint"] = str(send_result["endpoint"])
+    if isinstance(send_result.get("http_status"), int):
+        enriched["delivery_send_http_status"] = int(send_result["http_status"])
+    if send_result.get("ack_id"):
+        enriched["delivery_send_ack_id"] = str(send_result["ack_id"])
+    if send_result.get("error"):
+        enriched["delivery_send_error"] = str(send_result["error"])
+
+    if isinstance(tooling_metadata, dict):
+        tooling_metadata["digest_delivery_send_status"] = send_status
+        if send_result.get("endpoint"):
+            tooling_metadata["digest_delivery_send_endpoint"] = str(send_result["endpoint"])
+        if isinstance(send_result.get("http_status"), int):
+            tooling_metadata["digest_delivery_send_http_status"] = int(send_result["http_status"])
+        if send_result.get("ack_id"):
+            tooling_metadata["digest_delivery_send_ack_id"] = str(send_result["ack_id"])
+        if send_result.get("error"):
+            tooling_metadata["digest_delivery_send_error"] = str(send_result["error"])
+
+    return enriched
+
+
+def _is_capture_intake_conversation(conversation_type: str) -> bool:
+    normalized = _normalize_conversation_type(conversation_type)
+    return normalized == "capture" or _is_digest_reply_conversation(normalized)
+
+
+def _extract_life_topic(conversation_type: str) -> Optional[str]:
+    if not conversation_type.startswith("life-"):
+        return None
+    topic = conversation_type[5:].strip().lower()
+    if topic in LIFE_ONBOARDING_TOPICS:
+        return topic
+    return None
+
+
+def _extract_life_topic_from_text(value: Any) -> Optional[str]:
+    if not isinstance(value, str):
+        return None
+
+    normalized = value.strip().lower()
+    if not normalized:
+        return None
+
+    alias_map = {
+        "finance": "finances",
+        "finances": "finances",
+        "fitness": "fitness",
+        "relationship": "relationships",
+        "relationships": "relationships",
+        "career": "career",
+        "whyfinder": "whyfinder",
+        "why finder": "whyfinder",
+    }
+
+    for alias, topic in alias_map.items():
+        if re.search(rf"\b{re.escape(alias)}\b", normalized):
+            return topic
+
+    return None
+
+
+def _coerce_page_context(page_context: Any) -> Dict[str, Any]:
+    if isinstance(page_context, dict):
+        return page_context
+    if isinstance(page_context, str) and page_context.strip():
+        try:
+            parsed = json.loads(page_context)
+            if isinstance(parsed, dict):
+                return parsed
+        except Exception:
+            return {}
+    return {}
+
+
+def _infer_life_topic_for_request(
+    conversation_type: str,
+    page_context: Any,
+    latest_user_message: Optional[str],
+) -> Optional[str]:
+    explicit_topic = _extract_life_topic(conversation_type)
+    if explicit_topic:
+        return explicit_topic
+
+    context = _coerce_page_context(page_context)
+    for key in ("pageName", "pageRoute", "route", "name", "title"):
+        topic = _extract_life_topic_from_text(context.get(key))
+        if topic:
+            return topic
+
+    return _extract_life_topic_from_text(latest_user_message)
+
+
+def _apply_conversation_scope_defaults(
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+) -> Optional[str]:
+    """
+    Ensure orchestration pages can resolve MCP tools even when the client omits scope.
+    Returns the applied source marker when defaults are injected.
+    """
+    scope_mode = str(mcp_scope.get("mcp_scope_mode") or "none").strip().lower()
+    project_slug = mcp_scope.get("mcp_project_slug")
+    has_project_scope = scope_mode == "project" and isinstance(project_slug, str) and bool(project_slug.strip())
+
+    if has_project_scope:
+        if not bool(mcp_scope.get("mcp_tools_enabled")):
+            mcp_scope["mcp_tools_enabled"] = True
+            return "conversation_type"
+        return None
+
+    topic = _extract_life_topic(conversation_type)
+    if topic:
+        mcp_scope.update(
+            {
+                "mcp_tools_enabled": True,
+                "mcp_scope_mode": "project",
+                "mcp_project_slug": topic,
+                "mcp_project_name": LIFE_ONBOARDING_TOPICS[topic],
+                "mcp_project_lifecycle": "active",
+                "mcp_project_source": "conversation_type",
+                "mcp_plugin_slug": mcp_scope.get("mcp_plugin_slug")
+                or DEFAULT_LIBRARY_MCP_PLUGIN_SLUG,
+            }
+        )
+        return "conversation_type"
+
+    if _is_capture_intake_conversation(conversation_type):
+        mcp_scope.update(
+            {
+                "mcp_tools_enabled": True,
+                "mcp_scope_mode": "project",
+                "mcp_project_slug": "capture",
+                "mcp_project_name": "Capture",
+                "mcp_project_lifecycle": "active",
+                "mcp_project_source": "conversation_type",
+                "mcp_plugin_slug": mcp_scope.get("mcp_plugin_slug")
+                or DEFAULT_LIBRARY_MCP_PLUGIN_SLUG,
+            }
+        )
+        return "conversation_type"
+
+    if _is_digest_conversation(conversation_type):
+        mcp_scope.update(
+            {
+                "mcp_tools_enabled": True,
+                "mcp_scope_mode": "project",
+                "mcp_project_slug": "digest",
+                "mcp_project_name": "Digest",
+                "mcp_project_lifecycle": "active",
+                "mcp_project_source": "conversation_type",
+                "mcp_plugin_slug": mcp_scope.get("mcp_plugin_slug")
+                or DEFAULT_LIBRARY_MCP_PLUGIN_SLUG,
+            }
+        )
+        return "conversation_type"
+
+    return None
+
+
+def _extract_resolved_tool_names(resolved_tools: List[Dict[str, Any]]) -> set[str]:
+    names: set[str] = set()
+    for schema in resolved_tools:
+        if not isinstance(schema, dict):
+            continue
+        function = schema.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if isinstance(name, str) and name.strip():
+            names.add(name.strip())
+    return names
+
+
+STRICT_NATIVE_TOOL_SCHEMA_PROVIDERS = {"openrouter", "openai"}
+STRICT_NATIVE_TOP_LEVEL_DISALLOWED = {"oneOf", "anyOf", "allOf", "enum", "not"}
+
+
+def _merge_top_level_object_variants(variants: Any) -> tuple[Dict[str, Any], List[str]]:
+    merged_properties: Dict[str, Any] = {}
+    merged_required: List[str] = []
+    if not isinstance(variants, list):
+        return merged_properties, merged_required
+
+    for variant in variants:
+        if not isinstance(variant, dict):
+            continue
+        if str(variant.get("type") or "object").strip().lower() != "object":
+            continue
+        properties = variant.get("properties")
+        if isinstance(properties, dict):
+            for key, value in properties.items():
+                if isinstance(key, str) and key and key not in merged_properties:
+                    merged_properties[key] = copy.deepcopy(value)
+        required = variant.get("required")
+        if isinstance(required, list):
+            for entry in required:
+                if isinstance(entry, str) and entry not in merged_required:
+                    merged_required.append(entry)
+    return merged_properties, merged_required
+
+
+def _sanitize_native_tool_parameters(parameters: Any) -> Dict[str, Any]:
+    sanitized: Dict[str, Any] = (
+        copy.deepcopy(parameters) if isinstance(parameters, dict) else {}
+    )
+    top_level_properties: Dict[str, Any] = (
+        copy.deepcopy(sanitized.get("properties"))
+        if isinstance(sanitized.get("properties"), dict)
+        else {}
+    )
+    top_level_required: List[str] = (
+        [entry for entry in sanitized.get("required") if isinstance(entry, str)]
+        if isinstance(sanitized.get("required"), list)
+        else []
+    )
+
+    for keyword in ("oneOf", "anyOf", "allOf"):
+        merged_properties, merged_required = _merge_top_level_object_variants(
+            sanitized.get(keyword)
+        )
+        for key, value in merged_properties.items():
+            if key not in top_level_properties:
+                top_level_properties[key] = value
+        for entry in merged_required:
+            if entry not in top_level_required:
+                top_level_required.append(entry)
+        sanitized.pop(keyword, None)
+
+    for keyword in STRICT_NATIVE_TOP_LEVEL_DISALLOWED:
+        sanitized.pop(keyword, None)
+
+    sanitized["type"] = "object"
+    sanitized["properties"] = top_level_properties
+    if top_level_required:
+        sanitized["required"] = top_level_required
+    elif "required" in sanitized:
+        sanitized.pop("required", None)
+    if "additionalProperties" not in sanitized:
+        sanitized["additionalProperties"] = True
+    return sanitized
+
+
+def _sanitize_tools_for_provider(
+    resolved_tools: List[Dict[str, Any]],
+    provider: Any,
+) -> tuple[List[Dict[str, Any]], int]:
+    provider_id = str(provider or "").strip().lower()
+    if provider_id not in STRICT_NATIVE_TOOL_SCHEMA_PROVIDERS:
+        return resolved_tools, 0
+
+    sanitized_tools: List[Dict[str, Any]] = []
+    sanitized_count = 0
+    for tool_schema in resolved_tools:
+        if not isinstance(tool_schema, dict):
+            sanitized_tools.append(tool_schema)
+            continue
+        schema_copy = copy.deepcopy(tool_schema)
+        function = schema_copy.get("function")
+        if not isinstance(function, dict):
+            sanitized_tools.append(schema_copy)
+            continue
+        parameters = function.get("parameters")
+        sanitized_parameters = _sanitize_native_tool_parameters(parameters)
+        if parameters != sanitized_parameters:
+            function["parameters"] = sanitized_parameters
+            sanitized_count += 1
+        sanitized_tools.append(schema_copy)
+    return sanitized_tools, sanitized_count
+
+
+def _is_strict_native_provider(provider: Any) -> bool:
+    return str(provider or "").strip().lower() in STRICT_NATIVE_TOOL_SCHEMA_PROVIDERS
+
+
+def _build_tool_result_message(
+    *,
+    provider: Any,
+    tool_name: Optional[str],
+    tool_call_id: Optional[str],
+    content: str,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "role": "tool",
+        "content": content,
+    }
+    if isinstance(tool_call_id, str) and tool_call_id.strip():
+        payload["tool_call_id"] = tool_call_id.strip()
+    if not _is_strict_native_provider(provider):
+        if isinstance(tool_name, str) and tool_name.strip():
+            payload["name"] = tool_name.strip()
+    return payload
+
+
+
+def _extract_resolved_tool_safety(resolved_tools: List[Dict[str, Any]]) -> Dict[str, str]:
+    safety: Dict[str, str] = {}
+    for schema in resolved_tools:
+        if not isinstance(schema, dict):
+            continue
+        function = schema.get("function")
+        if not isinstance(function, dict):
+            continue
+        name = function.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+        safety[name.strip()] = infer_safety_class(name, schema)
+    return safety
+
+
+def _infer_page_kind(conversation_type: str) -> str:
+    normalized = _normalize_conversation_type(conversation_type)
+    if _is_capture_intake_conversation(normalized):
+        return "capture"
+    if _is_digest_conversation(normalized):
+        return "digest"
+    if _extract_life_topic(normalized):
+        return "life"
+    return "project"
+
+
+def _normalize_project_scope_path(project_slug: Any) -> Optional[str]:
+    if not isinstance(project_slug, str):
+        return None
+
+    normalized = project_slug.strip().replace("\\", "/")
+    if not normalized:
+        return None
+
+    if normalized in {"capture", "life"}:
+        return normalized
+    if normalized == "digest":
+        return normalized
+
+    if normalized.startswith("users/"):
+        return normalized
+    if normalized.startswith("projects/"):
+        return normalized
+    if normalized.startswith("life/"):
+        return normalized
+    return f"projects/active/{normalized}"
+
+
+def _normalize_scoped_tool_path(path_value: Any, scope_path: Optional[str]) -> Optional[str]:
+    if not isinstance(path_value, str):
+        return None
+    normalized = path_value.strip().replace("\\", "/")
+    if not normalized:
+        return None
+    normalized = re.sub(r"^\./+", "", normalized)
+    if normalized.startswith(("projects/", "life/", "capture/", "digest/", "users/")):
+        return normalized
+    if not isinstance(scope_path, str) or not scope_path.strip():
+        return normalized
+    return f"{scope_path.strip().rstrip('/')}/{normalized.lstrip('/')}"
+
+
+def _is_new_page_interview_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return False
+    if "interview" in normalized or "onboarding" in normalized:
+        return True
+    start_markers = ("start", "resume", "continue", "next question", "question")
+    if any(marker in normalized for marker in start_markers) and "page" in normalized:
+        return True
+    return False
+
+
+def _apply_dual_path_scope_tool_policy(
+    *,
+    routing_decision: Dict[str, Any],
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+    latest_user_message: Optional[str] = None,
+) -> Dict[str, Any]:
+    updated = dict(routing_decision)
+    if str(updated.get("route_mode") or "").strip() != "dual_path_fallback":
+        return updated
+    if str(updated.get("tool_profile") or "").strip() != TOOL_PROFILE_READ_ONLY:
+        return updated
+    if str(updated.get("tool_profile_source") or "").strip() != "routing_default":
+        return updated
+
+    normalized_scope = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+    life_topic = _extract_life_topic(conversation_type)
+    new_page_intent = _is_new_page_engine_intent(latest_user_message)
+    new_page_interview_intent = _is_new_page_interview_intent(latest_user_message)
+    owner_profile_intent = bool(_extract_owner_profile_update_text(latest_user_message))
+    is_capture_scope = bool(
+        (isinstance(normalized_scope, str) and normalized_scope == "capture")
+        or _is_capture_intake_conversation(conversation_type)
+    )
+    is_life_scope = bool(
+        (isinstance(normalized_scope, str) and normalized_scope.startswith("life/"))
+        or life_topic
+    )
+    is_project_scope = bool(
+        isinstance(normalized_scope, str)
+        and normalized_scope.startswith("projects/")
+    )
+    if is_capture_scope:
+        allowlist = set(DUAL_PATH_CAPTURE_SCOPE_COMPAT_TOOL_ALLOWLIST)
+        policy_mode = "dual_path_capture_scope_compat"
+        if new_page_intent:
+            allowlist.update(DUAL_PATH_NEW_PAGE_COMPAT_TOOL_ALLOWLIST)
+            policy_mode = "dual_path_capture_new_page_compat"
+        updated.update(
+            {
+                "tool_profile": TOOL_PROFILE_FULL,
+                "tool_profile_source": "routing_scope_policy",
+                "allowed_safety_classes": [TOOL_PROFILE_READ_ONLY, "mutating"],
+                "tool_name_allowlist": sorted(allowlist),
+                "policy_mode": policy_mode,
+            }
+        )
+        return updated
+
+    if is_life_scope:
+        allowlist = set(DUAL_PATH_LIFE_SCOPE_COMPAT_TOOL_ALLOWLIST)
+        policy_mode = "dual_path_life_scope_compat"
+        if new_page_intent:
+            allowlist.update(DUAL_PATH_NEW_PAGE_COMPAT_TOOL_ALLOWLIST)
+            policy_mode = "dual_path_life_new_page_compat"
+        updated.update(
+            {
+                "tool_profile": TOOL_PROFILE_FULL,
+                "tool_profile_source": "routing_scope_policy",
+                "allowed_safety_classes": [TOOL_PROFILE_READ_ONLY, "mutating"],
+                "tool_name_allowlist": sorted(allowlist),
+                "policy_mode": policy_mode,
+            }
+        )
+        return updated
+
+    if is_project_scope and not new_page_intent and not new_page_interview_intent:
+        updated.update(
+            {
+                "tool_profile": TOOL_PROFILE_FULL,
+                "tool_profile_source": "routing_scope_policy",
+                "allowed_safety_classes": [TOOL_PROFILE_READ_ONLY, "mutating"],
+                "tool_name_allowlist": sorted(DUAL_PATH_PROJECT_SCOPE_COMPAT_TOOL_ALLOWLIST),
+                "policy_mode": "dual_path_project_scope_compat",
+            }
+        )
+        return updated
+
+    if owner_profile_intent and normalized_scope not in {"digest"}:
+        updated.update(
+            {
+                "tool_profile": TOOL_PROFILE_FULL,
+                "tool_profile_source": "routing_intent_policy",
+                "allowed_safety_classes": [TOOL_PROFILE_READ_ONLY, "mutating"],
+                "tool_name_allowlist": sorted(DUAL_PATH_OWNER_PROFILE_COMPAT_TOOL_ALLOWLIST),
+                "policy_mode": "dual_path_owner_profile_compat",
+            }
+        )
+        return updated
+
+    if new_page_intent:
+        updated.update(
+            {
+                "tool_profile": TOOL_PROFILE_FULL,
+                "tool_profile_source": "routing_intent_policy",
+                "allowed_safety_classes": [TOOL_PROFILE_READ_ONLY, "mutating"],
+                "tool_name_allowlist": sorted(DUAL_PATH_NEW_PAGE_COMPAT_TOOL_ALLOWLIST),
+                "policy_mode": "dual_path_new_page_compat",
+            }
+        )
+        return updated
+
+    if new_page_interview_intent and isinstance(normalized_scope, str) and normalized_scope not in {
+        "capture",
+        "digest",
+    }:
+        updated.update(
+            {
+                "tool_profile": TOOL_PROFILE_FULL,
+                "tool_profile_source": "routing_intent_policy",
+                "allowed_safety_classes": [TOOL_PROFILE_READ_ONLY, "mutating"],
+                "tool_name_allowlist": sorted(DUAL_PATH_NEW_PAGE_INTERVIEW_COMPAT_TOOL_ALLOWLIST),
+                "policy_mode": "dual_path_new_page_interview_compat",
+            }
+        )
+    return updated
+
+
+def _is_owner_profile_resume_approval_context(
+    approval_resume_context: Optional[Dict[str, Any]],
+) -> bool:
+    if not isinstance(approval_resume_context, dict):
+        return False
+    if str(approval_resume_context.get("action") or "").strip().lower() != "approve":
+        return False
+
+    synthetic_reason = str(approval_resume_context.get("synthetic_reason") or "").strip().lower()
+    if synthetic_reason in OWNER_PROFILE_UPDATE_REASONS:
+        return True
+
+    tool_name = str(approval_resume_context.get("tool") or "").strip()
+    if tool_name not in {"write_markdown", "create_markdown"}:
+        return False
+
+    summary_text = str(approval_resume_context.get("summary") or "").strip().lower()
+    if "me/profile.md" in summary_text or "me/profile" in summary_text:
+        return True
+
+    arguments = approval_resume_context.get("arguments")
+    if not isinstance(arguments, dict):
+        return False
+    raw_path = arguments.get("path")
+    if not isinstance(raw_path, str):
+        raw_path = arguments.get("file_path")
+    if not isinstance(raw_path, str) or not raw_path.strip():
+        return False
+
+    normalized_path = raw_path.strip().replace("\\", "/")
+    normalized_path = re.sub(r"^(?:\./)+", "", normalized_path)
+    normalized_path = normalized_path.lstrip("/").lower()
+    if normalized_path in {"profile", "profile.md", "me/profile", OWNER_PROFILE_RELATIVE_PATH.lower()}:
+        return True
+    if normalized_path.endswith("/me/profile.md"):
+        return True
+    return False
+
+
+def _apply_approval_resume_tool_policy(
+    *,
+    routing_decision: Dict[str, Any],
+    approval_resume_context: Optional[Dict[str, Any]],
+) -> Dict[str, Any]:
+    updated = dict(routing_decision)
+    if str(updated.get("route_mode") or "").strip() != "dual_path_fallback":
+        return updated
+    if not _is_owner_profile_resume_approval_context(approval_resume_context):
+        return updated
+
+    updated.update(
+        {
+            "tool_profile": TOOL_PROFILE_FULL,
+            "tool_profile_source": "routing_resume_policy",
+            "allowed_safety_classes": [TOOL_PROFILE_READ_ONLY, "mutating"],
+            "tool_name_allowlist": sorted(DUAL_PATH_OWNER_PROFILE_COMPAT_TOOL_ALLOWLIST),
+            "policy_mode": "dual_path_owner_profile_resume_compat",
+        }
+    )
+    return updated
+
+
+def _derive_scope_root_and_path(
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+) -> tuple[Optional[str], Optional[str]]:
+    page_kind = _infer_page_kind(conversation_type)
+    if page_kind == "capture":
+        return "capture", "capture"
+    if page_kind == "digest":
+        return "digest", "digest"
+
+    life_topic = _extract_life_topic(conversation_type)
+    if page_kind == "life" and life_topic:
+        return "life", f"life/{life_topic}"
+
+    scope_path = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+    if not scope_path:
+        return "projects", None
+
+    if scope_path.startswith("life/"):
+        return "life", scope_path
+    if scope_path.startswith("capture"):
+        return "capture", "capture"
+    if scope_path.startswith("projects/"):
+        return "projects", scope_path
+    return "projects", scope_path
+
+
+def _required_scope_files_for_page_kind(page_kind: str) -> List[str]:
+    normalized = str(page_kind or "").strip().lower()
+    if normalized == "project":
+        return ["AGENT.md", "spec.md", "build-plan.md", "decisions.md", "ideas.md"]
+    if normalized == "life":
+        return [
+            "AGENT.md",
+            "spec.md",
+            "build-plan.md",
+            "interview.md",
+            "goals.md",
+            "action-plan.md",
+        ]
+    if normalized == "capture":
+        return ["AGENT.md"]
+    if normalized == "digest":
+        return ["AGENT.md", "_meta/rollup-state.json"]
+    return ["AGENT.md", "spec.md", "build-plan.md"]
+
+
+def _extract_nested_mcp_error_code(error: Dict[str, Any]) -> Optional[str]:
+    if not isinstance(error, dict):
+        return None
+
+    details = error.get("details")
+    if not isinstance(details, dict):
+        return None
+
+    nested_error = details.get("error")
+    if not isinstance(nested_error, dict):
+        return None
+
+    nested_code = nested_error.get("code")
+    if isinstance(nested_code, str) and nested_code.strip():
+        return nested_code.strip()
+    return None
+
+
+def _extract_tool_execution_error_code(tool_call_payload: Dict[str, Any]) -> Optional[str]:
+    if not isinstance(tool_call_payload, dict):
+        return None
+    error = tool_call_payload.get("error")
+    if not isinstance(error, dict):
+        return None
+
+    nested = _extract_nested_mcp_error_code(error)
+    if isinstance(nested, str) and nested.strip():
+        return nested.strip()
+
+    direct = error.get("code")
+    if isinstance(direct, str) and direct.strip():
+        return direct.strip()
+
+    details = error.get("details")
+    if isinstance(details, dict):
+        nested_code = details.get("code")
+        if isinstance(nested_code, str) and nested_code.strip():
+            return nested_code.strip()
+
+    return None
+
+
+async def _check_scope_file_exists(
+    *,
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    plugin_slug_hint: Optional[str],
+    path: str,
+) -> tuple[Optional[bool], Optional[Dict[str, Any]]]:
+    execution = await _execute_tool_with_resync_fallback(
+        runtime_service=runtime_service,
+        mcp_user_id=mcp_user_id,
+        tool_name="read_file_metadata",
+        arguments={"path": path},
+        plugin_slug_hint=plugin_slug_hint,
+    )
+    if execution.get("ok"):
+        return True, None
+
+    error = execution.get("error") if isinstance(execution.get("error"), dict) else {}
+    nested_code = _extract_nested_mcp_error_code(error)
+    if nested_code == "FILE_NOT_FOUND":
+        return False, None
+
+    return None, error if error else {"code": "UNKNOWN_ERROR", "message": "Metadata lookup failed."}
+
+
+async def _build_orchestration_context_payload(
+    *,
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+    resolved_tools: List[Dict[str, Any]],
+    plugin_slug_hint: Optional[str],
+) -> Dict[str, Any]:
+    page_kind = _infer_page_kind(conversation_type)
+    scope_root, scope_path = _derive_scope_root_and_path(conversation_type, mcp_scope)
+    if scope_root == "life" and page_kind != "capture":
+        page_kind = "life"
+    elif scope_root == "capture":
+        page_kind = "capture"
+    required_files = _required_scope_files_for_page_kind(page_kind)
+
+    required_file_map: Dict[str, Dict[str, Any]] = {}
+    required_files_missing: List[str] = []
+    required_files_unverified: List[str] = []
+    context_missing: List[str] = []
+    resolved_tool_names = _extract_resolved_tool_names(resolved_tools)
+    has_metadata_tool = "read_file_metadata" in resolved_tool_names
+    has_onboarding_state_tool = "get_onboarding_state" in resolved_tool_names
+
+    if not scope_path:
+        context_missing.append("scope_path")
+    elif not has_metadata_tool:
+        for filename in required_files:
+            target_path = f"{scope_path.rstrip('/')}/{filename}"
+            required_file_map[target_path] = {
+                "exists": None,
+                "error": {
+                    "code": "TOOL_NOT_ALLOWED",
+                    "message": "read_file_metadata is not available in this tool set.",
+                },
+            }
+            required_files_unverified.append(target_path)
+    else:
+        for filename in required_files:
+            target_path = f"{scope_path.rstrip('/')}/{filename}"
+            exists, error = await _check_scope_file_exists(
+                runtime_service=runtime_service,
+                mcp_user_id=mcp_user_id,
+                plugin_slug_hint=plugin_slug_hint,
+                path=target_path,
+            )
+            entry: Dict[str, Any] = {"exists": exists}
+            if isinstance(error, dict) and error:
+                entry["error"] = error
+
+            required_file_map[target_path] = entry
+            if exists is False:
+                required_files_missing.append(target_path)
+            elif exists is None:
+                required_files_unverified.append(target_path)
+
+    scope_scaffold_repair: Optional[Dict[str, Any]] = None
+    if (
+        scope_path
+        and required_files_missing
+        and has_metadata_tool
+        and "ensure_scope_scaffold" in resolved_tool_names
+    ):
+        repair_result = await _execute_tool_with_resync_fallback(
+            runtime_service=runtime_service,
+            mcp_user_id=mcp_user_id,
+            tool_name="ensure_scope_scaffold",
+            arguments={"path": scope_path},
+            plugin_slug_hint=plugin_slug_hint,
+        )
+        if repair_result.get("ok"):
+            scope_scaffold_repair = {
+                "attempted": True,
+                "status": "success",
+                "result": repair_result.get("data") if isinstance(repair_result.get("data"), dict) else {},
+            }
+
+            required_file_map = {}
+            required_files_missing = []
+            required_files_unverified = []
+            for filename in required_files:
+                target_path = f"{scope_path.rstrip('/')}/{filename}"
+                exists, error = await _check_scope_file_exists(
+                    runtime_service=runtime_service,
+                    mcp_user_id=mcp_user_id,
+                    plugin_slug_hint=plugin_slug_hint,
+                    path=target_path,
+                )
+                entry: Dict[str, Any] = {"exists": exists}
+                if isinstance(error, dict) and error:
+                    entry["error"] = error
+
+                required_file_map[target_path] = entry
+                if exists is False:
+                    required_files_missing.append(target_path)
+                elif exists is None:
+                    required_files_unverified.append(target_path)
+        else:
+            scope_scaffold_repair = {
+                "attempted": True,
+                "status": "failed",
+                "error": repair_result.get("error") if isinstance(repair_result.get("error"), dict) else {},
+            }
+
+    onboarding_state: Optional[Dict[str, Any]] = None
+    onboarding_state_error: Optional[Dict[str, Any]] = None
+    onboarding_topic: Optional[str] = None
+    onboarding_topic_status: Optional[str] = None
+    if page_kind == "life":
+        onboarding_topic = _extract_life_topic_from_scope_path(scope_path) or _extract_life_topic(
+            _normalize_conversation_type(conversation_type)
+        )
+        if has_onboarding_state_tool:
+            onboarding_result = await _execute_tool_with_resync_fallback(
+                runtime_service=runtime_service,
+                mcp_user_id=mcp_user_id,
+                tool_name="get_onboarding_state",
+                arguments={},
+                plugin_slug_hint=plugin_slug_hint,
+            )
+            if onboarding_result.get("ok"):
+                onboarding_payload = onboarding_result.get("data")
+                if isinstance(onboarding_payload, dict):
+                    onboarding_data = onboarding_payload.get("data")
+                    if isinstance(onboarding_data, dict):
+                        state = onboarding_data.get("state")
+                        if isinstance(state, dict):
+                            onboarding_state = state
+                            starter_topics = state.get("starter_topics")
+                            if (
+                                onboarding_topic
+                                and isinstance(starter_topics, dict)
+                                and isinstance(starter_topics.get(onboarding_topic), str)
+                            ):
+                                onboarding_topic_status = str(starter_topics[onboarding_topic])
+            else:
+                onboarding_state_error = (
+                    onboarding_result.get("error")
+                    if isinstance(onboarding_result.get("error"), dict)
+                    else {"code": "ONBOARDING_STATE_UNAVAILABLE"}
+                )
+        else:
+            onboarding_state_error = {
+                "code": "TOOL_NOT_ALLOWED",
+                "message": "get_onboarding_state is not available in this tool set.",
+            }
+
+        if onboarding_state is None:
+            context_missing.append("onboarding_state")
+    context_ready = (
+        not context_missing
+        and not required_files_missing
+        and not required_files_unverified
+    )
+
+    return {
+        "conversation_type": _normalize_conversation_type(conversation_type),
+        "page_kind": page_kind,
+        "scope_root": scope_root,
+        "scope_path": scope_path,
+        "required_file_map": required_file_map,
+        "required_files_missing": required_files_missing,
+        "required_files_unverified": required_files_unverified,
+        "scope_scaffold_repair": scope_scaffold_repair,
+        "onboarding_state": onboarding_state,
+        "onboarding_state_error": onboarding_state_error,
+        "onboarding_topic": onboarding_topic,
+        "onboarding_topic_status": onboarding_topic_status,
+        "tool_safety_metadata": {
+            "tool_classes": _extract_resolved_tool_safety(resolved_tools),
+        },
+        "approval_mode_policy": APPROVAL_MODE_POLICY,
+        "context_missing": context_missing,
+        "context_ready": context_ready,
+        "checked_at": datetime.now(timezone.utc).replace(microsecond=0).isoformat(),
+    }
+
+
+def _build_orchestration_context_error_payload(
+    *,
+    tool_name: str,
+    orchestration_context: Dict[str, Any],
+) -> Dict[str, Any]:
+    missing_fields = orchestration_context.get("context_missing")
+    if not isinstance(missing_fields, list):
+        missing_fields = []
+
+    required_missing = orchestration_context.get("required_files_missing")
+    if not isinstance(required_missing, list):
+        required_missing = []
+
+    required_unverified = orchestration_context.get("required_files_unverified")
+    if not isinstance(required_unverified, list):
+        required_unverified = []
+
+    return {
+        "code": "MISSING_ORCHESTRATION_CONTEXT",
+        "message": (
+            "Mutating tool execution blocked until canonical scope context is complete."
+        ),
+        "details": {
+            "tool": tool_name,
+            "missing_fields": missing_fields,
+            "required_files_missing": required_missing,
+            "required_files_unverified": required_unverified,
+            "approval_mode_policy": APPROVAL_MODE_POLICY,
+            "scope_root": orchestration_context.get("scope_root"),
+            "scope_path": orchestration_context.get("scope_path"),
+            "remediation": [
+                "Run ensure_scope_scaffold (or bootstrap_user_library/create_project_scaffold) to repair missing canonical files.",
+                "Resolve scope mapping and required-file checks before retrying mutating tools.",
+                "Retry the request after orchestration context shows context_ready=true.",
+            ],
+        },
+    }
+
+
+def _validate_mutating_orchestration_context(
+    *,
+    tool_name: str,
+    safety_class: str,
+    orchestration_context: Optional[Dict[str, Any]],
+) -> tuple[bool, Optional[Dict[str, Any]]]:
+    if str(safety_class or "").strip().lower() != "mutating":
+        return True, None
+
+    if tool_name in MUTATION_CONTEXT_REMEDIATION_TOOLS:
+        return True, None
+
+    if not isinstance(orchestration_context, dict):
+        fallback_context = {
+            "context_missing": ["orchestration_context"],
+            "required_files_missing": [],
+            "required_files_unverified": [],
+            "scope_root": None,
+            "scope_path": None,
+        }
+        return False, _build_orchestration_context_error_payload(
+            tool_name=tool_name,
+            orchestration_context=fallback_context,
+        )
+
+    missing_fields = orchestration_context.get("context_missing")
+    if not isinstance(missing_fields, list):
+        missing_fields = []
+
+    required_missing = orchestration_context.get("required_files_missing")
+    if not isinstance(required_missing, list):
+        required_missing = []
+
+    required_unverified = orchestration_context.get("required_files_unverified")
+    if not isinstance(required_unverified, list):
+        required_unverified = []
+
+    required_file_map = orchestration_context.get("required_file_map")
+    if not isinstance(required_file_map, dict):
+        required_file_map = {}
+
+    effective_required_unverified = list(required_unverified)
+    if effective_required_unverified:
+        unresolved_paths = [
+            path
+            for path in effective_required_unverified
+            if not (
+                isinstance(path, str)
+                and isinstance(required_file_map.get(path), dict)
+                and isinstance(required_file_map[path].get("error"), dict)
+                and str(required_file_map[path]["error"].get("code") or "").strip() == "TOOL_NOT_ALLOWED"
+            )
+        ]
+        if not unresolved_paths:
+            # If metadata checks are unavailable in the active tool profile,
+            # keep the context signal for observability but do not block writes.
+            effective_required_unverified = []
+
+    effective_missing_fields = list(missing_fields)
+    context_conversation_type = _normalize_conversation_type(
+        str(orchestration_context.get("conversation_type") or "")
+    )
+    is_life_conversation = context_conversation_type.startswith("life-")
+    if (
+        "onboarding_state" in effective_missing_fields
+        and tool_name not in ONBOARDING_CONTEXT_REQUIRED_TOOLS
+        and not is_life_conversation
+    ):
+        effective_missing_fields = [
+            item for item in effective_missing_fields if item != "onboarding_state"
+        ]
+
+    if not effective_missing_fields and not required_missing and not effective_required_unverified:
+        return True, None
+
+    effective_context = dict(orchestration_context)
+    effective_context["context_missing"] = effective_missing_fields
+    effective_context["required_files_missing"] = required_missing
+    effective_context["required_files_unverified"] = effective_required_unverified
+
+    return False, _build_orchestration_context_error_payload(
+        tool_name=tool_name,
+        orchestration_context=effective_context,
+    )
+
+
+def _build_conversation_orchestration_prompt(
+    conversation_type: str,
+    resolved_tools: List[Dict[str, Any]],
+    *,
+    digest_sections: Optional[List[str]] = None,
+    digest_due_now: bool = False,
+) -> tuple[Optional[str], Optional[Dict[str, str]]]:
+    tool_names = _extract_resolved_tool_names(resolved_tools)
+    life_topic = _extract_life_topic(conversation_type)
+    if life_topic and {"get_onboarding_state", "start_topic_onboarding"}.issubset(tool_names):
+        return (
+            "life_onboarding",
+            {
+                "role": "system",
+                "content": (
+                    f"Life onboarding orchestration for topic '{life_topic}': "
+                    "call get_onboarding_state at the start; if this topic is not complete, "
+                    f"call start_topic_onboarding with topic='{life_topic}' to initialize interview context. "
+                    "Use topic AGENT context first (fallback to interview seed when needed), then generate dynamic topic-appropriate opening questions. "
+                    "Opening interview should be high-level and capped at 6 questions. "
+                    "Ask one question per turn and wait for the user's answer before asking the next question. "
+                    "This phase is discovery-only: do not provide coaching, recommendations, or solution plans unless the user explicitly asks. "
+                    "Keep responses short (max two setup sentences plus one question) and never output a full questionnaire list. "
+                    "Before any mutating write, summarize the proposed update and require explicit approval. "
+                    "After approval, call save_topic_onboarding_context with topic, question, answer, context, and approved=true. "
+                    "After opening questions finish, ask whether the user wants initial goals/tasks captured. "
+                    "When due dates are relative, convert them to explicit dates before save. "
+                    "When onboarding context is sufficient, call complete_topic_onboarding with a concise summary. "
+                    "For task requests in this topic, always call list_tasks first to resolve task IDs before mutating operations. "
+                    "If the user asks to complete or edit an existing task, do not call create_task; use update_task and/or complete_task for the matched task ID. "
+                    "Only call create_task when the user explicitly requests a new task and no existing task match is intended."
+                ),
+            },
+        )
+
+    if _is_digest_conversation(conversation_type) and not _is_digest_reply_conversation(conversation_type):
+        has_snapshot = "digest_snapshot" in tool_names
+        has_score = "score_digest_tasks" in tool_names
+        has_rollup = "rollup_digest_period" in tool_names
+        has_capture_writer = "create_markdown" in tool_names or "write_markdown" in tool_names
+        delivery_channel = _extract_digest_delivery_channel(conversation_type) or "chat"
+        if has_snapshot or has_score or has_rollup:
+            section_labels = ", ".join(digest_sections or list(DEFAULT_DIGEST_SECTIONS))
+            lines = [
+                "Digest heartbeat mode:",
+                f"Target sections: {section_labels}.",
+                "Keep digest output concise and scannable.",
+                "Always include one actionable library-improvement suggestion.",
+            ]
+            if delivery_channel != "chat":
+                lines.append(
+                    f"Delivery channel: {delivery_channel}. "
+                    "Format output as transport-friendly bullet points (no tables)."
+                )
+            if digest_due_now:
+                lines.append("A scheduled digest run is due now.")
+            if has_snapshot:
+                lines.append("Call digest_snapshot first to gather tasks, completions, and recent activity.")
+            if has_score:
+                lines.append("Call score_digest_tasks using digest_snapshot task data before drafting priorities.")
+            if has_rollup:
+                lines.append("Use rollup_digest_period for weekly digest persistence/checkpoints when appropriate.")
+            if has_capture_writer:
+                lines.append("If the user replies with quick updates, persist them into capture/inbox.")
+            lines.append("All mutating operations require explicit approval before execution.")
+            return (
+                "digest_heartbeat",
+                {
+                    "role": "system",
+                    "content": " ".join(lines),
+                },
+            )
+
+    if _is_capture_intake_conversation(conversation_type):
+        has_inbox_writer = "create_markdown" in tool_names or "write_markdown" in tool_names
+        has_rollup = "rollup_digest_period" in tool_names
+        has_task_lookup = "list_tasks" in tool_names
+        has_task_mutation = "update_task" in tool_names or "complete_task" in tool_names
+        has_task_creator = "create_task" in tool_names
+        if has_inbox_writer or has_rollup:
+            lines = ["Capture orchestration mode:"]
+            if _is_digest_reply_conversation(conversation_type):
+                lines.append(
+                    "This turn originated from a digest reply, so prioritize fast capture of notes/tasks."
+                )
+            if has_inbox_writer:
+                lines.append(
+                    "Persist raw captures to a markdown file under capture/inbox before any routing/categorization."
+                )
+                lines.append(
+                    "If the user records a decision, also write a canonical decision entry to decisions.md in the selected scope."
+                )
+            lines.append(
+                "When multiple distinct tasks or decisions are present, create separate entries so each can be tracked independently."
+            )
+            if has_task_lookup and has_task_mutation:
+                lines.append(
+                    "For requests to complete or edit an existing task, call list_tasks first to resolve task IDs, then use update_task and/or complete_task with the matched task ID."
+                )
+                if has_task_creator:
+                    lines.append(
+                        "Do not call create_task when the intent is to complete or edit an existing task; only call create_task for explicitly new tasks."
+                    )
+            elif has_task_creator:
+                lines.append(
+                    "Only call create_task when the user explicitly requests a new task."
+                )
+            if has_rollup:
+                lines.append(
+                    "After capture or daily-event writes, trigger rollup_digest_period (week, and month/year when relevant)."
+                )
+            lines.append(
+                "Use canonical current UTC dates in capture writes (filenames, due fields, and relative-date content)."
+            )
+            lines.append("All mutating operations require explicit approval before execution.")
+            return (
+                "capture_intake",
+                {
+                    "role": "system",
+                    "content": " ".join(lines),
+                },
+            )
+
+    return (None, None)
+
+
+
+def _insert_orchestration_system_message(
+    combined_messages: List[Dict[str, Any]],
+    orchestration_message: Optional[Dict[str, str]],
+) -> List[Dict[str, Any]]:
+    if not orchestration_message:
+        return combined_messages
+
+    insertion_index = 0
+    while insertion_index < len(combined_messages):
+        entry = combined_messages[insertion_index]
+        role = entry.get("role") if isinstance(entry, dict) else None
+        if role != "system":
+            break
+        insertion_index += 1
+
+    return (
+        combined_messages[:insertion_index]
+        + [orchestration_message]
+        + combined_messages[insertion_index:]
+    )
+
+
+def _latest_user_message_text(messages: List[Dict[str, Any]]) -> Optional[str]:
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if isinstance(content, str) and content.strip():
+            return content.strip()
+    return None
+
+
+def _latest_non_approval_user_message_text(messages: List[Dict[str, Any]]) -> Optional[str]:
+    for message in reversed(messages):
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "user":
+            continue
+        content = message.get("content")
+        if not isinstance(content, str):
+            continue
+        stripped = content.strip()
+        if not stripped:
+            continue
+        if _parse_chat_approval_action(stripped):
+            continue
+        return stripped
+    return None
+
+
+def _is_life_onboarding_kickoff_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+
+    normalized = message_text.strip().lower()
+    if not normalized:
+        return False
+
+    has_onboarding_context = "onboarding" in normalized or "interview" in normalized
+    has_start_intent = any(
+        token in normalized
+        for token in ("start", "begin", "kickoff", "kick off", "let us start", "lets start")
+    )
+    return has_onboarding_context and has_start_intent
+
+
+def _is_life_onboarding_skip_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return False
+
+    skip_markers = (
+        "skip",
+        "skip this",
+        "pass",
+        "move on",
+        "next question",
+        "not now",
+        "later",
+    )
+    return any(marker in normalized for marker in skip_markers)
+
+
+def _is_life_onboarding_resume_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return False
+
+    resume_markers = (
+        "resume",
+        "continue",
+        "pick up",
+        "where we left off",
+    )
+    has_onboarding_context = "onboarding" in normalized or "interview" in normalized
+    return any(marker in normalized for marker in resume_markers) and (
+        has_onboarding_context or len(normalized.split()) <= 3
+    )
+
+
+def _is_life_onboarding_topic_complete(status: Optional[str]) -> bool:
+    if not isinstance(status, str):
+        return False
+    normalized = status.strip().lower()
+    return normalized in {"complete", "completed", "done", "finished"}
+
+
+def _derive_life_onboarding_resume_index_from_context(
+    *,
+    orchestration_context: Optional[Dict[str, Any]],
+    life_topic: str,
+) -> Optional[int]:
+    if not isinstance(orchestration_context, dict):
+        return None
+
+    onboarding_state = orchestration_context.get("onboarding_state")
+    if not isinstance(onboarding_state, dict):
+        return None
+
+    topic_progress = onboarding_state.get("topic_progress")
+    if not isinstance(topic_progress, dict):
+        return None
+
+    progress = topic_progress.get(life_topic)
+    if not isinstance(progress, dict):
+        return None
+
+    question_total = _as_int(progress.get("question_total"), 0, 0, 10_000)
+    question_index = _as_int(progress.get("question_index"), 0, 0, 10_000)
+    if question_total <= 0:
+        return None
+
+    if question_index <= 0:
+        return 1
+    if question_index >= question_total:
+        return question_total
+    return question_index + 1
+
+
+def _extract_seed_questions(interview_markdown: str) -> List[str]:
+    if not isinstance(interview_markdown, str) or not interview_markdown.strip():
+        return []
+
+    questions: List[str] = []
+    in_seed_section = False
+    for raw_line in interview_markdown.splitlines():
+        line = raw_line.strip()
+        if not in_seed_section:
+            if line.lower().startswith("## seed questions"):
+                in_seed_section = True
+            continue
+
+        if line.startswith("## "):
+            break
+
+        match = re.match(r"^\d+\.\s+(.*\S)\s*$", line)
+        if match:
+            questions.append(match.group(1).strip())
+
+    if questions:
+        return questions
+
+    for raw_line in interview_markdown.splitlines():
+        line = raw_line.strip()
+        match = re.match(r"^\d+\.\s+(.*\S)\s*$", line)
+        if match:
+            questions.append(match.group(1).strip())
+
+    return questions
+
+
+def _dedupe_questions(questions: List[str]) -> List[str]:
+    seen: set[str] = set()
+    deduped: List[str] = []
+    for question in questions:
+        if not isinstance(question, str):
+            continue
+        normalized = " ".join(question.strip().split())
+        if not normalized:
+            continue
+        key = normalized.lower()
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(normalized)
+    return deduped
+
+
+def _extract_agent_focus_lines(agent_markdown: str) -> List[str]:
+    if not isinstance(agent_markdown, str) or not agent_markdown.strip():
+        return []
+
+    focus_lines: List[str] = []
+    in_focus_section = False
+    for raw_line in agent_markdown.splitlines():
+        line = raw_line.strip()
+        lowered = line.lower()
+
+        if lowered.startswith("## ") and "focus" in lowered:
+            in_focus_section = True
+            continue
+        if lowered.startswith("## ") and in_focus_section:
+            break
+        if not in_focus_section:
+            continue
+
+        bullet_match = re.match(r"^[-*]\s+(.*\S)\s*$", line)
+        if bullet_match:
+            focus_lines.append(bullet_match.group(1).strip())
+            continue
+
+        numbered_match = re.match(r"^\d+\.\s+(.*\S)\s*$", line)
+        if numbered_match:
+            focus_lines.append(numbered_match.group(1).strip())
+            continue
+
+    if focus_lines:
+        return focus_lines
+
+    fallback_lines: List[str] = []
+    for raw_line in agent_markdown.splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if len(line.split()) < 3:
+            continue
+        fallback_lines.append(line)
+        if len(fallback_lines) >= 5:
+            break
+    return fallback_lines
+
+
+def _build_life_questions_from_agent_focus(
+    *,
+    life_topic: str,
+    agent_markdown: Optional[str],
+) -> List[str]:
+    topic_key = str(life_topic or "").strip().lower()
+    defaults = list(LIFE_ONBOARDING_DEFAULT_QUESTIONS.get(topic_key, []))
+    focus_text = agent_markdown or ""
+    focus_lower = focus_text.lower()
+
+    keyword_map = LIFE_ONBOARDING_KEYWORD_QUESTION_MAP.get(topic_key, {})
+    prioritized: List[str] = []
+    for keyword, question in keyword_map.items():
+        if keyword in focus_lower:
+            prioritized.append(question)
+
+    focus_lines = _extract_agent_focus_lines(focus_text)
+    for line in focus_lines:
+        cleaned = line.strip().rstrip(".")
+        if not cleaned:
+            continue
+        lowered = cleaned.lower()
+        if lowered.startswith("use this folder for"):
+            continue
+        if lowered.startswith("help the user"):
+            continue
+        prioritized.append(
+            f"What is your current situation with {cleaned.lower()}, and what would you like to improve first?"
+        )
+
+    combined = _dedupe_questions(prioritized + defaults)
+    if not combined:
+        combined = _dedupe_questions(
+            [
+                f"What matters most to you in {topic_key} right now?",
+                f"What is currently working well in your {topic_key} area?",
+                f"What constraints are making progress harder in {topic_key}?",
+                "What would make the next 30 days feel successful?",
+            ]
+        )
+    return combined[:MAX_LIFE_ONBOARDING_OPENING_QUESTIONS]
+
+
+def _extract_opening_questions_from_state(state: Dict[str, Any]) -> List[str]:
+    questions = state.get("questions")
+    if not isinstance(questions, list):
+        return []
+    parsed: List[str] = []
+    for item in questions:
+        if isinstance(item, str) and item.strip():
+            parsed.append(item.strip())
+    deduped = _dedupe_questions(parsed)
+    return deduped[:MAX_LIFE_ONBOARDING_OPENING_QUESTIONS]
+
+
+def _parse_yes_no(message_text: Optional[str]) -> Optional[bool]:
+    if not isinstance(message_text, str):
+        return None
+    normalized = message_text.strip().lower()
+    if not normalized:
+        return None
+    yes_tokens = ("yes", "yep", "yeah", "sure", "ok", "okay", "do it")
+    no_tokens = ("no", "nope", "not now", "skip", "later")
+    if any(token in normalized for token in yes_tokens):
+        return True
+    if any(token in normalized for token in no_tokens):
+        return False
+    return None
+
+
+def _next_weekday(reference_date: datetime, target_weekday: int) -> datetime:
+    days_ahead = (target_weekday - reference_date.weekday()) % 7
+    if days_ahead == 0:
+        days_ahead = 7
+    return reference_date + timedelta(days=days_ahead)
+
+
+def _month_end(reference_date: datetime) -> datetime:
+    if reference_date.month == 12:
+        next_month = reference_date.replace(year=reference_date.year + 1, month=1, day=1)
+    else:
+        next_month = reference_date.replace(month=reference_date.month + 1, day=1)
+    return next_month - timedelta(days=1)
+
+
+def _normalize_relative_dates_in_text(text: str) -> tuple[str, List[Dict[str, str]]]:
+    if not isinstance(text, str) or not text.strip():
+        return text, []
+
+    now = datetime.now(timezone.utc)
+    normalized_text = text
+    replacements: List[Dict[str, str]] = []
+
+    static_phrases = {
+        "today": now.date(),
+        "tomorrow": (now + timedelta(days=1)).date(),
+        "next week": (now + timedelta(days=7)).date(),
+        "month end": _month_end(now).date(),
+    }
+    for phrase, resolved_date in static_phrases.items():
+        pattern = re.compile(rf"\b{re.escape(phrase)}\b", flags=re.IGNORECASE)
+        if not pattern.search(normalized_text):
+            continue
+        replacement = f"{phrase} ({resolved_date.isoformat()})"
+        normalized_text = pattern.sub(replacement, normalized_text)
+        replacements.append({"phrase": phrase, "resolved_date": resolved_date.isoformat()})
+
+    weekday_map = {
+        "monday": 0,
+        "tuesday": 1,
+        "wednesday": 2,
+        "thursday": 3,
+        "friday": 4,
+        "saturday": 5,
+        "sunday": 6,
+    }
+    weekday_pattern = re.compile(
+        r"\bnext\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)\b",
+        flags=re.IGNORECASE,
+    )
+    for match in list(weekday_pattern.finditer(normalized_text)):
+        weekday_name = match.group(1).lower()
+        resolved = _next_weekday(now, weekday_map[weekday_name]).date().isoformat()
+        phrase = match.group(0)
+        normalized_text = normalized_text.replace(phrase, f"{phrase} ({resolved})", 1)
+        replacements.append({"phrase": phrase.lower(), "resolved_date": resolved})
+
+    return normalized_text, replacements
+
+
+def _summarize_approved_turns_for_followup_task(
+    approved_turns: Any,
+    *,
+    max_chars: int = 140,
+) -> str:
+    if not isinstance(approved_turns, list):
+        return ""
+
+    snippets: List[str] = []
+    for turn in approved_turns[-3:]:
+        if not isinstance(turn, dict):
+            continue
+        answer = turn.get("answer")
+        if not isinstance(answer, str):
+            continue
+        cleaned = " ".join(answer.split())
+        if not cleaned:
+            continue
+        snippets.append(cleaned)
+
+    if not snippets:
+        return ""
+
+    combined = "; ".join(snippets)
+    if len(combined) <= max_chars:
+        return combined
+    return combined[: max(0, max_chars - 3)].rstrip() + "..."
+
+
+def _trim_onboarding_task_title(value: str, *, max_chars: int = 140) -> str:
+    compact = " ".join(str(value or "").split()).strip()
+    if len(compact) <= max_chars:
+        return compact
+    return compact[: max(0, max_chars - 3)].rstrip() + "..."
+
+
+def _extract_due_date_from_segment(text: str) -> Optional[str]:
+    if not isinstance(text, str):
+        return None
+    match = re.search(r"\b\d{4}-\d{2}-\d{2}\b", text)
+    if not match:
+        return None
+    return match.group(0)
+
+
+def _clean_goal_task_segment(text: str) -> str:
+    cleaned = " ".join(str(text or "").split()).strip(" .;,-")
+    if not cleaned:
+        return ""
+    # Remove explicit due-date tokens from title body when present.
+    cleaned = re.sub(r"\b(by|due|on)\s+\d{4}-\d{2}-\d{2}\b", "", cleaned, flags=re.IGNORECASE)
+    cleaned = re.sub(
+        r"\b(by|due|on)\s+(today|tomorrow|next week|month end|next\s+(?:monday|tuesday|wednesday|thursday|friday|saturday|sunday))\b(?:\s*\(\s*\d{4}-\d{2}-\d{2}\s*\))?",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"\b(?:priority|owner|tags?|scope|project)\s*:\s*[^,;.\n\r]+",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"\b(?:assigned?\s+to)\s+[A-Za-z][A-Za-z0-9 .'\-]{1,60}\b",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(
+        r"\b(?:in|for|under)\s+(?:life/)?(?:finance|finances|fitness|relationship|relationships|career|whyfinder|why finder)\b",
+        "",
+        cleaned,
+        flags=re.IGNORECASE,
+    )
+    cleaned = re.sub(r"\(\s*\d{4}-\d{2}-\d{2}\s*\)", "", cleaned)
+    cleaned = re.sub(r"\s{2,}", " ", cleaned).strip(" .;,-")
+    return cleaned
+
+
+def _split_labeled_goal_task_segments(text: str) -> List[Dict[str, str]]:
+    if not isinstance(text, str) or not text.strip():
+        return []
+
+    labeled_pattern = re.compile(r"\b(goal|task)\s*:\s*", flags=re.IGNORECASE)
+    matches = list(labeled_pattern.finditer(text))
+    if not matches:
+        return []
+
+    segments: List[Dict[str, str]] = []
+    for index, match in enumerate(matches):
+        kind = match.group(1).lower()
+        start = match.end()
+        end = matches[index + 1].start() if index + 1 < len(matches) else len(text)
+        segment = text[start:end].strip(" \n\r\t.;,-")
+        if not segment:
+            continue
+        segments.append({"kind": kind, "text": segment})
+    return segments
+
+
+def _fallback_goal_task_segments(text: str) -> List[Dict[str, str]]:
+    if not isinstance(text, str) or not text.strip():
+        return []
+
+    segments: List[Dict[str, str]] = []
+    for raw_line in text.splitlines():
+        cleaned_line = raw_line.strip()
+        if not cleaned_line:
+            continue
+        cleaned_line = re.sub(r"^[\-\*\d\.\)\s]+", "", cleaned_line).strip()
+        if not cleaned_line:
+            continue
+        parts = [part.strip() for part in re.split(r"\s*;\s*", cleaned_line) if part.strip()]
+        for part in parts:
+            lower = part.lower()
+            kind = "goal" if lower.startswith("goal ") or "goal" in lower[:16] else "task"
+            segments.append({"kind": kind, "text": part})
+
+    if segments:
+        return segments
+    return [{"kind": "task", "text": text.strip()}]
+
+
+def _extract_onboarding_goal_task_segments(text: str) -> List[Dict[str, str]]:
+    labeled = _split_labeled_goal_task_segments(text)
+    raw_segments = labeled if labeled else _fallback_goal_task_segments(text)
+
+    deduped: List[Dict[str, str]] = []
+    seen: set[str] = set()
+    for segment in raw_segments:
+        kind = segment.get("kind", "task").strip().lower()
+        raw_text = str(segment.get("text") or "").strip()
+        if not raw_text:
+            continue
+        due = _extract_due_date_from_segment(raw_text)
+        cleaned = _clean_goal_task_segment(raw_text)
+        if not cleaned:
+            cleaned = " ".join(raw_text.split()).strip()
+        key = f"{kind}|{cleaned.lower()}|{due or ''}"
+        if key in seen:
+            continue
+        seen.add(key)
+        deduped.append(
+            {
+                "kind": "goal" if kind == "goal" else "task",
+                "text": cleaned,
+                "due": due or "",
+            }
+        )
+
+    return deduped[:6]
+
+
+def _build_onboarding_initial_task_payloads(
+    *,
+    topic_slug: str,
+    topic_title: str,
+    goals_tasks_text: str,
+) -> List[Dict[str, Any]]:
+    segments = _extract_onboarding_goal_task_segments(goals_tasks_text)
+    payloads: List[Dict[str, Any]] = []
+    for segment in segments:
+        kind = segment["kind"]
+        text = segment["text"]
+        due = segment["due"] or None
+        label = "Goal" if kind == "goal" else "Task"
+        payload: Dict[str, Any] = {
+            "title": _trim_onboarding_task_title(f"{topic_title} {label}: {text}"),
+            "priority": "p2" if kind == "goal" else "p3",
+            "tags": [topic_slug, "onboarding", kind],
+            "scope": f"life/{topic_slug}",
+        }
+        if due:
+            payload["due"] = due
+        payloads.append(payload)
+    return payloads
+
+
+def _build_onboarding_followup_task_payload(
+    *,
+    topic_slug: str,
+    topic_title: str,
+    approved_turns: Any,
+) -> Dict[str, Any]:
+    due_date = (datetime.now(timezone.utc) + timedelta(days=3)).date().isoformat()
+    title = f"{topic_title} follow-up interview check-in"
+
+    return {
+        "title": title,
+        "priority": "p2",
+        "tags": [topic_slug, "onboarding", "followup"],
+        "scope": f"life/{topic_slug}",
+        "due": due_date,
+    }
+
+
+def _extract_markdown_content_from_tool_payload(tool_payload: Dict[str, Any]) -> Optional[str]:
+    if not isinstance(tool_payload, dict):
+        return None
+
+    nested = tool_payload.get("data")
+    if isinstance(nested, dict):
+        content = nested.get("content")
+        if isinstance(content, str) and content.strip():
+            return content
+
+    content = tool_payload.get("content")
+    if isinstance(content, str) and content.strip():
+        return content
+
+    return None
+
+
+
+def _extract_life_topic_from_scope_path(scope_path: Any) -> Optional[str]:
+    if not isinstance(scope_path, str):
+        return None
+
+    normalized = scope_path.strip().replace("\\", "/").strip("/")
+    if not normalized.startswith("life/"):
+        return None
+
+    parts = normalized.split("/")
+    if len(parts) < 2:
+        return None
+
+    topic = parts[1].strip().lower()
+    if topic in LIFE_ONBOARDING_TOPICS:
+        return topic
+
+    return None
+
+
+def _extract_cross_pollination_target_topics(
+    message_text: Optional[str],
+    *,
+    source_topic: Optional[str],
+) -> List[Dict[str, Any]]:
+    if not isinstance(message_text, str):
+        return []
+
+    normalized = " ".join(message_text.strip().split())
+    lowered = normalized.lower()
+    if not lowered:
+        return []
+
+    if lowered.endswith("?") and len(lowered.split()) <= 18:
+        return []
+
+    source_normalized = str(source_topic or "").strip().lower()
+    ranked: List[Dict[str, Any]] = []
+    for topic, keywords in CROSS_POLLINATION_TOPIC_KEYWORDS.items():
+        if source_normalized and topic == source_normalized:
+            continue
+        hits: List[str] = []
+        for keyword in keywords:
+            keyword_normalized = str(keyword or "").strip().lower()
+            if not keyword_normalized:
+                continue
+            if re.search(rf"\b{re.escape(keyword_normalized)}\b", lowered):
+                hits.append(keyword_normalized)
+        if not hits:
+            continue
+        ranked.append(
+            {
+                "topic": topic,
+                "score": len(hits),
+                "keywords": hits,
+            }
+        )
+
+    ranked.sort(
+        key=lambda item: (
+            -int(item.get("score") or 0),
+            str(item.get("topic") or ""),
+        )
+    )
+    return ranked
+
+
+def _build_cross_pollination_followthrough_tool_call(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    if _is_capture_intake_conversation(conversation_type):
+        return None
+    if _is_digest_conversation(conversation_type):
+        return None
+    can_create_markdown = "create_markdown" in available_tool_names
+    can_read_markdown = "read_markdown" in available_tool_names
+    if not can_create_markdown and not can_read_markdown:
+        return None
+
+    attempted_statuses = {
+        "success",
+        "error",
+        "blocked_intent",
+        "blocked_context",
+        "denied",
+    }
+    if executed_tool_calls:
+        # Allow non-synthetic read-only calls (provider variance) but stop chaining
+        # if non-synthetic mutating calls already occurred in this pass.
+        blocking_mutations = []
+        for call in executed_tool_calls:
+            if not isinstance(call, dict):
+                continue
+            if bool(call.get("synthetic_reason")):
+                continue
+            status = str(call.get("status") or "").strip().lower()
+            if status and status not in attempted_statuses:
+                continue
+            tool_name = str(call.get("name") or "").strip()
+            if infer_safety_class(tool_name) == "mutating":
+                blocking_mutations.append(call)
+        if blocking_mutations:
+            return None
+
+    scope_path = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+    source_topic = _extract_life_topic_from_scope_path(scope_path)
+    if not source_topic:
+        return None
+
+    normalized_message = " ".join(str(latest_user_message or "").strip().split())
+    if not normalized_message:
+        return None
+    if _normalize_approval_action(normalized_message):
+        for item in reversed(executed_tool_calls):
+            if not isinstance(item, dict):
+                continue
+            reason = str(item.get("synthetic_reason") or "").strip().lower()
+            if not reason.startswith("cross_pollination_"):
+                continue
+            arguments = item.get("arguments")
+            if not isinstance(arguments, dict):
+                continue
+            content = arguments.get("content")
+            if not isinstance(content, str) or not content.strip():
+                continue
+            captured_match = re.search(
+                r"##\s*Captured Context\s*(.+?)(?:\n##\s*|\Z)",
+                content,
+                flags=re.IGNORECASE | re.DOTALL,
+            )
+            if not captured_match:
+                continue
+            extracted = " ".join(str(captured_match.group(1) or "").strip().split())
+            if extracted:
+                normalized_message = extracted
+                break
+
+    now_utc = datetime.now(timezone.utc)
+    today_iso = now_utc.date().isoformat()
+    slug = _slugify_capture_fragment(
+        normalized_message,
+        fallback=f"{source_topic}-context",
+        max_length=42,
+    )
+
+    candidates = _extract_cross_pollination_target_topics(
+        normalized_message,
+        source_topic=source_topic,
+    )
+    source_title = LIFE_ONBOARDING_TOPICS.get(source_topic) or source_topic.title()
+
+    if not can_create_markdown:
+        candidate = candidates[0] if candidates else None
+        if not isinstance(candidate, dict):
+            return None
+        target_topic = str(candidate.get("topic") or "").strip().lower()
+        if target_topic not in LIFE_ONBOARDING_TOPICS:
+            return None
+        context_reason = f"cross_pollination_context_{source_topic}_to_{target_topic}"
+        if _has_synthetic_reason_execution(
+            executed_tool_calls,
+            context_reason,
+            statuses=attempted_statuses,
+        ):
+            return None
+        return {
+            "id": f"auto_cross_pollination_context_{source_topic}_{target_topic}",
+            "name": "read_markdown",
+            "arguments": {
+                "path": f"life/{target_topic}/{CROSS_POLLINATION_CONTEXT_SOURCE_FILE}",
+            },
+            "synthetic": True,
+            "reason": context_reason,
+        }
+
+    for candidate in candidates:
+        target_topic = str(candidate.get("topic") or "").strip().lower()
+        if target_topic not in LIFE_ONBOARDING_TOPICS:
+            continue
+
+        synthetic_reason = f"cross_pollination_{source_topic}_to_{target_topic}"
+        context_reason = f"cross_pollination_context_{source_topic}_to_{target_topic}"
+        if _has_synthetic_reason_execution(
+            executed_tool_calls,
+            synthetic_reason,
+            statuses=attempted_statuses,
+        ):
+            continue
+        if can_read_markdown and not _has_synthetic_reason_execution(
+            executed_tool_calls,
+            context_reason,
+            statuses=attempted_statuses,
+        ):
+            return {
+                "id": f"auto_cross_pollination_context_{source_topic}_{target_topic}",
+                "name": "read_markdown",
+                "arguments": {
+                    "path": f"life/{target_topic}/{CROSS_POLLINATION_CONTEXT_SOURCE_FILE}",
+                },
+                "synthetic": True,
+                "reason": context_reason,
+            }
+
+        target_title = LIFE_ONBOARDING_TOPICS.get(target_topic) or target_topic.title()
+        keyword_hits = [
+            item
+            for item in (candidate.get("keywords") or [])
+            if isinstance(item, str) and item.strip()
+        ]
+        keyword_text = ", ".join(keyword_hits[:6]) if keyword_hits else "detected topic overlap"
+        target_context = _extract_cross_pollination_context_excerpt(
+            executed_tool_calls=executed_tool_calls,
+            synthetic_reason=context_reason,
+        )
+        content = "\n".join(
+            [
+                "# Cross-Pollination Context",
+                "",
+                f"- Date (UTC): {now_utc.isoformat()}",
+                f"- Source Topic: {source_title}",
+                f"- Target Topic: {target_title}",
+                f"- Trigger Keywords: {keyword_text}",
+                "",
+                "## Captured Context",
+                normalized_message,
+                "",
+                "## Target Topic Context",
+                (
+                    f"From life/{target_topic}/{CROSS_POLLINATION_CONTEXT_SOURCE_FILE}: "
+                    f"{target_context}"
+                    if target_context
+                    else "No target-topic context was available from AGENT.md during this run."
+                ),
+            ]
+        )
+        path = f"life/{target_topic}/cross-pollination/{today_iso}-{slug}.md"
+        return {
+            "id": f"auto_cross_pollination_{source_topic}_{target_topic}",
+            "name": "create_markdown",
+            "arguments": {
+                "path": path,
+                "content": content,
+            },
+            "synthetic": True,
+            "reason": synthetic_reason,
+        }
+
+    return None
+
+
+def _extract_cross_pollination_context_excerpt(
+    *,
+    executed_tool_calls: List[Dict[str, Any]],
+    synthetic_reason: str,
+) -> Optional[str]:
+    expected_reason = str(synthetic_reason or "").strip().lower()
+    if not expected_reason:
+        return None
+
+    for item in reversed(executed_tool_calls):
+        if not isinstance(item, dict):
+            continue
+        reason = str(item.get("synthetic_reason") or "").strip().lower()
+        if reason != expected_reason:
+            continue
+        if str(item.get("status") or "").strip().lower() != "success":
+            return None
+        if str(item.get("name") or "").strip() != "read_markdown":
+            return None
+
+        payload = item.get("result")
+        content = _extract_markdown_content_from_tool_payload(
+            payload if isinstance(payload, dict) else {}
+        )
+        if not content:
+            return None
+
+        compact = " ".join(content.split())
+        if not compact:
+            return None
+
+        if len(compact) > CROSS_POLLINATION_CONTEXT_MAX_CHARS:
+            compact = f"{compact[:CROSS_POLLINATION_CONTEXT_MAX_CHARS].rstrip()}..."
+        return compact
+    return None
+
+
+def _parse_chat_approval_action(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+
+    normalized = message_text.strip().lower()
+    if not normalized:
+        return None
+
+    direct = _normalize_approval_action(normalized)
+    if direct:
+        return direct
+
+    if any(token in normalized for token in ("approve", "approved", "yes", "allow", "looks good", "go ahead")):
+        return "approve"
+    if any(token in normalized for token in ("reject", "denied", "deny", "no", "change it", "edit")):
+        return "reject"
+    return None
+
+
+def _has_tool_execution(
+    executed_tool_calls: List[Dict[str, Any]],
+    tool_name: str,
+    *,
+    statuses: Optional[set[str]] = None,
+) -> bool:
+    expected = str(tool_name or "").strip()
+    if not expected:
+        return False
+
+    normalized_statuses = {item.strip().lower() for item in (statuses or {"success"}) if str(item).strip()}
+    if not normalized_statuses:
+        normalized_statuses = {"success"}
+
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        name = str(item.get("name") or "").strip()
+        status = str(item.get("status") or "").strip().lower()
+        if name == expected and status in normalized_statuses:
+            return True
+    return False
+
+
+def _has_successful_tool_execution(
+    executed_tool_calls: List[Dict[str, Any]],
+    tool_name: str,
+) -> bool:
+    return _has_tool_execution(
+        executed_tool_calls,
+        tool_name,
+        statuses={"success"},
+    )
+
+
+def _capture_task_mutation_kind(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return None
+
+    if not re.search(r"\b(task|tasks|todo|to-do|t-\d{1,6})\b", normalized):
+        return None
+
+    negated_mutation_patterns = (
+        r"\b(?:do\s+not|don't|dont|without)\s+(?:create|add|open|make|edit|modify|update|change|complete|close|finish|resolve|mark)\b",
+        r"\blookup\s+only\b",
+        r"\bread[\s-]?only\b",
+        r"\bno\s+changes?\b",
+    )
+    if any(re.search(pattern, normalized) for pattern in negated_mutation_patterns):
+        return None
+
+    create_new_markers = (
+        "create a task",
+        "create task",
+        "new task",
+        "add a task",
+        "add task",
+        "make a task",
+        "open a task",
+        "log a task",
+        "track a task",
+    )
+    if any(marker in normalized for marker in create_new_markers):
+        return None
+
+    completion_patterns = (
+        r"\bcomplete(d|ing)?\b",
+        r"\bmark\b.{0,32}\b(done|complete|completed)\b",
+        r"\bdone\b",
+        r"\bfinish(ed|ing)?\b",
+        r"\bclose(d|ing)?\b",
+        r"\bresolve(d|ing)?\b",
+    )
+    if any(re.search(pattern, normalized) for pattern in completion_patterns):
+        return "complete"
+
+    edit_patterns = (
+        r"\b(edit|update|modify|change|adjust|rename|reschedule)\b",
+        r"\bassign(?:ed)?\b",
+        r"\bset\b.{0,32}\b(?:due|owner|assignee|priority|status|tags?|scope|project)\b",
+        r"\bmove\b.{0,32}\b(?:due|owner|assignee|priority|status|tags?|scope|project|to\s+p[0-3])\b",
+    )
+    if any(re.search(pattern, normalized) for pattern in edit_patterns):
+        return "edit"
+
+    return None
+
+
+def _capture_is_task_lookup_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return False
+
+    if not re.search(r"\b(task|tasks|todo|to-do|t-\d{1,6})\b", normalized):
+        return False
+
+    if _capture_task_mutation_kind(normalized) in {"complete", "edit"}:
+        return False
+
+    create_markers = (
+        "create a task",
+        "create task",
+        "new task",
+        "add a task",
+        "add task",
+        "make a task",
+        "open a task",
+        "log a task",
+        "track a task",
+    )
+    if any(marker in normalized for marker in create_markers):
+        return False
+
+    if normalized.endswith("?"):
+        return True
+
+    lookup_markers = (
+        "check",
+        "show",
+        "list",
+        "find",
+        "lookup",
+        "look up",
+        "search",
+        "existing",
+        "open task",
+        "open tasks",
+        "already",
+        "match",
+        "matches",
+        "read-only",
+        "read only",
+        "lookup only",
+    )
+    return any(marker in normalized for marker in lookup_markers)
+
+
+def _is_capture_existing_task_mutation_intent(message_text: Optional[str]) -> bool:
+    return _capture_task_mutation_kind(message_text) is not None
+
+
+def _capture_task_guard_error(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    tool_name: str,
+    executed_tool_calls: List[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    if not _is_capture_intake_conversation(conversation_type):
+        return None
+
+    normalized_tool = str(tool_name or "").strip()
+    if normalized_tool not in {"create_task", "update_task", "complete_task"}:
+        return None
+
+    if not _is_capture_existing_task_mutation_intent(latest_user_message):
+        return None
+
+    if normalized_tool == "create_task":
+        return {
+            "code": "CAPTURE_TASK_INTENT_CONFLICT",
+            "message": (
+                "Completion/edit intent detected. Do not call create_task for existing-task completion or edits. "
+                "Call list_tasks first, then use update_task and/or complete_task with the matched task ID."
+            ),
+        }
+
+    if normalized_tool in {"update_task", "complete_task"} and not _has_successful_tool_execution(
+        executed_tool_calls,
+        "list_tasks",
+    ):
+        return {
+            "code": "CAPTURE_TASK_ID_RESOLUTION_REQUIRED",
+            "message": (
+                "Task mutation requires ID resolution first. Call list_tasks, then use update_task/complete_task "
+                "for the matched task ID."
+            ),
+        }
+
+    return None
+
+
+def _rewrite_capture_decisions_path(
+    *,
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    if not _is_capture_intake_conversation(conversation_type):
+        return tool_arguments
+    if tool_name not in {"create_markdown", "write_markdown"}:
+        return tool_arguments
+    if not isinstance(tool_arguments, dict):
+        return tool_arguments
+
+    path_key: Optional[str] = None
+    raw_path: Optional[str] = None
+    for key in ("path", "file_path"):
+        candidate = tool_arguments.get(key)
+        if isinstance(candidate, str) and candidate.strip():
+            path_key = key
+            raw_path = candidate
+            break
+
+    if not path_key or not raw_path:
+        return tool_arguments
+
+    normalized_path = raw_path.strip().replace("\\", "/")
+    normalized_path = re.sub(r"^(?:\./)+", "", normalized_path)
+    normalized_path = normalized_path.lstrip("/")
+
+    if normalized_path.lower() != "decisions.md":
+        return tool_arguments
+
+    normalized_scope_path = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+    if not normalized_scope_path or normalized_scope_path in {"capture", "life"}:
+        return tool_arguments
+
+    scoped_decisions_path = f"{normalized_scope_path.rstrip('/')}/decisions.md"
+    if scoped_decisions_path.lower() == normalized_path.lower():
+        return tool_arguments
+
+    rewritten_arguments = dict(tool_arguments)
+    rewritten_arguments[path_key] = scoped_decisions_path
+    return rewritten_arguments
+
+
+def _normalize_capture_inbox_path_date(path_value: str) -> str:
+    if not isinstance(path_value, str):
+        return path_value
+
+    normalized_path = path_value.strip().replace("\\", "/")
+    normalized_path = re.sub(r"^(?:\./)+", "", normalized_path)
+    normalized_path = normalized_path.lstrip("/")
+    if not normalized_path:
+        return path_value
+
+    lowered = normalized_path.lower()
+    if not lowered.startswith("capture/inbox/"):
+        # Provider variance can emit non-canonical inbox paths such as
+        # "finances/relationships/inbox/2023-10-05.md" in capture mode.
+        # Force these to canonical capture/inbox before date normalization.
+        normalized_tokens = [token for token in normalized_path.split("/") if token]
+        inbox_index = -1
+        for idx, token in enumerate(normalized_tokens):
+            if token.lower() == "inbox":
+                inbox_index = idx
+                break
+        if inbox_index < 0:
+            return normalized_path
+        filename = (
+            normalized_tokens[inbox_index + 1]
+            if inbox_index + 1 < len(normalized_tokens)
+            else ""
+        )
+        if not filename:
+            filename = "capture-entry.md"
+        if not filename.lower().endswith(".md"):
+            filename = f"{filename}.md"
+        normalized_path = f"capture/inbox/{filename}"
+
+    parent, _, filename = normalized_path.rpartition("/")
+    if not filename:
+        return normalized_path
+
+    match = re.match(
+        r"^(?P<date>\d{4}-\d{2}-\d{2})(?P<suffix>(?:[-_].*)?\.md)$",
+        filename,
+        flags=re.IGNORECASE,
+    )
+    if not match:
+        return normalized_path
+
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    if match.group("date") == today_iso:
+        return normalized_path
+
+    updated_filename = f"{today_iso}{match.group('suffix')}"
+    return f"{parent}/{updated_filename}" if parent else updated_filename
+
+
+def _normalize_capture_due_value(raw_due: Any) -> Optional[str]:
+    if not isinstance(raw_due, str):
+        return None
+
+    candidate = raw_due.strip()
+    if not candidate:
+        return None
+
+    parsed_iso = _extract_due_date_from_segment(candidate)
+    if parsed_iso:
+        return parsed_iso
+
+    normalized_text, _ = _normalize_relative_dates_in_text(candidate)
+    parsed_normalized = _extract_due_date_from_segment(normalized_text)
+    if parsed_normalized:
+        return parsed_normalized
+
+    return None
+
+
+def _normalize_capture_markdown_content(
+    *,
+    content: str,
+    path: Optional[str],
+    ensure_capture_stamp: bool,
+) -> str:
+    if not isinstance(content, str):
+        return content
+
+    normalized_content, _date_resolutions = _normalize_relative_dates_in_text(content)
+    if not ensure_capture_stamp:
+        return normalized_content
+
+    normalized_path = str(path or "").strip().replace("\\", "/").lstrip("/")
+    if not normalized_path.lower().startswith("capture/inbox/"):
+        return normalized_content
+
+    if re.search(r"\bcaptured on\s*\(utc\)\s*:\s*\d{4}-\d{2}-\d{2}\b", normalized_content, flags=re.IGNORECASE):
+        return normalized_content
+    if re.search(r"\b\d{4}-\d{2}-\d{2}\b", normalized_content):
+        return normalized_content
+
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    body = normalized_content.lstrip("\n")
+    return f"Captured On (UTC): {today_iso}\n\n{body}" if body else f"Captured On (UTC): {today_iso}\n"
+
+
+def _normalize_owner_profile_tool_arguments(
+    *,
+    latest_user_message: Optional[str],
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+    synthetic_reason: Optional[str] = None,
+) -> Dict[str, Any]:
+    if tool_name not in {"create_markdown", "write_markdown"}:
+        return tool_arguments
+    if not isinstance(tool_arguments, dict):
+        return tool_arguments
+
+    normalized_reason = str(synthetic_reason or "").strip().lower()
+    owner_profile_intent = bool(_extract_owner_profile_update_text(latest_user_message))
+    if normalized_reason not in OWNER_PROFILE_UPDATE_REASONS and not owner_profile_intent:
+        return tool_arguments
+
+    rewritten_arguments = dict(tool_arguments)
+    for path_key in ("path", "file_path"):
+        if isinstance(rewritten_arguments.get(path_key), str):
+            rewritten_arguments[path_key] = OWNER_PROFILE_RELATIVE_PATH
+            return rewritten_arguments
+
+    rewritten_arguments["path"] = OWNER_PROFILE_RELATIVE_PATH
+    return rewritten_arguments
+
+
+def _normalize_life_scope_task_arguments(
+    *,
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    if tool_name != "create_task":
+        return tool_arguments
+    if not isinstance(tool_arguments, dict):
+        return tool_arguments
+
+    life_topic = _extract_life_topic(conversation_type)
+    if not life_topic:
+        scope_path = _normalize_project_scope_path(
+            mcp_scope.get("mcp_project_slug") if isinstance(mcp_scope, dict) else None
+        )
+        life_topic = _extract_life_topic_from_scope_path(scope_path)
+    if not life_topic:
+        return tool_arguments
+
+    normalized_arguments = dict(tool_arguments)
+    default_scope = f"life/{life_topic}"
+
+    existing_scope = normalized_arguments.get("scope")
+    if isinstance(existing_scope, str) and existing_scope.strip():
+        scope_token = existing_scope.strip().lower()
+        if "/" not in scope_token:
+            alias_topic = CAPTURE_LIFE_TOPIC_ALIASES.get(scope_token)
+            if alias_topic:
+                normalized_arguments["scope"] = f"life/{alias_topic}"
+            else:
+                normalized_arguments["scope"] = default_scope
+    else:
+        normalized_arguments["scope"] = default_scope
+
+    resolved_scope = str(normalized_arguments.get("scope") or "").strip().lower()
+    if resolved_scope.startswith("life/"):
+        normalized_arguments["project"] = resolved_scope.split("/")[-1]
+    elif not (isinstance(normalized_arguments.get("project"), str) and normalized_arguments.get("project").strip()):
+        normalized_arguments["project"] = life_topic
+
+    owner_value = normalized_arguments.get("owner")
+    if not (isinstance(owner_value, str) and owner_value.strip()):
+        normalized_arguments["owner"] = "user"
+
+    return normalized_arguments
+
+
+def _normalize_capture_tool_arguments(
+    *,
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+    ensure_capture_stamp: bool = True,
+) -> Dict[str, Any]:
+    rewritten_arguments = _rewrite_capture_decisions_path(
+        conversation_type=conversation_type,
+        mcp_scope=mcp_scope,
+        tool_name=tool_name,
+        tool_arguments=tool_arguments,
+    )
+    if isinstance(rewritten_arguments, dict):
+        rewritten_arguments = _normalize_life_scope_task_arguments(
+            conversation_type=conversation_type,
+            mcp_scope=mcp_scope,
+            tool_name=tool_name,
+            tool_arguments=rewritten_arguments,
+        )
+    if not _is_capture_intake_conversation(conversation_type) or not isinstance(
+        rewritten_arguments, dict
+    ):
+        return rewritten_arguments
+
+    normalized_arguments = dict(rewritten_arguments)
+
+    if tool_name in {"create_markdown", "write_markdown"}:
+        for path_key in ("path", "file_path"):
+            path_candidate = normalized_arguments.get(path_key)
+            if isinstance(path_candidate, str) and path_candidate.strip():
+                normalized_arguments[path_key] = _normalize_capture_inbox_path_date(path_candidate)
+                break
+
+    if tool_name == "create_markdown":
+        content = normalized_arguments.get("content")
+        if isinstance(content, str):
+            content_path = (
+                normalized_arguments.get("path")
+                if isinstance(normalized_arguments.get("path"), str)
+                else normalized_arguments.get("file_path")
+            )
+            normalized_arguments["content"] = _normalize_capture_markdown_content(
+                content=content,
+                path=content_path if isinstance(content_path, str) else None,
+                ensure_capture_stamp=ensure_capture_stamp,
+            )
+
+    if tool_name == "write_markdown":
+        operation = normalized_arguments.get("operation")
+        if isinstance(operation, dict) and isinstance(operation.get("content"), str):
+            updated_operation = dict(operation)
+            updated_operation["content"] = _normalize_capture_markdown_content(
+                content=operation["content"],
+                path=str(normalized_arguments.get("path") or normalized_arguments.get("file_path") or ""),
+                ensure_capture_stamp=False,
+            )
+            normalized_arguments["operation"] = updated_operation
+
+    if tool_name == "create_task":
+        normalized_due = _normalize_capture_due_value(normalized_arguments.get("due"))
+        if normalized_due:
+            normalized_arguments["due"] = normalized_due
+        elif isinstance(normalized_arguments.get("title"), str):
+            title_due = _normalize_capture_due_value(normalized_arguments.get("title"))
+            if title_due:
+                normalized_arguments["due"] = title_due
+
+        scope_hint_parts: List[str] = []
+        for key in ("title", "description", "notes"):
+            value = normalized_arguments.get(key)
+            if isinstance(value, str) and value.strip():
+                scope_hint_parts.append(value.strip())
+        scope_hint_text = " ".join(scope_hint_parts) if scope_hint_parts else None
+
+        inferred_scope = _extract_capture_scope_path_from_message(
+            message_text=scope_hint_text,
+            mcp_scope=mcp_scope,
+        )
+        resolved_scope: Optional[str] = None
+
+        existing_scope = normalized_arguments.get("scope")
+        if isinstance(existing_scope, str) and existing_scope.strip():
+            scope_token = existing_scope.strip()
+            scope_token_lower = scope_token.lower()
+            alias_topic = CAPTURE_LIFE_TOPIC_ALIASES.get(scope_token_lower)
+            if not alias_topic:
+                alias_items = sorted(
+                    CAPTURE_LIFE_TOPIC_ALIASES.items(),
+                    key=lambda item: len(item[0]),
+                    reverse=True,
+                )
+                for alias, topic in alias_items:
+                    if re.search(rf"\b{re.escape(alias)}\b", scope_token_lower):
+                        alias_topic = topic
+                        break
+            if alias_topic:
+                resolved_scope = f"life/{alias_topic}"
+            elif scope_token_lower in {"personal", "general", "default", "self", "me", "my"}:
+                if inferred_scope and inferred_scope not in {"capture", "life"}:
+                    resolved_scope = inferred_scope
+        else:
+            if inferred_scope and inferred_scope not in {"capture", "life"}:
+                resolved_scope = inferred_scope
+
+        if resolved_scope:
+            normalized_arguments["scope"] = resolved_scope
+            if "/" in resolved_scope:
+                normalized_arguments["project"] = resolved_scope.split("/")[-1]
+
+        owner_value = normalized_arguments.get("owner")
+        if not (isinstance(owner_value, str) and owner_value.strip()):
+            inferred_owner = _extract_capture_owner_from_text(scope_hint_text)
+            normalized_arguments["owner"] = inferred_owner or "user"
+
+    if tool_name == "list_tasks":
+        # Capture verify flows should not over-filter list_tasks. Provider-supplied
+        # filters (owner/tag/status/scope) frequently cause false negatives.
+        normalized_arguments = {}
+
+    if tool_name == "update_task":
+        fields = normalized_arguments.get("fields")
+        if isinstance(fields, dict):
+            normalized_due = _normalize_capture_due_value(fields.get("due"))
+            if normalized_due:
+                updated_fields = dict(fields)
+                updated_fields["due"] = normalized_due
+                normalized_arguments["fields"] = updated_fields
+
+    return normalized_arguments
+
+
+def _extract_capture_project_hint(mcp_scope: Dict[str, Any]) -> Optional[str]:
+    if not isinstance(mcp_scope, dict):
+        return None
+
+    normalized_scope_path = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+    if not normalized_scope_path:
+        return None
+
+    if normalized_scope_path.startswith("life/"):
+        parts = normalized_scope_path.split("/")
+        if len(parts) >= 2 and parts[1].strip():
+            return parts[1].strip()
+
+    if normalized_scope_path.startswith("projects/active/"):
+        parts = normalized_scope_path.split("/")
+        if parts and parts[-1].strip():
+            return parts[-1].strip()
+
+    if normalized_scope_path in {"capture", "life"}:
+        return None
+
+    if "/" not in normalized_scope_path and normalized_scope_path.strip():
+        return normalized_scope_path.strip()
+    return None
+
+
+def _has_synthetic_reason_execution(
+    executed_tool_calls: List[Dict[str, Any]],
+    synthetic_reason: str,
+    *,
+    statuses: Optional[set[str]] = None,
+) -> bool:
+    expected = str(synthetic_reason or "").strip().lower()
+    if not expected:
+        return False
+
+    normalized_statuses = {item.strip().lower() for item in (statuses or {"success"}) if str(item).strip()}
+    if not normalized_statuses:
+        normalized_statuses = {"success"}
+
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "").strip().lower()
+        reason = str(item.get("synthetic_reason") or "").strip().lower()
+        if status in normalized_statuses and reason == expected:
+            return True
+    return False
+
+
+def _has_successful_synthetic_reason(
+    executed_tool_calls: List[Dict[str, Any]],
+    synthetic_reason: str,
+) -> bool:
+    return _has_synthetic_reason_execution(
+        executed_tool_calls,
+        synthetic_reason,
+        statuses={"success"},
+    )
+
+
+def _slugify_capture_fragment(value: str, *, fallback: str = "entry", max_length: int = 48) -> str:
+    if not isinstance(value, str):
+        return fallback
+
+    normalized = " ".join(value.strip().split())
+    if not normalized:
+        return fallback
+
+    slug = re.sub(r"[^a-z0-9]+", "-", normalized.lower()).strip("-")
+    if not slug:
+        return fallback
+    if len(slug) > max_length:
+        slug = slug[:max_length].rstrip("-")
+    return slug or fallback
+
+
+def _extract_capture_life_topic_from_message(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+
+    lowered = " ".join(message_text.strip().lower().split())
+    if not lowered:
+        return None
+
+    alias_items = sorted(
+        CAPTURE_LIFE_TOPIC_ALIASES.items(),
+        key=lambda item: len(item[0]),
+        reverse=True,
+    )
+    for alias, topic in alias_items:
+        if re.search(rf"\b{re.escape(alias)}\b", lowered):
+            return topic
+
+    finance_signals = (
+        r"\$\s*\d+(?:\.\d+)?",
+        r"\b\d+(?:\.\d+)?\s*(?:dollars?|usd)\b",
+    )
+    if any(re.search(pattern, lowered) for pattern in finance_signals):
+        return "finances"
+
+    finance_keywords = (
+        "pay back",
+        "payback",
+        "repay",
+        "repayment",
+        "owe",
+        "owed",
+        "payment",
+        "debt",
+        "invoice",
+        "bill",
+    )
+    if any(keyword in lowered for keyword in finance_keywords):
+        return "finances"
+
+    return None
+
+
+def _extract_capture_scope_path_from_message(
+    message_text: Optional[str],
+    mcp_scope: Optional[Dict[str, Any]] = None,
+) -> Optional[str]:
+    normalized_scope_match = re.search(
+        r"\b(?:scope|path)\s*:\s*([a-z0-9/_-]{3,120})",
+        str(message_text or ""),
+        flags=re.IGNORECASE,
+    )
+    if normalized_scope_match:
+        explicit_scope = _normalize_project_scope_path(normalized_scope_match.group(1))
+        if explicit_scope:
+            return explicit_scope
+
+    if isinstance(message_text, str):
+        lowered = " ".join(message_text.strip().lower().split())
+        if lowered:
+            topic = _extract_capture_life_topic_from_message(lowered)
+            if topic:
+                if re.search(rf"\b(?:in|for|under)\s+{re.escape(topic)}\b", lowered):
+                    return f"life/{topic}"
+                if topic == "finances":
+                    return "life/finances"
+
+            explicit_project = re.search(
+                r"\bproject\s*:\s*([a-z0-9][a-z0-9 _-]{1,60})\b",
+                lowered,
+            )
+            if explicit_project:
+                project_slug = _slugify_capture_fragment(
+                    explicit_project.group(1),
+                    fallback="project",
+                    max_length=64,
+                )
+                if project_slug:
+                    return f"projects/active/{project_slug}"
+
+    scope_source = mcp_scope if isinstance(mcp_scope, dict) else {}
+    scope_path = _normalize_project_scope_path(scope_source.get("mcp_project_slug"))
+    if scope_path and scope_path not in {"capture", "life"}:
+        return scope_path
+    return None
+
+
+def _extract_capture_fanout_scope_paths(
+    *,
+    message_text: Optional[str],
+    mcp_scope: Optional[Dict[str, Any]] = None,
+) -> List[str]:
+    discovered: List[str] = []
+    seen: set[str] = set()
+
+    def _append_scope(candidate: Any) -> None:
+        normalized = _normalize_project_scope_path(candidate)
+        if not normalized or normalized in {"capture", "life"}:
+            return
+        if normalized in seen:
+            return
+        seen.add(normalized)
+        discovered.append(normalized)
+
+    message_raw = str(message_text or "")
+    for match in re.finditer(
+        r"\b(?:scope|path)\s*:\s*([a-z0-9/_-]{3,120})",
+        message_raw,
+        flags=re.IGNORECASE,
+    ):
+        _append_scope(match.group(1))
+    for match in re.finditer(
+        r"\b((?:life/[a-z0-9][a-z0-9_-]{1,80})|(?:projects/[a-z0-9][a-z0-9/_-]{2,140}))\b",
+        message_raw,
+        flags=re.IGNORECASE,
+    ):
+        _append_scope(match.group(1))
+
+    if isinstance(message_text, str):
+        lowered = " ".join(message_text.strip().lower().split())
+        if lowered:
+            for explicit_project in re.finditer(
+                r"\bproject\s*:\s*([a-z0-9][a-z0-9 _-]{1,60})\b",
+                lowered,
+            ):
+                project_slug = _slugify_capture_fragment(
+                    explicit_project.group(1),
+                    fallback="project",
+                    max_length=64,
+                )
+                if project_slug:
+                    _append_scope(f"projects/active/{project_slug}")
+
+            alias_items = sorted(
+                CAPTURE_LIFE_TOPIC_ALIASES.items(),
+                key=lambda item: len(item[0]),
+                reverse=True,
+            )
+            for phrase_match in re.finditer(
+                r"\b(?:in|for|under|across|to)\s+([a-z0-9 ,/_-]{3,160})",
+                lowered,
+                flags=re.IGNORECASE,
+            ):
+                phrase_segment = re.split(
+                    r"[.;!?]",
+                    str(phrase_match.group(1) or ""),
+                    maxsplit=1,
+                )[0].strip()
+                if not phrase_segment:
+                    continue
+                for alias, topic in alias_items:
+                    if re.search(rf"\b{re.escape(alias)}\b", phrase_segment):
+                        _append_scope(f"life/{topic}")
+
+    scope_source = mcp_scope if isinstance(mcp_scope, dict) else {}
+    default_scope = _normalize_project_scope_path(scope_source.get("mcp_project_slug"))
+    _append_scope(default_scope)
+    if isinstance(default_scope, str) and default_scope in discovered and len(discovered) > 1:
+        discovered = [scope for scope in discovered if scope != default_scope] + [default_scope]
+
+    return discovered[:CAPTURE_SCOPE_FANOUT_MAX_TARGETS]
+
+
+def _capture_scope_fanout_token(scope_path: Any) -> str:
+    normalized = str(scope_path or "").strip().lower()
+    token = re.sub(r"[^a-z0-9]+", "_", normalized).strip("_")
+    if len(token) > 72:
+        token = token[:72].rstrip("_")
+    return token or "scope"
+
+
+def _is_capture_inbox_path(path_value: Any) -> bool:
+    if not isinstance(path_value, str):
+        return False
+    normalized = path_value.strip().replace("\\", "/")
+    if not normalized:
+        return False
+    normalized = re.sub(r"^\./+", "", normalized)
+    return normalized.startswith("capture/inbox/") or "/capture/inbox/" in normalized
+
+
+def _extract_capture_inbox_content_from_tool_call(
+    tool_name: Any,
+    tool_arguments: Any,
+) -> Optional[str]:
+    if not isinstance(tool_arguments, dict):
+        return None
+
+    normalized_tool = str(tool_name or "").strip()
+    if normalized_tool not in {"create_markdown", "write_markdown"}:
+        return None
+
+    if not _is_capture_inbox_path(tool_arguments.get("path")):
+        return None
+
+    direct_content = tool_arguments.get("content")
+    if isinstance(direct_content, str) and direct_content.strip():
+        return direct_content.strip()
+
+    operation = tool_arguments.get("operation")
+    if isinstance(operation, dict):
+        operation_content = operation.get("content")
+        if isinstance(operation_content, str) and operation_content.strip():
+            return operation_content.strip()
+
+    return None
+
+
+def _build_capture_scope_fanout_tool_call(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    if not _is_capture_intake_conversation(conversation_type):
+        return None
+    if "create_markdown" not in available_tool_names:
+        return None
+    if not isinstance(latest_user_message, str):
+        return None
+
+    normalized_message = " ".join(latest_user_message.strip().split())
+    if not normalized_message:
+        return None
+    if _normalize_approval_action(normalized_message):
+        for item in reversed(executed_tool_calls):
+            if not isinstance(item, dict):
+                continue
+            arguments = item.get("arguments")
+            if not isinstance(arguments, dict):
+                continue
+            fallback_content: Optional[str] = None
+            if str(item.get("synthetic_reason") or "").strip().lower() == "capture_inbox_persist":
+                synthetic_content = arguments.get("content")
+                if isinstance(synthetic_content, str) and synthetic_content.strip():
+                    fallback_content = synthetic_content.strip()
+            if not fallback_content:
+                fallback_content = _extract_capture_inbox_content_from_tool_call(
+                    item.get("name"),
+                    arguments,
+                )
+            if isinstance(fallback_content, str) and fallback_content.strip():
+                normalized_message = " ".join(fallback_content.strip().split())
+                break
+
+    target_scopes = _extract_capture_fanout_scope_paths(
+        message_text=normalized_message,
+        mcp_scope=mcp_scope,
+    )
+    if len(target_scopes) < 2:
+        return None
+
+    attempted_statuses = {
+        "success",
+        "error",
+        "blocked_intent",
+        "blocked_context",
+        "denied",
+    }
+    capture_write_attempted = (
+        _has_synthetic_reason_execution(
+            executed_tool_calls,
+            "capture_inbox_persist",
+            statuses=attempted_statuses,
+        )
+        or _has_tool_execution(
+            executed_tool_calls,
+            "create_markdown",
+            statuses=attempted_statuses,
+        )
+        or _has_tool_execution(
+            executed_tool_calls,
+            "write_markdown",
+            statuses=attempted_statuses,
+        )
+    )
+    if not capture_write_attempted:
+        return None
+
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    filename_slug = _slugify_capture_fragment(normalized_message, max_length=56)
+
+    for scope_path in target_scopes:
+        token = _capture_scope_fanout_token(scope_path)
+        reason = f"capture_scope_fanout_{token}"
+        if _has_synthetic_reason_execution(
+            executed_tool_calls,
+            reason,
+            statuses=attempted_statuses,
+        ):
+            continue
+
+        content = "\n".join(
+            [
+                "# Capture Fanout Entry",
+                "",
+                f"- Captured On (UTC): {today_iso}",
+                f"- Target Scope: {scope_path}",
+                f"- Source Inbox Path: capture/inbox/{today_iso}-{filename_slug}.md",
+                "",
+                "## Captured Context",
+                normalized_message,
+            ]
+        )
+        return {
+            "id": f"auto_capture_scope_fanout_{token}",
+            "name": "create_markdown",
+            "arguments": {
+                "path": f"{scope_path}/capture/{today_iso}-{filename_slug}.md",
+                "content": content,
+            },
+            "synthetic": True,
+            "reason": reason,
+        }
+
+    return None
+
+
+def _capture_is_new_task_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return False
+
+    if not re.search(r"\b(task|tasks|todo|to-do)\b", normalized):
+        return False
+
+    if _capture_task_mutation_kind(normalized) in {"complete", "edit"}:
+        return False
+
+    if "task:" in normalized or normalized.startswith("todo:"):
+        return True
+
+    create_markers = (
+        "create a task",
+        "create task",
+        "new task",
+        "add a task",
+        "add task",
+        "make a task",
+        "open a task",
+        "log a task",
+        "track a task",
+    )
+    return any(marker in normalized for marker in create_markers)
+
+
+def _extract_capture_priority_from_text(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+
+    lowered = " ".join(message_text.strip().lower().split())
+    if not lowered:
+        return None
+
+    if re.search(r"\b(p0|critical|blocker)\b", lowered):
+        return "p0"
+    if re.search(r"\b(p1|urgent|highest priority|high priority)\b", lowered):
+        return "p1"
+    if re.search(r"\b(p2|medium priority|normal priority)\b", lowered):
+        return "p2"
+    if re.search(r"\b(p3|low priority)\b", lowered):
+        return "p3"
+    return None
+
+
+def _extract_capture_owner_from_text(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+
+    candidate = " ".join(message_text.strip().split())
+    if not candidate:
+        return None
+
+    owner_patterns = (
+        r"\bowner\s*:\s*([A-Za-z][A-Za-z0-9 .'\-]{0,60}?)(?=(?:\s+\b(?:due|by|priority|tags?|scope|project|in)\b|[,;.]|$))",
+        r"\bowner\s+(?:to\s+)?([A-Za-z][A-Za-z0-9 .'\-]{0,60}?)(?=(?:\s+\b(?:for|task|due|by|priority|tags?|scope|project|in)\b|[,;.]|$))",
+        r"\bassign(?:ed)?\s+to\s+([A-Za-z][A-Za-z0-9 .'\-]{0,60}?)(?=(?:\s+\b(?:due|by|priority|tags?|scope|project|in)\b|[,;.]|$))",
+        r"\bassign\s+([A-Za-z][A-Za-z0-9 .'\-]{0,60}?)\s+to\b",
+        r"\bfor\s+([A-Z][A-Za-z]*(?:\s+[A-Z][A-Za-z]*){0,2})(?=(?:\s+\b(?:to|by|due|on|in|with)\b|[,;.]|$))",
+    )
+    for pattern in owner_patterns:
+        match = re.search(pattern, candidate, flags=re.IGNORECASE)
+        if not match:
+            continue
+        owner = " ".join(match.group(1).strip(" .;,:-").split())
+        if owner:
+            return owner
+    owner_from_labeled_task = _extract_capture_owner_from_task_labeled_segment(candidate)
+    if owner_from_labeled_task:
+        return owner_from_labeled_task
+    return None
+
+
+def _extract_capture_owner_from_task_labeled_segment(task_text: str) -> Optional[str]:
+    if not isinstance(task_text, str):
+        return None
+    compact = " ".join(task_text.strip().split())
+    if not compact:
+        return None
+    segment_match = re.search(r"\btask\s*:\s*([^\n\r;.,!?]{4,180})", compact, flags=re.IGNORECASE)
+    if not segment_match:
+        return None
+    segment = " ".join(str(segment_match.group(1) or "").strip().split())
+    if not segment:
+        return None
+
+    name_token = r"[A-Z][A-Za-z]{0,24}\.?"
+    with_to = re.match(
+        rf"^(?P<owner>{name_token}(?:\s+{name_token}){{1,2}})\s+to\s+[a-z].+$",
+        segment,
+    )
+    if with_to:
+        owner = " ".join(str(with_to.group("owner") or "").strip(" .;,:-").split())
+        if owner:
+            return owner
+
+    no_to = re.match(
+        rf"^(?P<owner>{name_token}(?:\s+{name_token}){{1,2}})\s+[a-z].+$",
+        segment,
+    )
+    if no_to:
+        owner = " ".join(str(no_to.group("owner") or "").strip(" .;,:-").split())
+        if owner:
+            return owner
+    return None
+
+
+def _strip_capture_owner_prefix_from_task_segment(task_text: str) -> str:
+    compact = " ".join(str(task_text or "").split()).strip()
+    if not compact:
+        return ""
+
+    name_token = r"[A-Z][A-Za-z]{0,24}\.?"
+    with_to = re.match(
+        rf"^(?P<owner>{name_token}(?:\s+{name_token}){{1,2}})\s+to\s+(?P<body>.+)$",
+        compact,
+    )
+    if with_to:
+        body = str(with_to.group("body") or "").strip()
+        if body:
+            return body
+
+    no_to = re.match(
+        rf"^(?P<owner>{name_token}(?:\s+{name_token}){{1,2}})\s+(?P<body>[a-z].+)$",
+        compact,
+    )
+    if no_to:
+        body = str(no_to.group("body") or "").strip()
+        if body:
+            return body
+    return compact
+
+
+def _extract_capture_tags_from_text(message_text: Optional[str]) -> List[str]:
+    if not isinstance(message_text, str):
+        return []
+
+    tags: List[str] = []
+    seen: set[str] = set()
+
+    for hash_tag in re.findall(r"#([a-z0-9][a-z0-9_-]{1,30})", message_text, flags=re.IGNORECASE):
+        normalized = hash_tag.strip().lower()
+        if normalized and normalized not in seen:
+            seen.add(normalized)
+            tags.append(normalized)
+
+    labeled_match = re.search(
+        r"\btags?\s*:\s*([^\n\r;.]*)",
+        message_text,
+        flags=re.IGNORECASE,
+    )
+    if labeled_match:
+        raw_value = str(labeled_match.group(1) or "").strip()
+        if raw_value:
+            stop_match = re.search(
+                r"\b(?:due|by|priority|owner|assign(?:ed)?|scope|project)\b",
+                raw_value,
+                flags=re.IGNORECASE,
+            )
+            if stop_match:
+                raw_value = raw_value[: stop_match.start()].strip(" ,")
+
+        if "," in raw_value:
+            raw_tokens = [token.strip() for token in raw_value.split(",")]
+        else:
+            raw_tokens = re.split(r"\s+", raw_value)
+        for token in raw_tokens:
+            normalized = token.strip().lower().strip("#")
+            if len(normalized) < 2:
+                continue
+            if not re.fullmatch(r"[a-z0-9][a-z0-9_-]{1,30}", normalized):
+                continue
+            if normalized in seen:
+                continue
+            seen.add(normalized)
+            tags.append(normalized)
+
+    return tags
+
+
+def _extract_capture_task_title_from_message(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+
+    compact = " ".join(message_text.strip().split())
+    if not compact:
+        return None
+
+    labeled_segments = _split_labeled_goal_task_segments(compact)
+    for segment in labeled_segments:
+        if str(segment.get("kind") or "").strip().lower() != "task":
+            continue
+        raw_segment = str(segment.get("text") or "")
+        stripped_segment = _strip_capture_owner_prefix_from_task_segment(raw_segment)
+        title = _clean_goal_task_segment(stripped_segment or raw_segment)
+        if title:
+            return title
+
+    patterns = (
+        r"\b(?:create|add|open|make|log|track)\s+(?:a\s+)?task(?:\s+to)?\s+(.+)$",
+        r"\btodo\s*:\s*(.+)$",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, compact, flags=re.IGNORECASE)
+        if not match:
+            continue
+        title = _clean_goal_task_segment(match.group(1))
+        if title:
+            return title
+
+    fallback_title = compact
+    fallback_title = re.sub(
+        r"\b(?:add|create|open|make|log|track)\s+(?:a\s+)?task(?:\s+to)?\b",
+        "",
+        fallback_title,
+        flags=re.IGNORECASE,
+    )
+    fallback_title = re.sub(
+        r"^(?:capture this|note this|log this)\s*[:\-]?\s*",
+        "",
+        fallback_title,
+        flags=re.IGNORECASE,
+    )
+    fallback_title = re.sub(r"^(?:and|then)\s+", "", fallback_title, flags=re.IGNORECASE)
+    fallback_title = _clean_goal_task_segment(fallback_title)
+    if fallback_title and len(fallback_title) >= 6 and not fallback_title.endswith("?"):
+        if len(fallback_title) > 140:
+            return fallback_title[:137].rstrip() + "..."
+        return fallback_title
+
+    return None
+
+
+def _build_capture_create_task_arguments(
+    *,
+    message_text: Optional[str],
+    mcp_scope: Dict[str, Any],
+) -> Dict[str, Any]:
+    title = _extract_capture_task_title_from_message(message_text)
+    if not title:
+        title = "Follow up on captured item"
+
+    arguments: Dict[str, Any] = {"title": title}
+
+    priority = _extract_capture_priority_from_text(message_text)
+    if priority:
+        arguments["priority"] = priority
+
+    owner = _extract_capture_owner_from_text(message_text)
+    if owner:
+        arguments["owner"] = owner
+
+    due_value = _normalize_capture_due_value(message_text if isinstance(message_text, str) else None)
+    if due_value:
+        arguments["due"] = due_value
+
+    tags = _extract_capture_tags_from_text(message_text)
+    if tags:
+        arguments["tags"] = tags
+
+    scope_path = _extract_capture_scope_path_from_message(
+        message_text=message_text,
+        mcp_scope=mcp_scope,
+    )
+    if scope_path and scope_path not in {"capture", "life"}:
+        arguments["scope"] = scope_path
+        if "/" in scope_path:
+            arguments["project"] = scope_path.split("/")[-1]
+
+    return arguments
+
+
+def _capture_has_intake_write_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return False
+
+    if _capture_is_task_lookup_intent(normalized):
+        return False
+
+    if normalized.endswith("?") and len(normalized.split()) <= 10:
+        return False
+
+    explicit_mutation_markers = (
+        "create a task",
+        "create task",
+        "add a task",
+        "add task",
+        "make a task",
+        "open a task",
+        "log a task",
+        "track a task",
+        "capture this",
+        "note this",
+        "log this",
+        "write this down",
+        "remember this",
+    )
+    if _is_likely_question_request(normalized) and not any(
+        marker in normalized for marker in explicit_mutation_markers
+    ):
+        return False
+
+    markers = (
+        "capture",
+        "note",
+        "log this",
+        "write this down",
+        "remember this",
+        "decision",
+        "task",
+        "todo",
+        "transcript",
+    )
+    return any(marker in normalized for marker in markers)
+
+
+def _build_capture_inbox_persist_tool_call(message_text: Optional[str]) -> Optional[Dict[str, Any]]:
+    if not isinstance(message_text, str):
+        return None
+
+    normalized_message = " ".join(message_text.strip().split())
+    if not normalized_message:
+        return None
+
+    today_iso = datetime.now(timezone.utc).date().isoformat()
+    filename_slug = _slugify_capture_fragment(normalized_message)
+    path = f"capture/inbox/{today_iso}-{filename_slug}.md"
+    return {
+        "id": "auto_capture_inbox_persist",
+        "name": "create_markdown",
+        "arguments": {
+            "path": path,
+            "content": normalized_message,
+        },
+        "synthetic": True,
+        "reason": "capture_inbox_persist",
+    }
+
+
+def _title_from_scope_slug(scope_slug: str) -> str:
+    normalized = str(scope_slug or "").strip().replace("_", " ").replace("-", " ")
+    tokens = [token for token in normalized.split() if token]
+    if not tokens:
+        return "Untitled"
+    return " ".join(token.capitalize() for token in tokens)
+
+
+def _infer_new_page_engine_archetype(
+    *,
+    page_kind: str,
+    page_slug: str,
+    label_text: str,
+) -> str:
+    lowered = str(label_text or "").strip().lower()
+
+    if page_kind == "life":
+        known_topic = CAPTURE_LIFE_TOPIC_ALIASES.get(page_slug, page_slug)
+        topic_archetypes = {
+            "finances": "finance",
+            "fitness": "wellbeing",
+            "relationships": "relationships",
+            "career": "career",
+            "whyfinder": "purpose",
+        }
+        by_topic = topic_archetypes.get(known_topic)
+        if by_topic:
+            return by_topic
+
+        keyword_map = (
+            ("habit", ("habit", "routine", "streak", "discipline")),
+            ("wellbeing", ("wellness", "sleep", "energy", "nutrition", "health", "fitness")),
+            ("relationships", ("family", "partner", "kids", "marriage", "relationship")),
+            ("career", ("career", "job", "promotion", "resume", "interview", "work")),
+            ("finance", ("budget", "debt", "savings", "cash flow", "spending", "money")),
+            ("purpose", ("purpose", "values", "mission", "meaning", "identity")),
+        )
+        for archetype, keywords in keyword_map:
+            if any(keyword in lowered for keyword in keywords):
+                return archetype
+        return "life_general"
+
+    keyword_map = (
+        ("research", ("research", "analy", "discovery", "investigat", "validate", "experiment")),
+        ("operations", ("operations", "ops", "process", "workflow", "runbook", "automation", "sop")),
+        ("content", ("content", "newsletter", "blog", "video", "podcast", "editorial", "course")),
+        ("planning", ("roadmap", "plan", "strategy", "milestone", "program")),
+        ("product_build", ("build", "feature", "mvp", "prototype", "launch", "implementation", "app")),
+    )
+    for archetype, keywords in keyword_map:
+        if any(keyword in lowered for keyword in keywords):
+            return archetype
+    return "project_general"
+
+
+def _extract_new_page_engine_request(
+    *,
+    message_text: Optional[str],
+    conversation_type: str,
+    mcp_scope: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(message_text, str):
+        return None
+
+    normalized = " ".join(message_text.strip().split())
+    if not normalized:
+        return None
+
+    verb_pattern = r"(?:create|add|start|open|make|build|spin up|set up|setup)"
+    typed_match = re.search(
+        rf"\b{verb_pattern}\s+(?:a\s+)?(?:new\s+)?(life|project)\s+"
+        r"(?:page|area|scope|workspace|folder)?(?:\s+(?:for|about|called|named))?\s+(.+)$",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    untyped_match = re.search(
+        rf"\b{verb_pattern}\s+(?:a\s+)?new\s+(?:page|area|scope|workspace|folder)"
+        r"(?:\s+(?:for|about|called|named))?\s+(.+)$",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if not typed_match and not untyped_match:
+        return None
+
+    explicit_kind = ""
+    raw_name = ""
+    if typed_match:
+        explicit_kind = str(typed_match.group(1) or "").strip().lower()
+        raw_name = str(typed_match.group(2) or "").strip()
+    else:
+        raw_name = str(untyped_match.group(1) or "").strip()
+
+    if not raw_name:
+        return None
+
+    # Keep the first clause as the page label; preserve long-form description in summary.
+    label = re.split(r"\b(?:with|where|so that|because)\b", raw_name, maxsplit=1, flags=re.IGNORECASE)[0]
+    label = label.strip(" .,:;!?")
+    page_slug = _slugify_capture_fragment(label, fallback="", max_length=64)
+    if not page_slug:
+        return None
+
+    page_kind = explicit_kind
+    if page_kind not in {"life", "project"}:
+        normalized_scope = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+        if _extract_life_topic(conversation_type) or (
+            isinstance(normalized_scope, str) and normalized_scope.startswith("life/")
+        ):
+            page_kind = "life"
+        elif any(keyword in label.lower() for keyword in NEW_PAGE_ENGINE_LIFE_KEYWORDS):
+            page_kind = "life"
+        else:
+            page_kind = "project"
+
+    if page_kind == "life":
+        canonical_topic = CAPTURE_LIFE_TOPIC_ALIASES.get(page_slug, page_slug)
+        page_slug = _slugify_capture_fragment(canonical_topic, fallback=page_slug, max_length=64)
+        page_path = f"life/{page_slug}"
+    else:
+        page_path = f"projects/active/{page_slug}"
+
+    page_archetype = _infer_new_page_engine_archetype(
+        page_kind=page_kind,
+        page_slug=page_slug,
+        label_text=raw_name or label,
+    )
+
+    return {
+        "page_kind": page_kind,
+        "page_archetype": page_archetype,
+        "page_slug": page_slug,
+        "page_path": page_path,
+        "title": _title_from_scope_slug(page_slug),
+        "topic_summary": normalized,
+    }
+
+
+def _is_new_page_engine_intent(message_text: Optional[str]) -> bool:
+    parsed = _extract_new_page_engine_request(
+        message_text=message_text,
+        conversation_type="chat",
+        mcp_scope={},
+    )
+    return bool(parsed)
+
+
+def _build_new_page_engine_seed_questions(
+    *,
+    page_kind: str,
+    page_slug: str,
+    page_title: str,
+    page_archetype: str,
+) -> List[str]:
+    if page_kind == "life":
+        known_topic = CAPTURE_LIFE_TOPIC_ALIASES.get(page_slug, page_slug)
+        seeded = LIFE_ONBOARDING_DEFAULT_QUESTIONS.get(known_topic)
+        if seeded:
+            return list(seeded)[:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+        if page_archetype == "habit":
+            return [
+                f"What habit in {page_title} would create the biggest improvement this month?",
+                "What is your minimum viable daily routine for this first phase?",
+                "What usually breaks consistency, and how will you handle it this time?",
+                "What metric or signal will prove the routine is working?",
+                "What should happen if you miss 1-2 days in a row?",
+                "What is the first seven-day commitment starting now?",
+            ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+        if page_archetype == "relationships":
+            return [
+                f"Which relationship outcomes matter most for {page_title} this quarter?",
+                "What communication patterns should change first?",
+                "What boundaries or agreements need to be explicit?",
+                "What recurring check-in cadence is realistic this month?",
+                "What conflict trigger should be handled proactively?",
+                "What first action can you take this week?",
+            ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+        if page_archetype == "finance":
+            return [
+                f"What financial target matters most in {page_title} over the next 90 days?",
+                "Which current spending/debt pattern needs the fastest correction?",
+                "What budget guardrails will you enforce starting this week?",
+                "What baseline numbers should be tracked every week?",
+                "What risk would derail this plan if left unresolved?",
+                "What is your first concrete money action in the next 48 hours?",
+            ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+        if page_archetype == "career":
+            return [
+                f"What career outcome does {page_title} target in the next quarter?",
+                "Which skills or projects need to advance first?",
+                "What blockers in role/scope/support must be addressed now?",
+                "What network or mentorship actions should happen this month?",
+                "What evidence would show trajectory is improving?",
+                "What one action can be completed this week?",
+            ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+        if page_archetype == "purpose":
+            return [
+                f"What values should anchor decisions in {page_title}?",
+                "Where are current priorities misaligned with those values?",
+                "What commitments should be reduced or removed first?",
+                "What weekly reflection ritual will keep alignment visible?",
+                "What decision filters should be explicit going forward?",
+                "What immediate action best reflects your intended direction?",
+            ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+        return [
+            f"What does success look like for {page_title} in the next 90 days?",
+            f"What is working today in {page_title}, and what is not?",
+            f"What constraints could block progress in {page_title} right now?",
+            "What habit or routine would create the biggest momentum this month?",
+            "What should be explicitly out of scope for this first phase?",
+            "What is the next concrete action you can take this week?",
+        ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+
+    if page_archetype == "research":
+        return [
+            f"What decisions should research in {page_title} unlock first?",
+            "What hypotheses do you need to validate early?",
+            "What evidence sources and methods will be used?",
+            "What are your acceptance criteria for confidence in findings?",
+            "What timeline and checkpoints should guide this research pass?",
+            "What first artifact will you publish this week?",
+        ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+    if page_archetype == "operations":
+        return [
+            f"What operational outcome does {page_title} need to improve first?",
+            "Which workflow bottleneck causes the most recurring drag?",
+            "What standard process should be documented first?",
+            "What automation opportunities can remove manual work quickly?",
+            "What service levels or quality targets should be explicit?",
+            "What first runbook action can be completed this week?",
+        ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+    if page_archetype == "content":
+        return [
+            f"What audience and channel are primary for {page_title}?",
+            "What publishing cadence is realistic for the next 30 days?",
+            "What content pillars should anchor the first cycle?",
+            "What production constraints need mitigation early?",
+            "What quality bar defines a ready-to-ship piece?",
+            "What first deliverable will you publish this week?",
+        ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+    if page_archetype == "planning":
+        return [
+            f"What top milestones should {page_title} hit in the next 4-8 weeks?",
+            "What scope cuts are required to keep execution realistic?",
+            "Which dependencies need owners and dates immediately?",
+            "What risk register should be maintained from day one?",
+            "What review cadence keeps this plan current?",
+            "What first planning artifact should be finalized this week?",
+        ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+    if page_archetype == "product_build":
+        return [
+            f"What user problem does {page_title} solve first?",
+            "What is the smallest end-to-end outcome that proves value?",
+            "What architecture or platform constraints matter now?",
+            "What technical unknowns should be de-risked first?",
+            "What release criteria define MVP readiness?",
+            "What first build milestone should land this week?",
+        ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+
+    return [
+        f"What problem is this {page_title} page solving, and for whom?",
+        "What does a successful first version look like?",
+        "What is in scope now, and what is explicitly out of scope?",
+        "What existing assets, code, or context already exist?",
+        "What are the top risks, unknowns, or blockers?",
+        "What are the first milestones for the next 2-4 weeks?",
+    ][:NEW_PAGE_ENGINE_MAX_SEED_QUESTIONS]
+
+
+def _build_new_page_engine_followup_questions(
+    *,
+    page_kind: str,
+    page_title: str,
+    page_archetype: str,
+) -> List[str]:
+    if page_kind == "life":
+        if page_archetype == "habit":
+            return [
+                f"What consistency did you maintain in {page_title} this week?",
+                "Which trigger broke the routine, and what is the adjustment?",
+                "Should difficulty or cadence be scaled up or down next?",
+                "What context update should be logged for the next coaching pass?",
+            ]
+        if page_archetype == "relationships":
+            return [
+                f"What changed in communication outcomes for {page_title}?",
+                "Which conversation or boundary still needs work?",
+                "What action should happen before the next check-in?",
+                "What context update would improve future guidance quality?",
+            ]
+        if page_archetype == "finance":
+            return [
+                f"What money target moved in {page_title} since kickoff?",
+                "Which spending/debt pattern improved or regressed?",
+                "Which budget guardrail needs correction this week?",
+                "What additional context should be captured for planning?",
+            ]
+        if page_archetype == "career":
+            return [
+                f"What career milestone in {page_title} moved since kickoff?",
+                "Which blocker needs escalation or reframing next?",
+                "What should be re-prioritized for the next week?",
+                "What context update should be saved for future planning?",
+            ]
+        if page_archetype == "purpose":
+            return [
+                f"What decision in {page_title} best reflected your values this week?",
+                "Where did misalignment still show up?",
+                "What commitment should be changed before the next check-in?",
+                "What context update would sharpen future guidance?",
+            ]
+        return [
+            f"What progress have you made in {page_title} since kickoff?",
+            "Which blockers or routines need adjustment right now?",
+            "Which goal or task should be re-prioritized for the next week?",
+            "What context should be added so future coaching is more accurate?",
+        ]
+
+    if page_archetype == "research":
+        return [
+            f"What evidence was gathered for {page_title} since kickoff?",
+            "Which hypothesis is now validated or invalidated?",
+            "What research gap should be closed next?",
+            "What decision should be made based on current findings?",
+        ]
+    if page_archetype == "operations":
+        return [
+            f"What process improvement in {page_title} moved this week?",
+            "Which operational bottleneck still blocks throughput?",
+            "What SOP/runbook section needs refinement next?",
+            "What metric should be reviewed before the next check-in?",
+        ]
+    if page_archetype == "content":
+        return [
+            f"What publishing progress did {page_title} make since kickoff?",
+            "Which content pillar performed best or worst?",
+            "What production bottleneck should be addressed next?",
+            "What should the next planned content deliverable be?",
+        ]
+    if page_archetype == "planning":
+        return [
+            f"Which milestone in {page_title} moved since kickoff?",
+            "What dependency or risk changed most this week?",
+            "What should be re-scoped before the next planning pass?",
+            "What is the next concrete planning deliverable?",
+        ]
+    if page_archetype == "product_build":
+        return [
+            f"What build milestone in {page_title} moved forward?",
+            "Which implementation risk became clearer?",
+            "What should be cut, delayed, or accelerated next?",
+            "What is the next concrete deliverable for this week?",
+        ]
+
+    return [
+        f"What milestone in {page_title} moved forward since kickoff?",
+        "Which implementation risk or unknown became clearer?",
+        "What should be re-scoped before the next build pass?",
+        "What is the next concrete deliverable for this week?",
+    ]
+
+
+def _build_new_page_engine_meta_payload(
+    *,
+    page_kind: str,
+    page_archetype: str,
+    page_slug: str,
+    page_title: str,
+    topic_summary: str,
+    created_on: str,
+    first_followup_due: str,
+    seed_questions: List[str],
+    followup_questions: List[str],
+) -> Dict[str, Any]:
+    return {
+        "engine_version": "v1.1",
+        "page_kind": page_kind,
+        "page_archetype": page_archetype,
+        "page_slug": page_slug,
+        "page_title": page_title,
+        "created_on_utc": created_on,
+        "first_followup_due_utc": first_followup_due,
+        "topic_summary": topic_summary,
+        "seed_questions": seed_questions,
+        "followup_questions": followup_questions,
+        "status": {
+            "interview_stage": "seeded",
+            "question_total": len(seed_questions),
+            "approved_answers": 0,
+        },
+    }
+
+
+def _build_new_page_engine_archetype_file_pack(
+    *,
+    page_kind: str,
+    page_archetype: str,
+    page_title: str,
+    created_on: str,
+) -> List[Dict[str, str]]:
+    life_archetype_files: Dict[str, Dict[str, str]] = {
+        "habit": {
+            "path": "habits.md",
+            "content": (
+                f"# {page_title} Habits\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Keystone Habits\n\n"
+                "## Daily Tracking\n\n"
+                "## Weekly Review\n"
+            ),
+        },
+        "finance": {
+            "path": "money-map.md",
+            "content": (
+                f"# {page_title} Money Map\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Baseline Numbers\n\n"
+                "## Budget Guardrails\n\n"
+                "## Debt / Savings Plan\n"
+            ),
+        },
+        "relationships": {
+            "path": "connection-plan.md",
+            "content": (
+                f"# {page_title} Connection Plan\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Priority Relationships\n\n"
+                "## Communication Cadence\n\n"
+                "## Agreements / Boundaries\n"
+            ),
+        },
+        "career": {
+            "path": "career-map.md",
+            "content": (
+                f"# {page_title} Career Map\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Target Roles / Outcomes\n\n"
+                "## Skill Gaps\n\n"
+                "## Opportunity Pipeline\n"
+            ),
+        },
+        "purpose": {
+            "path": "values-map.md",
+            "content": (
+                f"# {page_title} Values Map\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Core Values\n\n"
+                "## Decision Filters\n\n"
+                "## Alignment Check-ins\n"
+            ),
+        },
+        "wellbeing": {
+            "path": "routine-baseline.md",
+            "content": (
+                f"# {page_title} Routine Baseline\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Sleep / Recovery\n\n"
+                "## Movement\n\n"
+                "## Nutrition / Energy\n"
+            ),
+        },
+    }
+    project_archetype_files: Dict[str, Dict[str, str]] = {
+        "research": {
+            "path": "research.md",
+            "content": (
+                f"# {page_title} Research\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Questions\n\n"
+                "## Findings\n\n"
+                "## Decision Impact\n"
+            ),
+        },
+        "operations": {
+            "path": "runbook.md",
+            "content": (
+                f"# {page_title} Runbook\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Standard Flow\n\n"
+                "## Alerts / Escalation\n\n"
+                "## Recovery Steps\n"
+            ),
+        },
+        "content": {
+            "path": "content-plan.md",
+            "content": (
+                f"# {page_title} Content Plan\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Audience / Channels\n\n"
+                "## Editorial Calendar\n\n"
+                "## Production Checklist\n"
+            ),
+        },
+        "planning": {
+            "path": "roadmap.md",
+            "content": (
+                f"# {page_title} Roadmap\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Milestones\n\n"
+                "## Dependencies\n\n"
+                "## Risks\n"
+            ),
+        },
+        "product_build": {
+            "path": "architecture.md",
+            "content": (
+                f"# {page_title} Architecture\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## System Shape\n\n"
+                "## Tradeoffs\n\n"
+                "## Open Questions\n"
+            ),
+        },
+    }
+
+    if page_kind == "life":
+        pack = life_archetype_files.get(page_archetype)
+        return [pack] if isinstance(pack, dict) else []
+
+    pack = project_archetype_files.get(page_archetype)
+    return [pack] if isinstance(pack, dict) else []
+
+
+def _build_new_page_engine_files(request_payload: Dict[str, Any]) -> List[Dict[str, str]]:
+    page_kind = str(request_payload.get("page_kind") or "project").strip().lower()
+    page_archetype = str(request_payload.get("page_archetype") or "").strip().lower()
+    page_title = str(request_payload.get("title") or "New Page").strip() or "New Page"
+    page_slug = str(request_payload.get("page_slug") or "").strip()
+    summary = str(request_payload.get("topic_summary") or "").strip()
+    if not summary:
+        summary = f"{page_title} kickoff context (to be expanded during interview)."
+    created_on = datetime.now(timezone.utc).date().isoformat()
+    first_followup_due = (
+        datetime.now(timezone.utc) + timedelta(days=NEW_PAGE_ENGINE_FIRST_FOLLOWUP_DAYS)
+    ).date().isoformat()
+    questions = _build_new_page_engine_seed_questions(
+        page_kind=page_kind,
+        page_slug=page_slug,
+        page_title=page_title,
+        page_archetype=page_archetype,
+    )
+    followup_questions = _build_new_page_engine_followup_questions(
+        page_kind=page_kind,
+        page_title=page_title,
+        page_archetype=page_archetype,
+    )
+    question_lines = "\n".join(
+        f"{index}. {question}" for index, question in enumerate(questions, start=1)
+    )
+    followup_lines = "\n".join(
+        f"{index}. {question}" for index, question in enumerate(followup_questions, start=1)
+    )
+    interview_areas_lines = "\n".join(
+        [
+            "1. Core Goal",
+            "2. Scope Boundaries",
+            "3. Current State",
+            "4. Approach",
+            "5. Risks and Blockers",
+            "6. Priorities and Next Actions",
+        ]
+    )
+    meta_payload = _build_new_page_engine_meta_payload(
+        page_kind=page_kind,
+        page_archetype=page_archetype,
+        page_slug=page_slug,
+        page_title=page_title,
+        topic_summary=summary,
+        created_on=created_on,
+        first_followup_due=first_followup_due,
+        seed_questions=questions,
+        followup_questions=followup_questions,
+    )
+    meta_content = json.dumps(meta_payload, ensure_ascii=True, indent=2)
+    archetype_files = _build_new_page_engine_archetype_file_pack(
+        page_kind=page_kind,
+        page_archetype=page_archetype,
+        page_title=page_title,
+        created_on=created_on,
+    )
+
+    interview_content = (
+        f"# {page_title} Interview\n\n"
+        f"Created On (UTC): {created_on}\n\n"
+        f"First Follow-up Due (UTC Date): {first_followup_due}\n\n"
+        "## Topic Summary\n"
+        f"{summary}\n\n"
+        "## Interview Areas\n"
+        f"{interview_areas_lines}\n\n"
+        "## Seed Questions\n"
+        f"{question_lines}\n"
+    )
+    followup_content = (
+        f"# {page_title} Interview Follow-up\n\n"
+        f"Created On (UTC): {created_on}\n\n"
+        f"Target Follow-up Date (UTC Date): {first_followup_due}\n\n"
+        "## Context Snapshot\n"
+        f"{summary}\n\n"
+        "## First Follow-up Prompts\n"
+        f"{followup_lines}\n"
+    )
+
+    if page_kind == "life":
+        return [
+            {
+                "path": "AGENT.md",
+                "content": (
+                    f"# {page_title} Agent\n\n"
+                    f"Use this folder for {page_title.lower()} planning and execution.\n"
+                    f"Created by unified page engine on {created_on}.\n"
+                ),
+            },
+            {"path": "interview.md", "content": interview_content},
+            {"path": "interview-followup.md", "content": followup_content},
+            {
+                "path": "spec.md",
+                "content": (
+                    f"# {page_title} Spec\n\n"
+                    f"Created On (UTC): {created_on}\n\n"
+                    "## Current Reality\n"
+                    f"{summary}\n\n"
+                    "## Desired Outcomes\n\n"
+                    "## Constraints\n\n"
+                    "## Success Criteria\n"
+                ),
+            },
+            {
+                "path": "build-plan.md",
+                "content": (
+                    f"# {page_title} Build Plan\n\n"
+                    f"Created On (UTC): {created_on}\n\n"
+                    "## Phase 1\n\n"
+                    "## Phase 2\n\n"
+                    "## Risks\n\n"
+                    "## Next Review\n"
+                ),
+            },
+            {
+                "path": "goals.md",
+                "content": (
+                    f"# {page_title} Goals\n\n"
+                    f"Created On (UTC): {created_on}\n\n"
+                    "## Current Goals\n\n"
+                    "## 90-Day Targets\n"
+                ),
+            },
+            {
+                "path": "action-plan.md",
+                "content": (
+                    f"# {page_title} Action Plan\n\n"
+                    f"Created On (UTC): {created_on}\n\n"
+                    "## Immediate Actions\n\n"
+                    "## Weekly Cadence\n"
+                ),
+            },
+            {
+                "path": "context.md",
+                "content": (
+                    f"# {page_title} Context\n\n"
+                    f"Created On (UTC): {created_on}\n\n"
+                    "## Baseline Notes\n"
+                    f"{summary}\n\n"
+                    "## Constraints and Dependencies\n"
+                ),
+            },
+            {
+                "path": "checkins.md",
+                "content": (
+                    f"# {page_title} Check-ins\n\n"
+                    f"Created On (UTC): {created_on}\n\n"
+                    f"- Planned first follow-up: {first_followup_due}\n"
+                ),
+            },
+            *archetype_files,
+            {"path": "_meta/interview-state.md", "content": meta_content},
+        ]
+
+    return [
+        {
+            "path": "AGENT.md",
+            "content": (
+                f"# {page_title} Agent\n\n"
+                "Use this scope to plan, build, and track execution.\n"
+                f"Created by unified page engine on {created_on}.\n"
+            ),
+        },
+        {"path": "interview.md", "content": interview_content},
+        {"path": "interview-followup.md", "content": followup_content},
+        {
+            "path": "spec.md",
+            "content": (
+                f"# {page_title} Spec\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Problem Statement\n"
+                f"{summary}\n\n"
+                "## Scope\n\n"
+                "## Success Criteria\n\n"
+                "## Risks\n"
+            ),
+        },
+        {
+            "path": "build-plan.md",
+            "content": (
+                f"# {page_title} Build Plan\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Milestone 1\n\n"
+                "## Milestone 2\n\n"
+                "## Dependencies\n\n"
+                "## Next Steps\n"
+            ),
+        },
+        {
+            "path": "decisions.md",
+            "content": (
+                f"# {page_title} Decisions\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Decision Log\n"
+                "- (to be populated)\n"
+            ),
+        },
+        {
+            "path": "ideas.md",
+            "content": (
+                f"# {page_title} Ideas\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Candidate Ideas\n"
+                "- (to be populated)\n"
+            ),
+        },
+        {
+            "path": "status.md",
+            "content": (
+                f"# {page_title} Status\n\n"
+                f"Created On (UTC): {created_on}\n\n"
+                "## Current Phase\n"
+                "- Discovery\n\n"
+                "## Next Checkpoint\n"
+                f"- {first_followup_due}\n"
+            ),
+        },
+        *archetype_files,
+        {"path": "_meta/interview-state.md", "content": meta_content},
+    ]
+
+
+def _build_new_page_engine_tool_call(
+    *,
+    latest_user_message: Optional[str],
+    conversation_type: str,
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    request_payload = _extract_new_page_engine_request(
+        message_text=latest_user_message,
+        conversation_type=conversation_type,
+        mcp_scope=mcp_scope,
+    )
+    if not request_payload:
+        return None
+
+    page_path = request_payload["page_path"]
+    if "create_project" in available_tool_names:
+        return {
+            "id": "auto_new_page_engine_create",
+            "name": "create_project",
+            "arguments": {
+                "path": page_path,
+                "files": _build_new_page_engine_files(request_payload),
+            },
+            "synthetic": True,
+            "reason": "new_page_engine_scaffold",
+        }
+
+    if "create_project_scaffold" in available_tool_names:
+        return {
+            "id": "auto_new_page_engine_create",
+            "name": "create_project_scaffold",
+            "arguments": {"path": page_path},
+            "synthetic": True,
+            "reason": "new_page_engine_scaffold",
+        }
+    return None
+
+
+def _build_new_page_engine_followthrough_tool_calls(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    normalized_type = _normalize_conversation_type(conversation_type)
+    if _is_capture_intake_conversation(normalized_type) or _is_digest_conversation(normalized_type):
+        return []
+
+    attempted_statuses = {"success", "error", "blocked_context", "denied"}
+    if _has_synthetic_reason_execution(
+        executed_tool_calls,
+        "new_page_engine_scaffold",
+        statuses=attempted_statuses,
+    ):
+        return []
+
+    new_page_call = _build_new_page_engine_tool_call(
+        latest_user_message=latest_user_message,
+        conversation_type=conversation_type,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if new_page_call:
+        return [new_page_call]
+    return []
+
+
+def _maybe_override_capture_provider_tool_call(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+    synthetic_reason: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+) -> tuple[str, Dict[str, Any], Optional[str]]:
+    if synthetic_reason:
+        return tool_name, tool_arguments, synthetic_reason
+
+    normalized_type = _normalize_conversation_type(conversation_type)
+    if normalized_type != "capture":
+        return tool_name, tool_arguments, synthetic_reason
+    if "create_markdown" not in available_tool_names:
+        return tool_name, tool_arguments, synthetic_reason
+    if _capture_is_task_lookup_intent(latest_user_message):
+        return tool_name, tool_arguments, synthetic_reason
+    if _is_capture_existing_task_mutation_intent(latest_user_message):
+        return tool_name, tool_arguments, synthetic_reason
+    if not _capture_has_intake_write_intent(latest_user_message):
+        return tool_name, tool_arguments, synthetic_reason
+
+    attempted_statuses = {"success", "error", "blocked_intent", "blocked_context", "denied"}
+    has_inbox_persist = _has_synthetic_reason_execution(
+        executed_tool_calls,
+        "capture_inbox_persist",
+        statuses=attempted_statuses,
+    )
+    has_capture_inbox_write = False
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "").strip().lower()
+        if status not in attempted_statuses:
+            continue
+        executed_name = str(item.get("name") or "").strip()
+        if executed_name not in {"create_markdown", "write_markdown"}:
+            continue
+        args = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+        if _is_capture_inbox_path(args.get("path")):
+            has_capture_inbox_write = True
+            break
+
+    if has_inbox_persist or has_capture_inbox_write:
+        return tool_name, tool_arguments, synthetic_reason
+
+    if tool_name in {"create_markdown", "write_markdown"} and _is_capture_inbox_path(
+        tool_arguments.get("path")
+    ):
+        return tool_name, tool_arguments, synthetic_reason
+
+    override_call = _build_capture_inbox_persist_tool_call(latest_user_message)
+    if not isinstance(override_call, dict):
+        return tool_name, tool_arguments, synthetic_reason
+
+    override_name = str(override_call.get("name") or "").strip() or tool_name
+    override_arguments = (
+        override_call.get("arguments")
+        if isinstance(override_call.get("arguments"), dict)
+        else tool_arguments
+    )
+    override_reason = str(override_call.get("reason") or "").strip() or synthetic_reason
+    return override_name, override_arguments, override_reason
+
+
+def _maybe_override_new_page_provider_tool_call(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+    synthetic_reason: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> tuple[str, Dict[str, Any], Optional[str]]:
+    if synthetic_reason:
+        return tool_name, tool_arguments, synthetic_reason
+
+    normalized_type = _normalize_conversation_type(conversation_type)
+    if _is_capture_intake_conversation(normalized_type) or _is_digest_conversation(normalized_type):
+        return tool_name, tool_arguments, synthetic_reason
+
+    if tool_name not in {"create_project", "create_project_scaffold", "project_exists"}:
+        return tool_name, tool_arguments, synthetic_reason
+
+    if not _is_new_page_engine_intent(latest_user_message):
+        return tool_name, tool_arguments, synthetic_reason
+
+    attempted_statuses = {"success", "error", "blocked_intent", "blocked_context", "denied"}
+    if _has_synthetic_reason_execution(
+        executed_tool_calls,
+        "new_page_engine_scaffold",
+        statuses=attempted_statuses,
+    ):
+        return tool_name, tool_arguments, synthetic_reason
+
+    override_call = _build_new_page_engine_tool_call(
+        latest_user_message=latest_user_message,
+        conversation_type=conversation_type,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if not isinstance(override_call, dict):
+        return tool_name, tool_arguments, synthetic_reason
+
+    override_name = str(override_call.get("name") or "").strip() or tool_name
+    override_arguments = (
+        override_call.get("arguments")
+        if isinstance(override_call.get("arguments"), dict)
+        else tool_arguments
+    )
+    override_reason = str(override_call.get("reason") or "").strip() or synthetic_reason
+    return override_name, override_arguments, override_reason
+
+
+def _maybe_override_compound_edit_provider_tool_call(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+    synthetic_reason: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> tuple[str, Dict[str, Any], Optional[str]]:
+    if synthetic_reason:
+        return tool_name, tool_arguments, synthetic_reason
+
+    normalized_type = _normalize_conversation_type(conversation_type)
+    if _is_capture_intake_conversation(normalized_type) or _is_digest_conversation(normalized_type):
+        return tool_name, tool_arguments, synthetic_reason
+
+    if tool_name != "edit_markdown" or "edit_markdown" not in available_tool_names:
+        return tool_name, tool_arguments, synthetic_reason
+
+    scope_path = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+    operations = _extract_compound_edit_operations_from_message(
+        latest_user_message=latest_user_message,
+        scope_path=scope_path,
+    )
+    if len(operations) < 2:
+        return tool_name, tool_arguments, synthetic_reason
+
+    attempted_statuses = {"success", "error", "blocked_intent", "blocked_context", "denied"}
+    attempted_paths: set[str] = set()
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "").strip() != "edit_markdown":
+            continue
+        if str(item.get("status") or "").strip() not in attempted_statuses:
+            continue
+        args = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+        normalized_path = _normalize_scoped_tool_path(args.get("path"), scope_path)
+        if normalized_path:
+            attempted_paths.add(normalized_path)
+
+    for operation in operations:
+        path = _normalize_scoped_tool_path(operation.get("path"), scope_path)
+        if not path or path in attempted_paths:
+            continue
+        override_arguments = copy.deepcopy(operation)
+        override_arguments["path"] = path
+        return "edit_markdown", override_arguments, COMPOUND_EDIT_SYNTHETIC_REASON
+
+    return tool_name, tool_arguments, synthetic_reason
+
+
+def _extract_compound_edit_operations_from_message(
+    *,
+    latest_user_message: Optional[str],
+    scope_path: Optional[str],
+) -> List[Dict[str, Any]]:
+    if not isinstance(scope_path, str) or not scope_path.strip():
+        return []
+    if not isinstance(latest_user_message, str):
+        return []
+
+    normalized = " ".join(latest_user_message.strip().split())
+    lowered = normalized.lower()
+    if not lowered:
+        return []
+
+    edit_markers = ("edit", "update", "revise", "append", "change")
+    if not any(marker in lowered for marker in edit_markers):
+        return []
+
+    alias_to_file = [
+        ("build-plan.md", "build-plan.md"),
+        ("build plan", "build-plan.md"),
+        ("spec.md", "spec.md"),
+        ("status.md", "status.md"),
+        ("decisions.md", "decisions.md"),
+        ("ideas.md", "ideas.md"),
+    ]
+    target_files: List[str] = []
+    seen_files: set[str] = set()
+    for alias, file_name in alias_to_file:
+        if alias not in lowered:
+            continue
+        if file_name in seen_files:
+            continue
+        seen_files.add(file_name)
+        target_files.append(file_name)
+    if len(target_files) < 2:
+        return []
+
+    quoted_segments: List[str] = []
+    for match in re.findall(r'"([^"\n]{1,260})"', normalized):
+        cleaned = " ".join(str(match).strip().split())
+        if cleaned:
+            quoted_segments.append(cleaned)
+    for match in re.findall(r"'([^'\n]{1,260})'", normalized):
+        cleaned = " ".join(str(match).strip().split())
+        if cleaned:
+            quoted_segments.append(cleaned)
+
+    fallback_line = _summarize_new_page_answer(normalized, max_chars=180)
+    timestamp = datetime.now(timezone.utc).date().isoformat()
+    heading_map = {
+        "spec.md": "## Success Criteria",
+        "build-plan.md": "## Next Steps",
+        "status.md": "## Current Phase",
+        "decisions.md": "## Decision Log",
+        "ideas.md": "## Candidate Ideas",
+    }
+
+    operations: List[Dict[str, Any]] = []
+    for index, file_name in enumerate(target_files[:COMPOUND_EDIT_MAX_OPERATIONS]):
+        quoted_line = quoted_segments[index] if index < len(quoted_segments) else fallback_line
+        content_line = f"- {timestamp}: {quoted_line}"
+        operations.append(
+            {
+                "path": f"{scope_path}/{file_name}",
+                "operation": {
+                    "type": "insert_after",
+                    "target": heading_map.get(file_name, ""),
+                    "content": content_line,
+                },
+            }
+        )
+    return operations
+
+
+def _build_compound_edit_followthrough_tool_calls(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    normalized_type = _normalize_conversation_type(conversation_type)
+    if _is_capture_intake_conversation(normalized_type) or _is_digest_conversation(normalized_type):
+        return []
+    if "edit_markdown" not in available_tool_names:
+        return []
+
+    scope_path = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+    operations = _extract_compound_edit_operations_from_message(
+        latest_user_message=latest_user_message,
+        scope_path=scope_path,
+    )
+    if len(operations) < 2:
+        return []
+
+    attempted_statuses = {"success", "error", "blocked_intent", "blocked_context", "denied"}
+    attempted_paths: set[str] = set()
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "").strip() != "edit_markdown":
+            continue
+        if str(item.get("synthetic_reason") or "").strip() != COMPOUND_EDIT_SYNTHETIC_REASON:
+            continue
+        if str(item.get("status") or "").strip() not in attempted_statuses:
+            continue
+        arguments = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+        path = arguments.get("path")
+        if isinstance(path, str) and path.strip():
+            attempted_paths.add(path.strip())
+
+    for operation in operations:
+        path = str(operation.get("path") or "").strip()
+        if not path or path in attempted_paths:
+            continue
+        return [
+            {
+                "id": f"auto_{COMPOUND_EDIT_SYNTHETIC_REASON}",
+                "name": "edit_markdown",
+                "arguments": operation,
+                "synthetic": True,
+                "reason": COMPOUND_EDIT_SYNTHETIC_REASON,
+            }
+        ]
+
+    return []
+
+
+def _extract_capture_new_page_path(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+
+    normalized = " ".join(message_text.strip().split())
+    lowered = normalized.lower()
+    if not normalized or "page" not in lowered:
+        return None
+
+    if not any(marker in lowered for marker in ("new page", "create page", "create a page", "create new", "new project page", "new life page")):
+        return None
+
+    typed_match = re.search(
+        r"\b(?:create|add|open|start)\s+(?:a\s+)?new\s+(life|project)\s+page(?:\s+for)?\s+([A-Za-z0-9][A-Za-z0-9 _-]{1,80})",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    untyped_match = re.search(
+        r"\b(?:create|add|open|start)\s+(?:a\s+)?new\s+([A-Za-z0-9][A-Za-z0-9 _-]{1,80})\s+page\b",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+
+    page_type = ""
+    page_name = ""
+    if typed_match:
+        page_type = typed_match.group(1).strip().lower()
+        page_name = typed_match.group(2).strip()
+    elif untyped_match:
+        page_name = untyped_match.group(1).strip()
+
+    if not page_name:
+        return None
+
+    page_slug = _slugify_capture_fragment(page_name, fallback="", max_length=64)
+    if not page_slug or page_slug in LIFE_ONBOARDING_TOPICS:
+        return None
+
+    if page_type == "life":
+        return f"life/{page_slug}"
+    if page_type == "project":
+        return f"projects/active/{page_slug}"
+    return f"projects/active/{page_slug}"
+
+
+def _build_capture_new_page_tool_call(
+    *,
+    latest_user_message: Optional[str],
+    available_tool_names: set[str],
+) -> Optional[Dict[str, Any]]:
+    page_path = _extract_capture_new_page_path(latest_user_message)
+    if not page_path:
+        return None
+
+    if "create_project" in available_tool_names:
+        return {
+            "id": "auto_capture_create_page",
+            "name": "create_project",
+            "arguments": {"path": page_path},
+            "synthetic": True,
+            "reason": "capture_new_page_proposal",
+        }
+
+    if "create_project_scaffold" in available_tool_names:
+        return {
+            "id": "auto_capture_create_page",
+            "name": "create_project_scaffold",
+            "arguments": {"path": page_path},
+            "synthetic": True,
+            "reason": "capture_new_page_proposal",
+        }
+
+    return None
+
+
+def _build_capture_digest_rollup_tool_call(
+    *,
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+) -> Optional[Dict[str, Any]]:
+    if "rollup_digest_period" not in available_tool_names:
+        return None
+
+    if _has_successful_tool_execution(executed_tool_calls, "rollup_digest_period"):
+        return None
+
+    digest_write_sources = {
+        "create_markdown",
+        "write_markdown",
+        "create_task",
+        "update_task",
+        "complete_task",
+        "reopen_task",
+        "ingest_transcript",
+    }
+    has_recent_write = False
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        status = str(item.get("status") or "").strip().lower()
+        if status != "success":
+            continue
+        name = str(item.get("name") or "").strip()
+        if name in digest_write_sources:
+            has_recent_write = True
+            break
+
+    if not has_recent_write:
+        return None
+
+    return {
+        "id": "auto_capture_digest_rollup_week",
+        "name": "rollup_digest_period",
+        "arguments": {
+            "period": "week",
+            "target_date": datetime.now(timezone.utc).date().isoformat(),
+        },
+        "synthetic": True,
+        "reason": "capture_digest_rollup_week",
+    }
+
+
+def _extract_owner_profile_update_text(message_text: Optional[str]) -> Optional[str]:
+    if not isinstance(message_text, str):
+        return None
+    normalized = " ".join(message_text.strip().split())
+    if not normalized:
+        return None
+
+    lowered = normalized.lower()
+    if lowered.startswith("profile:"):
+        candidate = normalized.split(":", 1)[1].strip(" .")
+        return candidate if candidate else None
+
+    patterns = (
+        r"\b(?:update|add|append|save|set|remember|note)\b(?:\s+(?:to|for|in))?\s+(?:my\s+)?(?:owner\s+)?profile(?:\s+with)?\s*[:,-]?\s*(.+)$",
+        r"\b(?:my\s+)?(?:owner\s+)?profile(?:\s+should\s+include|\s+includes?|\s+update)\s*[:,-]?\s*(.+)$",
+    )
+    for pattern in patterns:
+        match = re.search(pattern, normalized, flags=re.IGNORECASE)
+        if not match:
+            continue
+        candidate = match.group(1).strip(" .")
+        if candidate:
+            return candidate
+
+    return None
+
+
+def _build_owner_profile_update_note_line(update_text: str) -> str:
+    compact = " ".join(str(update_text or "").split())
+    if compact.startswith("- "):
+        return compact
+    timestamp = datetime.now(timezone.utc).date().isoformat()
+    return f"- {timestamp}: {compact}"
+
+
+def _build_owner_profile_markdown_scaffold(note_line: str) -> str:
+    normalized_note = _build_owner_profile_update_note_line(note_line)
+    return (
+        "# Profile\n\n"
+        "## Identity\n\n"
+        "## Goals\n\n"
+        "## Constraints\n\n"
+        "## Preferences\n\n"
+        "## Last Updated\n"
+        f"{normalized_note}\n"
+    )
+
+
+def _latest_owner_profile_update_note_line(
+    executed_tool_calls: List[Dict[str, Any]],
+) -> Optional[str]:
+    for item in reversed(executed_tool_calls):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("synthetic_reason") or "").strip() != OWNER_PROFILE_UPDATE_WRITE_REASON:
+            continue
+        arguments = item.get("arguments")
+        if not isinstance(arguments, dict):
+            continue
+        operation = arguments.get("operation")
+        if not isinstance(operation, dict):
+            continue
+        content = operation.get("content")
+        if isinstance(content, str) and content.strip():
+            return _build_owner_profile_update_note_line(content.strip())
+    return None
+
+
+def _has_owner_profile_write_missing_file_error(
+    executed_tool_calls: List[Dict[str, Any]],
+) -> bool:
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "").strip() != "write_markdown":
+            continue
+        if str(item.get("synthetic_reason") or "").strip() != OWNER_PROFILE_UPDATE_WRITE_REASON:
+            continue
+        if str(item.get("status") or "").strip().lower() != "error":
+            continue
+        error_code = _extract_tool_execution_error_code(item)
+        if error_code == "FILE_NOT_FOUND":
+            return True
+    return False
+
+
+def _build_owner_profile_followthrough_tool_call(
+    *,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+) -> Optional[Dict[str, Any]]:
+    attempted_statuses = {"success", "error", "blocked_intent", "blocked_context", "denied"}
+    write_attempted = _has_synthetic_reason_execution(
+        executed_tool_calls,
+        OWNER_PROFILE_UPDATE_WRITE_REASON,
+        statuses=attempted_statuses,
+    )
+    create_attempted = _has_synthetic_reason_execution(
+        executed_tool_calls,
+        OWNER_PROFILE_UPDATE_CREATE_REASON,
+        statuses=attempted_statuses,
+    )
+    if _has_successful_synthetic_reason(executed_tool_calls, OWNER_PROFILE_UPDATE_WRITE_REASON):
+        return None
+    if _has_successful_synthetic_reason(executed_tool_calls, OWNER_PROFILE_UPDATE_CREATE_REASON):
+        return None
+
+    if _has_owner_profile_write_missing_file_error(executed_tool_calls):
+        if "create_markdown" not in available_tool_names or create_attempted:
+            return None
+        fallback_line = _latest_owner_profile_update_note_line(executed_tool_calls)
+        if not fallback_line:
+            extracted_text = _extract_owner_profile_update_text(latest_user_message)
+            if not extracted_text:
+                return None
+            fallback_line = _build_owner_profile_update_note_line(extracted_text)
+        return {
+            "id": "auto_owner_profile_create",
+            "name": "create_markdown",
+            "arguments": {
+                "path": OWNER_PROFILE_RELATIVE_PATH,
+                "content": _build_owner_profile_markdown_scaffold(fallback_line),
+            },
+            "synthetic": True,
+            "reason": OWNER_PROFILE_UPDATE_CREATE_REASON,
+        }
+
+    update_text = _extract_owner_profile_update_text(latest_user_message)
+    if not update_text:
+        return None
+    note_line = _build_owner_profile_update_note_line(update_text)
+
+    if "write_markdown" in available_tool_names and not write_attempted:
+        return {
+            "id": "auto_owner_profile_write",
+            "name": "write_markdown",
+            "arguments": {
+                "path": OWNER_PROFILE_RELATIVE_PATH,
+                "operation": {
+                    "type": "insert_after",
+                    "target": "## Last Updated",
+                    "content": note_line,
+                },
+            },
+            "synthetic": True,
+            "reason": OWNER_PROFILE_UPDATE_WRITE_REASON,
+        }
+
+    if "create_markdown" in available_tool_names and not create_attempted:
+        return {
+            "id": "auto_owner_profile_create",
+            "name": "create_markdown",
+            "arguments": {
+                "path": OWNER_PROFILE_RELATIVE_PATH,
+                "content": _build_owner_profile_markdown_scaffold(note_line),
+            },
+            "synthetic": True,
+            "reason": OWNER_PROFILE_UPDATE_CREATE_REASON,
+        }
+
+    return None
+
+
+def _build_capture_followthrough_tool_calls(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> List[Dict[str, Any]]:
+    if not _is_capture_intake_conversation(conversation_type):
+        return []
+
+    owner_profile_followthrough = _build_owner_profile_followthrough_tool_call(
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+    )
+    if owner_profile_followthrough:
+        return [owner_profile_followthrough]
+
+    attempted_statuses = {
+        "success",
+        "error",
+        "blocked_intent",
+        "blocked_context",
+        "denied",
+    }
+
+    task_followthrough = _build_capture_task_followthrough_tool_call(
+        conversation_type=conversation_type,
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if task_followthrough:
+        return [task_followthrough]
+
+    if (
+        "list_tasks" in available_tool_names
+        and _capture_is_task_lookup_intent(latest_user_message)
+        and not _has_tool_execution(
+            executed_tool_calls,
+            "list_tasks",
+            statuses=attempted_statuses,
+        )
+    ):
+        lookup_args: Dict[str, Any] = {"status": "open"}
+        project_hint = _extract_capture_project_hint(mcp_scope)
+        if project_hint:
+            lookup_args["project"] = project_hint
+        return [
+            {
+                "id": "auto_capture_lookup_list_tasks",
+                "name": "list_tasks",
+                "arguments": lookup_args,
+                "synthetic": True,
+                "reason": "capture_task_lookup_list",
+            }
+        ]
+
+    if not _has_successful_synthetic_reason(executed_tool_calls, "capture_new_page_proposal"):
+        create_page_call = _build_capture_new_page_tool_call(
+            latest_user_message=latest_user_message,
+            available_tool_names=available_tool_names,
+        )
+        if create_page_call:
+            return [create_page_call]
+
+    if (
+        "create_markdown" in available_tool_names
+        and _capture_has_intake_write_intent(latest_user_message)
+        and not (
+            _has_synthetic_reason_execution(
+                executed_tool_calls,
+                "capture_inbox_persist",
+                statuses=attempted_statuses,
+            )
+            or _has_tool_execution(
+                executed_tool_calls,
+                "create_markdown",
+                statuses=attempted_statuses,
+            )
+            or _has_tool_execution(
+                executed_tool_calls,
+                "write_markdown",
+                statuses=attempted_statuses,
+            )
+        )
+    ):
+        note_call = _build_capture_inbox_persist_tool_call(latest_user_message)
+        if note_call:
+            return [note_call]
+
+    fanout_call = _build_capture_scope_fanout_tool_call(
+        conversation_type=conversation_type,
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if fanout_call:
+        return [fanout_call]
+
+    if (
+        "create_task" in available_tool_names
+        and _capture_is_new_task_intent(latest_user_message)
+        and not _has_successful_synthetic_reason(executed_tool_calls, "capture_new_task_create")
+        and not _has_tool_execution(
+            executed_tool_calls,
+            "create_task",
+            statuses=attempted_statuses,
+        )
+    ):
+        return [
+            {
+                "id": "auto_capture_create_task",
+                "name": "create_task",
+                "arguments": _build_capture_create_task_arguments(
+                    message_text=latest_user_message,
+                    mcp_scope=mcp_scope,
+                ),
+                "synthetic": True,
+                "reason": "capture_new_task_create",
+            }
+        ]
+
+    digest_rollup_call = _build_capture_digest_rollup_tool_call(
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+    )
+    if digest_rollup_call:
+        return [digest_rollup_call]
+
+    return []
+
+
+def _extract_digest_snapshot_tasks_for_scoring(
+    executed_tool_calls: List[Dict[str, Any]],
+) -> List[Dict[str, Any]]:
+    for item in reversed(executed_tool_calls):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "").strip() != "digest_snapshot":
+            continue
+        if str(item.get("status") or "").strip().lower() != "success":
+            continue
+        result_payload = item.get("result")
+        if not isinstance(result_payload, dict):
+            continue
+        direct_tasks = result_payload.get("tasks")
+        if isinstance(direct_tasks, list):
+            return [task for task in direct_tasks if isinstance(task, dict)]
+        data_payload = result_payload.get("data")
+        if isinstance(data_payload, dict) and isinstance(data_payload.get("tasks"), list):
+            return [task for task in data_payload.get("tasks") if isinstance(task, dict)]
+    return []
+
+
+def _build_digest_schedule_followthrough_tool_call(
+    *,
+    conversation_type: str,
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    digest_schedule_config: Optional[Dict[str, Any]],
+) -> Optional[Dict[str, Any]]:
+    if not _is_digest_conversation(conversation_type) or _is_digest_reply_conversation(
+        conversation_type
+    ):
+        return None
+    if not isinstance(digest_schedule_config, dict):
+        return None
+    if not bool(digest_schedule_config.get("enabled")):
+        return None
+    if not bool(digest_schedule_config.get("due_now")):
+        return None
+
+    if "digest_snapshot" in available_tool_names and not _has_successful_tool_execution(
+        executed_tool_calls, "digest_snapshot"
+    ):
+        return {
+            "id": "auto_digest_schedule_snapshot",
+            "name": "digest_snapshot",
+            "arguments": {"include_completed": True, "completed_limit": 10, "activity_limit": 50},
+            "synthetic": True,
+            "reason": "digest_schedule_snapshot",
+        }
+
+    if "score_digest_tasks" in available_tool_names and not _has_successful_tool_execution(
+        executed_tool_calls, "score_digest_tasks"
+    ):
+        tasks_for_scoring = _extract_digest_snapshot_tasks_for_scoring(executed_tool_calls)
+        if tasks_for_scoring:
+            return {
+                "id": "auto_digest_schedule_score",
+                "name": "score_digest_tasks",
+                "arguments": {
+                    "tasks": tasks_for_scoring,
+                    "now": datetime.now(timezone.utc).isoformat(),
+                },
+                "synthetic": True,
+                "reason": "digest_schedule_score",
+            }
+
+    if "rollup_digest_period" in available_tool_names and not _has_successful_tool_execution(
+        executed_tool_calls, "rollup_digest_period"
+    ):
+        return {
+            "id": "auto_digest_schedule_rollup_week",
+            "name": "rollup_digest_period",
+            "arguments": {
+                "period": "week",
+                "target_date": datetime.now(timezone.utc).date().isoformat(),
+            },
+            "synthetic": True,
+            "reason": "digest_schedule_rollup_week",
+        }
+    return None
+
+
+def _build_orchestration_followthrough_tool_calls(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+    digest_schedule_config: Optional[Dict[str, Any]] = None,
+) -> List[Dict[str, Any]]:
+    capture_followthrough = _build_capture_followthrough_tool_calls(
+        conversation_type=conversation_type,
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if capture_followthrough:
+        return capture_followthrough
+
+    new_page_followthrough = _build_new_page_engine_followthrough_tool_calls(
+        conversation_type=conversation_type,
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if new_page_followthrough:
+        return new_page_followthrough
+
+    compound_edit_followthrough = _build_compound_edit_followthrough_tool_calls(
+        conversation_type=conversation_type,
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if compound_edit_followthrough:
+        return compound_edit_followthrough
+
+    owner_profile_followthrough = _build_owner_profile_followthrough_tool_call(
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+    )
+    if owner_profile_followthrough:
+        return [owner_profile_followthrough]
+
+    cross_pollination_followthrough = _build_cross_pollination_followthrough_tool_call(
+        conversation_type=conversation_type,
+        latest_user_message=latest_user_message,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+        mcp_scope=mcp_scope,
+    )
+    if cross_pollination_followthrough:
+        return [cross_pollination_followthrough]
+
+    digest_followthrough = _build_digest_schedule_followthrough_tool_call(
+        conversation_type=conversation_type,
+        executed_tool_calls=executed_tool_calls,
+        available_tool_names=available_tool_names,
+        digest_schedule_config=digest_schedule_config,
+    )
+    if digest_followthrough:
+        return [digest_followthrough]
+
+    return []
+
+
+def _extract_capture_tasks_from_tool_payload(payload: Dict[str, Any]) -> List[Dict[str, Any]]:
+    if not isinstance(payload, dict):
+        return []
+
+    candidates: List[Any] = []
+    direct_tasks = payload.get("tasks")
+    if isinstance(direct_tasks, list):
+        candidates.extend(direct_tasks)
+
+    nested_data = payload.get("data")
+    if isinstance(nested_data, dict):
+        nested_tasks = nested_data.get("tasks")
+        if isinstance(nested_tasks, list):
+            candidates.extend(nested_tasks)
+
+        nested_inner = nested_data.get("data")
+        if isinstance(nested_inner, dict) and isinstance(nested_inner.get("tasks"), list):
+            candidates.extend(nested_inner.get("tasks"))
+
+    parsed: List[Dict[str, Any]] = []
+    for item in candidates:
+        if not isinstance(item, dict):
+            continue
+        task_id = item.get("id")
+        try:
+            parsed_id = int(task_id)
+        except (TypeError, ValueError):
+            continue
+
+        status = str(item.get("status") or "").strip().lower()
+        if status in {"x", "completed", "done"}:
+            continue
+
+        parsed.append(
+            {
+                "id": parsed_id,
+                "title": str(item.get("title") or "").strip(),
+            }
+        )
+    return parsed
+
+
+def _latest_capture_listed_tasks(executed_tool_calls: List[Dict[str, Any]]) -> List[Dict[str, Any]]:
+    for item in reversed(executed_tool_calls):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "").strip() != "list_tasks":
+            continue
+        if str(item.get("status") or "").strip().lower() != "success":
+            continue
+        tool_result = item.get("result")
+        if not isinstance(tool_result, dict):
+            continue
+        parsed_tasks = _extract_capture_tasks_from_tool_payload(tool_result)
+        if parsed_tasks:
+            return parsed_tasks
+    return []
+
+
+def _extract_capture_task_id_hint(message_text: Optional[str]) -> Optional[int]:
+    if not isinstance(message_text, str):
+        return None
+    match = re.search(r"\bt-(\d{1,6})\b", message_text, flags=re.IGNORECASE)
+    if not match:
+        return None
+    try:
+        return int(match.group(1))
+    except (TypeError, ValueError):
+        return None
+
+
+def _extract_capture_match_tokens(message_text: Optional[str]) -> List[str]:
+    if not isinstance(message_text, str):
+        return []
+    stop_words = {
+        "task",
+        "tasks",
+        "todo",
+        "complete",
+        "completed",
+        "mark",
+        "done",
+        "finish",
+        "finished",
+        "close",
+        "closed",
+        "resolve",
+        "resolved",
+        "edit",
+        "update",
+        "change",
+        "modify",
+        "adjust",
+        "rename",
+        "reschedule",
+        "please",
+        "that",
+        "this",
+        "with",
+        "from",
+        "into",
+    }
+    tokens = re.findall(r"[a-z0-9]+", message_text.lower())
+    deduped: List[str] = []
+    seen: set[str] = set()
+    for token in tokens:
+        if len(token) < 3:
+            continue
+        if token in stop_words:
+            continue
+        if token.startswith("t") and token[1:].isdigit():
+            continue
+        if token.isdigit():
+            continue
+        if token in seen:
+            continue
+        seen.add(token)
+        deduped.append(token)
+    return deduped
+
+
+def _match_capture_task_id(
+    *,
+    message_text: Optional[str],
+    tasks: List[Dict[str, Any]],
+) -> Optional[int]:
+    if not tasks:
+        return None
+
+    explicit_id = _extract_capture_task_id_hint(message_text)
+    if explicit_id is not None:
+        for task in tasks:
+            if int(task.get("id")) == explicit_id:
+                return explicit_id
+        return None
+
+    if isinstance(message_text, str):
+        quoted_values = re.findall(r"['\"]([^'\"]{3,})['\"]", message_text)
+        for quoted in quoted_values:
+            lowered = quoted.strip().lower()
+            if not lowered:
+                continue
+            matches = [
+                task for task in tasks if lowered in str(task.get("title") or "").strip().lower()
+            ]
+            if len(matches) == 1:
+                return int(matches[0]["id"])
+
+    tokens = _extract_capture_match_tokens(message_text)
+    scored: List[tuple[int, int]] = []
+    for task in tasks:
+        title = str(task.get("title") or "").strip().lower()
+        if not title:
+            continue
+        score = sum(1 for token in tokens if token in title)
+        if score > 0:
+            scored.append((score, int(task["id"])))
+
+    if scored:
+        scored.sort(key=lambda item: item[0], reverse=True)
+        best_score, best_id = scored[0]
+        if len(scored) == 1:
+            return best_id
+        second_score = scored[1][0]
+        if best_score > second_score:
+            return best_id
+        return None
+
+    if len(tasks) == 1:
+        return int(tasks[0]["id"])
+    return None
+
+
+def _extract_capture_update_fields_from_message(message_text: Optional[str]) -> Dict[str, Any]:
+    if not isinstance(message_text, str):
+        return {}
+
+    normalized = " ".join(message_text.strip().split())
+    if not normalized:
+        return {}
+
+    fields: Dict[str, Any] = {}
+    due_value = _normalize_capture_due_value(normalized)
+    if due_value:
+        fields["due"] = due_value
+
+    lowered = normalized.lower()
+    priority = _extract_capture_priority_from_text(normalized)
+    if priority:
+        fields["priority"] = priority
+
+    owner = _extract_capture_owner_from_text(normalized)
+    if owner:
+        fields["owner"] = owner
+
+    tags = _extract_capture_tags_from_text(normalized)
+    if tags:
+        fields["tags"] = tags
+
+    scope_path = _extract_capture_scope_path_from_message(
+        message_text=normalized,
+        mcp_scope={},
+    )
+    if scope_path and scope_path not in {"capture", "life"}:
+        fields["scope"] = scope_path
+        if "/" in scope_path:
+            fields["project"] = scope_path.split("/")[-1]
+
+    title_match = re.search(
+        r"\b(?:rename|change title to|update title to)\s+(.+)$",
+        normalized,
+        flags=re.IGNORECASE,
+    )
+    if title_match:
+        candidate_title = title_match.group(1).strip(" .")
+        if candidate_title:
+            fields["title"] = candidate_title
+
+    if re.search(r"\bmark\b.{0,24}\b(open|reopen|active)\b", lowered):
+        fields["status"] = "open"
+    elif re.search(r"\bmark\b.{0,24}\b(done|complete|completed)\b", lowered):
+        fields["status"] = "completed"
+
+    return fields
+
+
+def _build_capture_task_followthrough_tool_call(
+    *,
+    conversation_type: str,
+    latest_user_message: Optional[str],
+    executed_tool_calls: List[Dict[str, Any]],
+    available_tool_names: set[str],
+    mcp_scope: Dict[str, Any],
+) -> Optional[Dict[str, Any]]:
+    if not _is_capture_intake_conversation(conversation_type):
+        return None
+
+    intent_kind = _capture_task_mutation_kind(latest_user_message)
+    if intent_kind not in {"complete", "edit"}:
+        return None
+
+    if "list_tasks" not in available_tool_names:
+        return None
+
+    if not _has_successful_tool_execution(executed_tool_calls, "list_tasks"):
+        lookup_args: Dict[str, Any] = {"status": "open"}
+        project_hint = _extract_capture_project_hint(mcp_scope)
+        if project_hint:
+            lookup_args["project"] = project_hint
+        return {
+            "id": "auto_capture_list_tasks",
+            "name": "list_tasks",
+            "arguments": lookup_args,
+            "synthetic": True,
+            "reason": "capture_task_id_resolution",
+        }
+
+    listed_tasks = _latest_capture_listed_tasks(executed_tool_calls)
+    if not listed_tasks:
+        return None
+
+    matched_id = _match_capture_task_id(
+        message_text=latest_user_message,
+        tasks=listed_tasks,
+    )
+    if matched_id is None:
+        return None
+
+    if intent_kind == "complete" and "complete_task" in available_tool_names:
+        return {
+            "id": "auto_capture_complete_task",
+            "name": "complete_task",
+            "arguments": {"id": matched_id},
+            "synthetic": True,
+            "reason": "capture_task_followthrough_complete",
+        }
+
+    if intent_kind == "edit" and "update_task" in available_tool_names:
+        update_fields = _extract_capture_update_fields_from_message(latest_user_message)
+        if not update_fields:
+            return None
+        return {
+            "id": "auto_capture_update_task",
+            "name": "update_task",
+            "arguments": {"id": matched_id, "fields": update_fields},
+            "synthetic": True,
+            "reason": "capture_task_followthrough_update",
+        }
+
+    return None
+
+
+def _extract_life_onboarding_state_from_message_metadata(
+    metadata: Dict[str, Any],
+    expected_topic: str,
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(metadata, dict):
+        return None
+
+    mcp_meta = metadata.get("mcp")
+    if not isinstance(mcp_meta, dict):
+        return None
+
+    state = mcp_meta.get("life_onboarding_deterministic")
+    if not isinstance(state, dict):
+        return None
+
+    topic = state.get("topic")
+    if not isinstance(topic, str) or topic.strip().lower() != expected_topic.strip().lower():
+        return None
+
+    awaiting = state.get("awaiting")
+    if not isinstance(awaiting, str) or not awaiting.strip():
+        return None
+
+    return dict(state)
+
+
+def _extract_new_page_interview_state_from_message_metadata(
+    metadata: Dict[str, Any],
+    expected_scope_path: str,
+) -> Optional[Dict[str, Any]]:
+    if not isinstance(metadata, dict):
+        return None
+    mcp_meta = metadata.get("mcp")
+    if not isinstance(mcp_meta, dict):
+        return None
+    state = mcp_meta.get(NEW_PAGE_INTERVIEW_STATE_KEY)
+    if not isinstance(state, dict):
+        return None
+    scope_path = str(state.get("scope_path") or "").strip()
+    if not scope_path:
+        return None
+    if scope_path != expected_scope_path:
+        return None
+    awaiting = str(state.get("awaiting") or "").strip().lower()
+    if not awaiting:
+        return None
+    return dict(state)
+
+
+def _is_new_page_interview_kickoff_intent(message_text: Optional[str]) -> bool:
+    if not isinstance(message_text, str):
+        return False
+    normalized = " ".join(message_text.strip().lower().split())
+    if not normalized:
+        return False
+    start_markers = ("start", "begin", "resume", "continue")
+    if not any(marker in normalized for marker in start_markers):
+        return False
+    return "interview" in normalized or "onboarding" in normalized
+
+
+def _parse_new_page_interview_questions(meta_payload: Dict[str, Any]) -> List[str]:
+    questions_raw = meta_payload.get("seed_questions")
+    if not isinstance(questions_raw, list):
+        return []
+    parsed: List[str] = []
+    for item in questions_raw:
+        if isinstance(item, str) and item.strip():
+            parsed.append(" ".join(item.strip().split()))
+    deduped = _dedupe_questions(parsed)
+    return deduped[:NEW_PAGE_INTERVIEW_MAX_QUESTIONS]
+
+
+def _summarize_new_page_answer(answer_text: str, *, max_chars: int = 220) -> str:
+    if not isinstance(answer_text, str):
+        return ""
+    normalized = " ".join(answer_text.strip().split())
+    if len(normalized) <= max_chars:
+        return normalized
+    return normalized[: max_chars - 3].rstrip() + "..."
+
+
+def _build_new_page_interview_edit_operations(
+    *,
+    scope_path: str,
+    page_kind: str,
+    question_index: int,
+    question_total: int,
+    question_text: str,
+    answer_text: str,
+) -> List[Dict[str, Any]]:
+    timestamp = datetime.now(timezone.utc).date().isoformat()
+    answer_summary = _summarize_new_page_answer(answer_text)
+    question_summary = _summarize_new_page_answer(question_text, max_chars=140)
+    base_line = (
+        f"- {timestamp} Q{question_index}/{question_total}: {answer_summary}"
+        if answer_summary
+        else f"- {timestamp} Q{question_index}/{question_total}: (captured)"
+    )
+    question_line = (
+        f"- Prompt: {question_summary}" if question_summary else "- Prompt: (not provided)"
+    )
+    plan_line = (
+        f"- {timestamp}: Interview update from Q{question_index} -> {answer_summary or 'captured'}"
+    )
+    status_line = (
+        f"- {timestamp}: Interview checkpoint Q{question_index} captured and integrated."
+    )
+
+    spec_target = "## Desired Outcomes" if page_kind == "life" else "## Success Criteria"
+    plan_target = "## Next Review" if page_kind == "life" else "## Next Steps"
+    status_target = "## Current Phase"
+
+    operations: List[Dict[str, Any]] = [
+        {
+            "path": f"{scope_path}/spec.md",
+            "operation": {
+                "type": "insert_after",
+                "target": spec_target,
+                "content": f"{base_line}\n{question_line}",
+            },
+        },
+        {
+            "path": f"{scope_path}/build-plan.md",
+            "operation": {
+                "type": "insert_after",
+                "target": plan_target,
+                "content": plan_line,
+            },
+        },
+        {
+            "path": f"{scope_path}/status.md",
+            "operation": {
+                "type": "insert_after",
+                "target": status_target,
+                "content": status_line,
+            },
+        },
+    ]
+    return operations
+
+
+def _extract_preview_summary(preview_payload: Dict[str, Any], *, fallback: str) -> str:
+    if not isinstance(preview_payload, dict):
+        return fallback
+    summary = preview_payload.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        if preview_payload.get("diffTruncated"):
+            return f"{summary.strip()} ({APPROVAL_PREVIEW_TRUNCATED_NOTICE.lower()})"
+        return summary.strip()
+    if preview_payload.get("diffTruncated"):
+        return APPROVAL_PREVIEW_TRUNCATED_NOTICE
+    return fallback
+
+
+async def _read_new_page_interview_seed(
+    *,
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    scope_path: str,
+    mcp_plugin_slug: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    meta_path = f"{scope_path}/_meta/interview-state.md"
+    parsed_meta: Dict[str, Any] = {}
+    read_meta = await _execute_tool_with_resync_fallback(
+        runtime_service=runtime_service,
+        mcp_user_id=mcp_user_id,
+        tool_name="read_markdown",
+        arguments={"path": meta_path},
+        plugin_slug_hint=mcp_plugin_slug,
+    )
+    if read_meta.get("ok"):
+        meta_payload = read_meta.get("data")
+        meta_content = _extract_markdown_content_from_tool_payload(
+            meta_payload if isinstance(meta_payload, dict) else {}
+        )
+        if meta_content:
+            try:
+                parsed = json.loads(meta_content)
+                if isinstance(parsed, dict):
+                    parsed_meta = parsed
+            except Exception:
+                parsed_meta = {}
+
+    questions = _parse_new_page_interview_questions(parsed_meta)
+    if not questions:
+        interview_path = f"{scope_path}/interview.md"
+        read_interview = await _execute_tool_with_resync_fallback(
+            runtime_service=runtime_service,
+            mcp_user_id=mcp_user_id,
+            tool_name="read_markdown",
+            arguments={"path": interview_path},
+            plugin_slug_hint=mcp_plugin_slug,
+        )
+        if read_interview.get("ok"):
+            interview_payload = read_interview.get("data")
+            interview_content = _extract_markdown_content_from_tool_payload(
+                interview_payload if isinstance(interview_payload, dict) else {}
+            )
+            questions = _extract_seed_questions(interview_content)
+    questions = _dedupe_questions(questions)[:NEW_PAGE_INTERVIEW_MAX_QUESTIONS]
+    if not questions:
+        return None
+
+    page_title = str(parsed_meta.get("page_title") or "").strip()
+    if not page_title:
+        page_title = _title_from_scope_slug(scope_path.split("/")[-1] if "/" in scope_path else scope_path)
+    page_kind = str(parsed_meta.get("page_kind") or "").strip().lower()
+    if page_kind not in {"life", "project"}:
+        page_kind = "life" if scope_path.startswith("life/") else "project"
+
+    status_payload = parsed_meta.get("status") if isinstance(parsed_meta.get("status"), dict) else {}
+    approved_answers = _as_int(status_payload.get("approved_answers"), 0, 0, 1000)
+    question_total = len(questions)
+    question_index = max(1, min(question_total, approved_answers + 1))
+    first_followup_due = str(parsed_meta.get("first_followup_due_utc") or "").strip()
+    if not first_followup_due:
+        first_followup_due = (datetime.now(timezone.utc).date() + timedelta(days=3)).isoformat()
+
+    if not isinstance(parsed_meta.get("status"), dict):
+        parsed_meta["status"] = {}
+    normalized_status = parsed_meta["status"]
+    normalized_status["question_total"] = question_total
+    normalized_status["approved_answers"] = approved_answers
+    stage_value = str(normalized_status.get("interview_stage") or "").strip().lower()
+    if not stage_value:
+        stage_value = "seeded" if approved_answers <= 0 else "in_progress"
+    normalized_status["interview_stage"] = stage_value
+    parsed_meta["status"] = normalized_status
+    parsed_meta["page_kind"] = page_kind
+    parsed_meta["page_slug"] = scope_path.split("/")[-1] if "/" in scope_path else scope_path
+    parsed_meta["page_title"] = page_title
+    if not str(parsed_meta.get("created_on_utc") or "").strip():
+        parsed_meta["created_on_utc"] = datetime.now(timezone.utc).date().isoformat()
+    parsed_meta["first_followup_due_utc"] = first_followup_due
+    if not isinstance(parsed_meta.get("seed_questions"), list) or not parsed_meta.get("seed_questions"):
+        parsed_meta["seed_questions"] = list(questions)
+
+    return {
+        "scope_path": scope_path,
+        "meta_path": meta_path,
+        "meta_payload": parsed_meta,
+        "page_title": page_title,
+        "page_kind": page_kind,
+        "questions": questions,
+        "question_total": question_total,
+        "question_index": question_index,
+        "approved_answers": approved_answers,
+        "first_followup_due_utc": first_followup_due,
+    }
+
+
+async def _execute_tool_with_resync_fallback(
+    *,
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    tool_name: str,
+    arguments: Dict[str, Any],
+    plugin_slug_hint: Optional[str],
+) -> Dict[str, Any]:
+    execution = await runtime_service.execute_tool_call(
+        mcp_user_id,
+        tool_name,
+        arguments,
+    )
+    if execution.get("ok"):
+        return execution
+
+    error = execution.get("error") if isinstance(execution.get("error"), dict) else {}
+    if error.get("code") != "TOOL_NOT_ALLOWED":
+        return execution
+
+    sync_filters: List[Optional[str]] = []
+    hint = plugin_slug_hint.strip() if isinstance(plugin_slug_hint, str) else ""
+    if hint:
+        sync_filters.append(hint)
+    sync_filters.append(None)
+
+    seen: set[str] = set()
+    for sync_filter in sync_filters:
+        key = sync_filter or "__none__"
+        if key in seen:
+            continue
+        seen.add(key)
+
+        try:
+            await runtime_service.sync_user_servers(
+                mcp_user_id,
+                plugin_slug_filter=sync_filter,
+            )
+        except Exception as sync_error:
+            MODULE_LOGGER.warning(
+                "life_onboarding_tool_resync_failed tool=%s plugin_filter=%s error=%s",
+                tool_name,
+                sync_filter,
+                sync_error,
+            )
+
+        retry = await runtime_service.execute_tool_call(
+            mcp_user_id,
+            tool_name,
+            arguments,
+        )
+        if retry.get("ok"):
+            return retry
+
+        retry_error = retry.get("error") if isinstance(retry.get("error"), dict) else {}
+        if retry_error.get("code") != "TOOL_NOT_ALLOWED":
+            return retry
+
+        execution = retry
+
+    return execution
+
+
+async def _read_life_seed_questions(
+    *,
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    life_topic: str,
+    mcp_plugin_slug: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    interview_path = f"life/{life_topic}/interview.md"
+    read_result = await _execute_tool_with_resync_fallback(
+        runtime_service=runtime_service,
+        mcp_user_id=mcp_user_id,
+        tool_name="read_markdown",
+        arguments={"path": interview_path},
+        plugin_slug_hint=mcp_plugin_slug,
+    )
+    if not read_result.get("ok"):
+        MODULE_LOGGER.info(
+            "life_onboarding_seed_read_failed topic=%s error=%s",
+            life_topic,
+            read_result.get("error"),
+        )
+        return None
+
+    payload = read_result.get("data")
+    content = _extract_markdown_content_from_tool_payload(payload if isinstance(payload, dict) else {})
+    if not content:
+        return None
+
+    questions = _extract_seed_questions(content)
+    if not questions:
+        return None
+
+    return {
+        "source_path": interview_path,
+        "questions": questions,
+    }
+
+
+async def _read_life_agent_questions(
+    *,
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    life_topic: str,
+    mcp_plugin_slug: Optional[str] = None,
+) -> Optional[Dict[str, Any]]:
+    agent_path = f"life/{life_topic}/AGENT.md"
+    read_result = await _execute_tool_with_resync_fallback(
+        runtime_service=runtime_service,
+        mcp_user_id=mcp_user_id,
+        tool_name="read_markdown",
+        arguments={"path": agent_path},
+        plugin_slug_hint=mcp_plugin_slug,
+    )
+    if not read_result.get("ok"):
+        MODULE_LOGGER.info(
+            "life_onboarding_agent_read_failed topic=%s error=%s",
+            life_topic,
+            read_result.get("error"),
+        )
+        return None
+
+    payload = read_result.get("data")
+    content = _extract_markdown_content_from_tool_payload(
+        payload if isinstance(payload, dict) else {}
+    )
+    if not content:
+        return None
+
+    questions = _build_life_questions_from_agent_focus(
+        life_topic=life_topic,
+        agent_markdown=content,
+    )
+    if not questions:
+        return None
+    return {
+        "source_path": agent_path,
+        "source_kind": "agent",
+        "questions": questions,
+    }
+
+
+async def _build_life_onboarding_kickoff_fallback(
+    *,
+    life_topic: str,
+    latest_user_message: Optional[str],
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    mcp_plugin_slug: Optional[str] = None,
+    auto_start: bool = False,
+    start_question_index: Optional[int] = None,
+) -> Optional[Dict[str, Any]]:
+    explicit_kickoff = _is_life_onboarding_kickoff_intent(latest_user_message)
+    resume_intent = _is_life_onboarding_resume_intent(latest_user_message)
+    if auto_start and _is_life_onboarding_skip_intent(latest_user_message):
+        return None
+
+    if not (explicit_kickoff or resume_intent or auto_start):
+        return None
+
+    interview_data = await _read_life_agent_questions(
+        runtime_service=runtime_service,
+        mcp_user_id=mcp_user_id,
+        life_topic=life_topic,
+        mcp_plugin_slug=mcp_plugin_slug,
+    )
+    if not interview_data:
+        interview_data = await _read_life_seed_questions(
+            runtime_service=runtime_service,
+            mcp_user_id=mcp_user_id,
+            life_topic=life_topic,
+            mcp_plugin_slug=mcp_plugin_slug,
+        )
+
+    if not interview_data:
+        MODULE_LOGGER.info(
+            "life_onboarding_kickoff_fallback_skipped topic=%s reason=seed_unavailable",
+            life_topic,
+        )
+        return None
+
+    questions = interview_data["questions"]
+    question_total = len(questions)
+    question_index = 1
+    if isinstance(start_question_index, int):
+        question_index = max(1, min(question_total, start_question_index))
+    first_question = questions[question_index - 1]
+    topic_title = LIFE_ONBOARDING_TOPICS.get(life_topic, life_topic.title())
+    if explicit_kickoff or resume_intent:
+        response_text = (
+            f"Great. We are building your {topic_title} library context so BrainDrive can get to know you better. "
+            "I will ask one question at a time and wait for your answer.\n\n"
+            f"Question {question_index} of {question_total}: {first_question}"
+        )
+        kickoff_mode = "explicit"
+    else:
+        response_text = (
+            f"Welcome to {topic_title}. We will start your onboarding interview now so this page can personalize to you.\n\n"
+            f"Question {question_index} of {question_total}: {first_question}"
+        )
+        kickoff_mode = "auto_first_visit"
+
+    return {
+        "topic": life_topic,
+        "topic_title": topic_title,
+        "source_path": interview_data["source_path"],
+        "source_kind": interview_data.get("source_kind", "seed"),
+        "questions": questions,
+        "question": first_question,
+        "question_index": question_index,
+        "question_total": question_total,
+        "kickoff_mode": kickoff_mode,
+        "response_text": response_text,
+    }
 
 
 def _normalize_approval_action(value: Any) -> Optional[str]:
@@ -465,6 +7881,8 @@ def _build_approval_request_payload(
     summary: Optional[str] = None,
     request_id: Optional[str] = None,
     scope: Optional[Dict[str, Any]] = None,
+    synthetic_reason: Optional[str] = None,
+    origin_user_message: Optional[str] = None,
 ) -> Dict[str, Any]:
     payload: Dict[str, Any] = {
         "type": "approval_request",
@@ -485,7 +7903,194 @@ def _build_approval_request_payload(
             "mcp_project_source": scope.get("mcp_project_source"),
             "mcp_plugin_slug": scope.get("mcp_plugin_slug"),
         }
+    if isinstance(synthetic_reason, str) and synthetic_reason.strip():
+        payload["synthetic_reason"] = synthetic_reason.strip()
+    if isinstance(origin_user_message, str) and origin_user_message.strip():
+        payload["origin_user_message"] = origin_user_message.strip()
     return payload
+
+
+def _extract_execution_data_payload(value: Any) -> Dict[str, Any]:
+    if not isinstance(value, dict):
+        return {}
+    direct_data = value.get("data")
+    if isinstance(direct_data, dict):
+        nested_data = direct_data.get("data")
+        if isinstance(nested_data, dict):
+            return nested_data
+        return direct_data
+    return value
+
+
+def _build_markdown_preview_payload(raw_payload: Any) -> Optional[Dict[str, Any]]:
+    candidates: List[Dict[str, Any]] = []
+    if isinstance(raw_payload, dict):
+        candidates.append(raw_payload)
+        data_payload = raw_payload.get("data")
+        if isinstance(data_payload, dict):
+            candidates.append(data_payload)
+            nested_payload = data_payload.get("data")
+            if isinstance(nested_payload, dict):
+                candidates.append(nested_payload)
+
+    selected: Optional[Dict[str, Any]] = None
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        if any(key in candidate for key in {"diff", "summary", "riskLevel"}):
+            selected = candidate
+            break
+    if not isinstance(selected, dict):
+        return None
+
+    diff_text = selected.get("diff")
+    if not isinstance(diff_text, str):
+        diff_text = ""
+    truncated = False
+    if len(diff_text) > APPROVAL_PREVIEW_MAX_DIFF_CHARS:
+        diff_text = diff_text[:APPROVAL_PREVIEW_MAX_DIFF_CHARS].rstrip() + "\n...[truncated]"
+        truncated = True
+
+    payload: Dict[str, Any] = {}
+    summary = selected.get("summary")
+    if isinstance(summary, str) and summary.strip():
+        payload["summary"] = summary.strip()
+    risk_level = selected.get("riskLevel")
+    if isinstance(risk_level, str) and risk_level.strip():
+        payload["riskLevel"] = risk_level.strip()
+    if diff_text:
+        payload["diff"] = diff_text
+        payload["diffTruncated"] = truncated
+    if truncated:
+        payload["previewNotice"] = APPROVAL_PREVIEW_TRUNCATED_NOTICE
+    if not payload:
+        return None
+    payload["previewTool"] = "preview_markdown_change"
+    return payload
+
+
+async def _build_mutating_approval_context(
+    *,
+    runtime_service: MCPRegistryService,
+    mcp_user_id: str,
+    tool_name: str,
+    tool_arguments: Dict[str, Any],
+) -> Dict[str, Any]:
+    context: Dict[str, Any] = {}
+
+    path_value = tool_arguments.get("path")
+    if (
+        tool_name in {"write_markdown", "edit_markdown"}
+        and isinstance(path_value, str)
+        and path_value.strip()
+        and isinstance(tool_arguments.get("operation"), dict)
+    ):
+        preview_result = await runtime_service.execute_tool_call(
+            mcp_user_id,
+            "preview_markdown_change",
+            {
+                "path": path_value,
+                "operation": tool_arguments["operation"],
+            },
+        )
+        if preview_result.get("ok"):
+            preview_payload = _build_markdown_preview_payload(preview_result.get("data"))
+            if isinstance(preview_payload, dict):
+                context["preview"] = preview_payload
+
+    preview_summary = (
+        context.get("preview", {}).get("summary")
+        if isinstance(context.get("preview"), dict)
+        else None
+    )
+    if isinstance(preview_summary, str) and preview_summary.strip():
+        context["summary"] = (
+            f"Approval required to run mutating tool '{tool_name}'. "
+            f"Preview: {preview_summary.strip()}"
+        )
+    elif isinstance(path_value, str) and path_value.strip():
+        context["summary"] = (
+            f"Approval required to run mutating tool '{tool_name}' on '{path_value.strip()}'."
+        )
+    return context
+
+
+def _extract_commit_sha_from_tool_result(result_payload: Any) -> Optional[str]:
+    if not isinstance(result_payload, dict):
+        return None
+    for key in ("commitSha", "commit_sha"):
+        value = result_payload.get(key)
+        if isinstance(value, str) and value.strip():
+            return value.strip()
+    nested_data = result_payload.get("data")
+    if isinstance(nested_data, dict):
+        return _extract_commit_sha_from_tool_result(nested_data)
+    return None
+
+
+def _build_approval_execution_success_message(
+    *,
+    executed_tool_calls: List[Dict[str, Any]],
+    approval_resolution_payload: Optional[Dict[str, Any]],
+) -> Optional[str]:
+    if not isinstance(approval_resolution_payload, dict):
+        return None
+    if str(approval_resolution_payload.get("status") or "").strip().lower() != "approved":
+        return None
+
+    tool_name = str(approval_resolution_payload.get("tool") or "").strip()
+    if not tool_name:
+        return None
+
+    successful_calls: List[Dict[str, Any]] = []
+    for item in executed_tool_calls:
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "").strip() != tool_name:
+            continue
+        if str(item.get("status") or "").strip().lower() != "success":
+            continue
+        successful_calls.append(item)
+
+    if len(successful_calls) > 1:
+        paths: List[str] = []
+        for item in successful_calls:
+            arguments = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+            path_value = arguments.get("path")
+            if isinstance(path_value, str) and path_value.strip() and path_value.strip() not in paths:
+                paths.append(path_value.strip())
+        message = (
+            f"Approved and executed `{tool_name}` successfully across "
+            f"{len(successful_calls)} operations."
+        )
+        if paths:
+            preview_paths = ", ".join(f"`{path}`" for path in paths[:3])
+            message += f" Paths: {preview_paths}."
+        return message
+
+    for item in reversed(executed_tool_calls):
+        if not isinstance(item, dict):
+            continue
+        if str(item.get("name") or "").strip() != tool_name:
+            continue
+        if str(item.get("status") or "").strip().lower() != "success":
+            continue
+
+        arguments = item.get("arguments") if isinstance(item.get("arguments"), dict) else {}
+        path_value = arguments.get("path")
+        task_id = arguments.get("id")
+        commit_sha = _extract_commit_sha_from_tool_result(item.get("result"))
+
+        message = f"Approved and executed `{tool_name}` successfully."
+        if isinstance(path_value, str) and path_value.strip():
+            message += f" Path: `{path_value.strip()}`."
+        elif isinstance(task_id, int):
+            message += f" Task ID: `{task_id}`."
+        if isinstance(commit_sha, str) and commit_sha:
+            message += f" Commit: `{commit_sha}`."
+        return message
+
+    return f"Approved and executed `{tool_name}` successfully."
 
 
 # Helper function to get provider instance from request
@@ -525,7 +8130,7 @@ async def get_provider_instance_from_request(request, db):
 
     try:
         # Get settings for the specified user
-        logger.info(f"Fetching settings with definition_id={request.settings_id}, user_id={user_id}")
+        MODULE_LOGGER.info(f"Fetching settings with definition_id={request.settings_id}, user_id={user_id}")
         settings = await SettingInstance.get_all_parameterized(
             db,
             definition_id=request.settings_id,
@@ -534,7 +8139,7 @@ async def get_provider_instance_from_request(request, db):
         )
         # Fallback to legacy direct SQL if ORM returns none (compat with legacy enum storage)
         if not settings or len(settings) == 0:
-            logger.info("ORM returned no settings; falling back to direct SQL query for settings")
+            MODULE_LOGGER.info("ORM returned no settings; falling back to direct SQL query for settings")
             settings = await SettingInstance.get_all(
                 db,
                 definition_id=request.settings_id,
@@ -542,7 +8147,7 @@ async def get_provider_instance_from_request(request, db):
                 user_id=user_id
             )
         
-        logger.info(f"Found {len(settings)} settings for user_id={user_id}")
+        MODULE_LOGGER.info(f"Found {len(settings)} settings for user_id={user_id}")
         
         if not settings or len(settings) == 0:
             logger.error(f"No settings found for definition_id={request.settings_id}, user_id={user_id}")
@@ -562,14 +8167,14 @@ async def get_provider_instance_from_request(request, db):
                 }
                 
                 # Get provider instance
-                logger.info(f"Getting provider instance for: {request.provider}, {request.server_id}")
+                MODULE_LOGGER.info(f"Getting provider instance for: {request.provider}, {request.server_id}")
                 provider_instance = await provider_registry.get_provider(
                     request.provider,
                     request.server_id,
                     config
                 )
                 
-                logger.info(f"Got provider instance: {provider_instance.provider_name}")
+                MODULE_LOGGER.info(f"Got provider instance: {provider_instance.provider_name}")
                 
                 return provider_instance
             elif request.provider in api_key_providers:
@@ -593,7 +8198,7 @@ async def get_provider_instance_from_request(request, db):
                         request.server_id,
                         config
                     )
-                    logger.info(f"Got provider instance with env key: {provider_instance.provider_name}")
+                    MODULE_LOGGER.info(f"Got provider instance with env key: {provider_instance.provider_name}")
                     return provider_instance
 
                 # No settings and no env fallback
@@ -628,7 +8233,7 @@ async def get_provider_instance_from_request(request, db):
                 try:
                     from app.core.encryption import encryption_service as _enc, EncryptionError as _EncErr
                     if _enc.is_encrypted_value(setting_value):
-                        logger.info("Attempting to decrypt settings value via encryption_service")
+                        MODULE_LOGGER.info("Attempting to decrypt settings value via encryption_service")
                         decrypted = _enc.decrypt_field('settings_instances', 'value', setting_value)
                         setting_value = decrypted
                 except Exception as dec_err:
@@ -676,7 +8281,7 @@ async def get_provider_instance_from_request(request, db):
             logger.error(f"Failed to parse encrypted settings: {e}")
             # For Ollama settings, provide helpful error message and fallback
             if 'ollama' in request.settings_id.lower():
-                logger.info("Ollama settings parsing failed, using fallback configuration")
+                MODULE_LOGGER.info("Ollama settings parsing failed, using fallback configuration")
                 value_dict = create_default_ollama_settings()
             elif request.provider in api_key_providers:
                 # Try environment fallback for API-key providers
@@ -707,17 +8312,17 @@ async def get_provider_instance_from_request(request, db):
         
         # Add specific validation for Ollama settings
         if 'ollama' in request.settings_id.lower():
-            logger.info("Validating Ollama settings format")
+            MODULE_LOGGER.info("Validating Ollama settings format")
             if not validate_ollama_settings_format(value_dict):
                 logger.warning("Ollama settings format validation failed, using default structure")
                 value_dict = create_default_ollama_settings()
             else:
-                logger.info("Ollama settings format validation passed")
+                MODULE_LOGGER.info("Ollama settings format validation passed")
         
         # Handle different provider configurations
         if request.provider == "openai":
             # OpenAI uses simple api_key structure
-            logger.info("Processing OpenAI provider configuration")
+            MODULE_LOGGER.info("Processing OpenAI provider configuration")
             api_key = value_dict.get("api_key") or value_dict.get("apiKey") or _get_env_api_key("openai") or ""
             if not api_key:
                 logger.error("OpenAI API key is missing")
@@ -725,17 +8330,23 @@ async def get_provider_instance_from_request(request, db):
                     status_code=400,
                     detail="OpenAI API key is required. Please configure your OpenAI API key in settings."
                 )
-            
+            configured_base_url = value_dict.get("base_url") or value_dict.get("baseUrl")
+            if isinstance(configured_base_url, str) and configured_base_url.strip():
+                openai_base_url = configured_base_url.strip()
+            else:
+                openai_base_url = "https://api.openai.com/v1"
+
             # For OpenAI, we create a virtual server configuration
             config = {
                 "api_key": api_key,
-                "server_url": "https://api.openai.com/v1",  # Default OpenAI API URL
-                "server_name": "OpenAI API"
+                "base_url": openai_base_url,
+                "server_url": openai_base_url,  # Keep server_url metadata aligned for diagnostics
+                "server_name": "OpenAI API",
             }
-            logger.info(f"Created OpenAI config with API key")
+            MODULE_LOGGER.info(f"Created OpenAI config with API key")
         elif request.provider == "openrouter":
             # OpenRouter uses simple api_key structure (similar to OpenAI)
-            logger.info("Processing OpenRouter provider configuration")
+            MODULE_LOGGER.info("Processing OpenRouter provider configuration")
             api_key = value_dict.get("api_key") or value_dict.get("apiKey") or _get_env_api_key("openrouter") or ""
             if not api_key:
                 logger.error("OpenRouter API key is missing")
@@ -750,10 +8361,10 @@ async def get_provider_instance_from_request(request, db):
                 "server_url": "https://openrouter.ai/api/v1",  # OpenRouter API URL
                 "server_name": "OpenRouter API"
             }
-            logger.info(f"Created OpenRouter config with API key")
+            MODULE_LOGGER.info(f"Created OpenRouter config with API key")
         elif request.provider == "claude":
             # Claude uses simple api_key structure (similar to OpenAI)
-            logger.info("Processing Claude provider configuration")
+            MODULE_LOGGER.info("Processing Claude provider configuration")
             api_key = value_dict.get("api_key") or value_dict.get("apiKey") or _get_env_api_key("claude") or ""
             if not api_key:
                 logger.error("Claude API key is missing")
@@ -768,10 +8379,10 @@ async def get_provider_instance_from_request(request, db):
                 "server_url": "https://api.anthropic.com",  # Claude API URL
                 "server_name": "Claude API"
             }
-            logger.info(f"Created Claude config with API key")
+            MODULE_LOGGER.info(f"Created Claude config with API key")
         elif request.provider == "groq":
             # Groq uses simple api_key structure (similar to OpenAI)
-            logger.info("Processing Groq provider configuration")
+            MODULE_LOGGER.info("Processing Groq provider configuration")
             api_key = value_dict.get("api_key") or value_dict.get("apiKey") or _get_env_api_key("groq") or ""
             if not api_key:
                 logger.error("Groq API key is missing")
@@ -786,7 +8397,7 @@ async def get_provider_instance_from_request(request, db):
                 "server_url": "https://api.groq.com",  # Groq API URL
                 "server_name": "Groq API"
             }
-            logger.info(f"Created Groq config with API key")
+            MODULE_LOGGER.info(f"Created Groq config with API key")
         else:
             # Other providers (like Ollama) use servers array
             logger.debug("Processing server-based provider configuration")
@@ -852,7 +8463,7 @@ async def get_provider_instance_from_request(request, db):
             config
         )
         
-        logger.info(f"Got provider instance: {provider_instance.provider_name}")
+        MODULE_LOGGER.info(f"Got provider instance: {provider_instance.provider_name}")
         
         return provider_instance
     except HTTPException:
@@ -1599,13 +9210,13 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
         print(f"📊 Model: {request.model}")
         print(f"📊 User ID: {request.user_id}")
         print(f"📊 Stream: {request.stream}")
-        logger.info(f"Production chat endpoint called with: provider={request.provider}, settings_id={request.settings_id}, server_id={request.server_id}, model={request.model}")
+        MODULE_LOGGER.info(f"Production chat endpoint called with: provider={request.provider}, settings_id={request.settings_id}, server_id={request.server_id}, model={request.model}")
         logger.debug(f"Messages: {request.messages}")
         logger.debug(f"Params: {request.params}")
         
         # Validate persona data if provided
         if request.persona_id or request.persona_system_prompt or request.persona_model_settings:
-            logger.info(f"Persona data provided - persona_id: {request.persona_id}")
+            MODULE_LOGGER.info(f"Persona data provided - persona_id: {request.persona_id}")
             
             # Basic validation: if persona_id is provided, persona_system_prompt should also be provided
             if request.persona_id and not request.persona_system_prompt:
@@ -1630,9 +9241,9 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     )
         
         # Get provider instance using the helper function
-        logger.info("Getting provider instance from request")
+        MODULE_LOGGER.info("Getting provider instance from request")
         provider_instance = await get_provider_instance_from_request(request, db)
-        logger.info(f"Provider instance created successfully: {provider_instance.provider_name}")
+        MODULE_LOGGER.info(f"Provider instance created successfully: {provider_instance.provider_name}")
         
         # Convert messages to the format expected by the provider
         current_messages = [message.model_dump() for message in request.messages]
@@ -1649,6 +9260,9 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
         user_id = request.user_id
         # The conversation_id is defined in the ChatCompletionRequest schema, so we can access it directly
         conversation_id = request.conversation_id
+        conversation_was_created = False
+        history_pre_compaction_event_ids: set[str] = set()
+        history_digest_schedule_event_ids: set[str] = set()
         print(f"Conversation ID from request: {conversation_id}")
         print(f"USER ID from request: {user_id} - THIS SHOULD BE THE CURRENT USER'S ID, NOT HARDCODED")
         
@@ -1679,10 +9293,25 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     print(f"ERROR: User {user_id} is not authorized to access conversation {conversation_id}")
                     print(f"Conversation owner: {conversation.user_id}, Request user: {user_id}, Original request user_id: {request.user_id}")
                     raise HTTPException(status_code=403, detail="Not authorized to access this conversation")
+
+                requested_page_id = _normalize_page_id(request.page_id)
+                conversation_page_id = _normalize_page_id(getattr(conversation, "page_id", None))
+                if requested_page_id and conversation_page_id and requested_page_id != conversation_page_id:
+                    raise HTTPException(
+                        status_code=409,
+                        detail=(
+                            "Conversation is bound to a different page. "
+                            "Start a new chat for this page."
+                        ),
+                    )
+                if requested_page_id and not conversation_page_id:
+                    conversation.page_id = requested_page_id
+                    await db.commit()
+                    await db.refresh(conversation)
                 
                 # Update conversation with persona_id if provided and different from current
                 if request.persona_id and conversation.persona_id != request.persona_id:
-                    logger.info(f"Updating conversation {conversation_id} with persona_id: {request.persona_id}")
+                    MODULE_LOGGER.info(f"Updating conversation {conversation_id} with persona_id: {request.persona_id}")
                     conversation.persona_id = request.persona_id
                     await db.commit()
                     await db.refresh(conversation)
@@ -1691,6 +9320,14 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 print(f"Retrieving previous messages for conversation {conversation_id}")
                 previous_messages = await conversation.get_messages(db)
                 print(f"Retrieved {len(previous_messages)} previous messages")
+                history_pre_compaction_event_ids = _collect_mcp_event_ids_from_history(
+                    previous_messages,
+                    event_key="pre_compaction_flush_event_id",
+                )
+                history_digest_schedule_event_ids = _collect_mcp_event_ids_from_history(
+                    previous_messages,
+                    event_key="digest_schedule_event_id",
+                )
                 
                 # Convert previous messages to the format expected by the provider
                 if previous_messages and len(previous_messages) > 0:
@@ -1735,7 +9372,7 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     for i, msg in enumerate(combined_messages):
                         print(f"  Combined message {i+1}: role={msg.get('role', 'unknown')}, content={msg.get('content', '')[:50]}...")
                     
-                    logger.info(f"Using {len(history_messages)} previous messages for context")
+                    MODULE_LOGGER.info(f"Using {len(history_messages)} previous messages for context")
                     logger.debug(f"Combined messages: {combined_messages}")
             else:
                 # Create a new conversation
@@ -1753,11 +9390,12 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 db.add(conversation)
                 await db.commit()
                 await db.refresh(conversation)
+                conversation_was_created = True
                 print(f"Created new conversation with ID: {conversation.id}")
                 
                 # If persona has a sample greeting, add it as the first assistant message
                 if request.persona_sample_greeting:
-                    logger.info(f"Adding persona sample greeting for persona_id: {request.persona_id}")
+                    MODULE_LOGGER.info(f"Adding persona sample greeting for persona_id: {request.persona_id}")
                     greeting_message = Message(
                         id=str(uuid.uuid4()),
                         conversation_id=conversation.id,
@@ -1784,6 +9422,13 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 request.persona_model_settings,
                 max_history=100  # trim oldest history messages if needed
             )
+            owner_profile_system_message, owner_profile_metadata = _build_owner_profile_system_message(
+                user_id
+            )
+            combined_messages = _insert_orchestration_system_message(
+                combined_messages,
+                owner_profile_system_message,
+            )
 
             # Remove local-only params before sending to provider
             provider_params = enhanced_params.copy()
@@ -1793,8 +9438,54 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
             approval_controls = _extract_mcp_approval_params(provider_params)
 
             # Extract MCP scope/tool flags from provider params (server-side orchestration contract).
+            requested_conversation_type = _normalize_conversation_type(request.conversation_type)
+            latest_user_message_hint = _latest_user_message_text(current_messages)
             mcp_scope = _extract_mcp_scope_params(provider_params)
+            explicit_project_scope = (
+                str(mcp_scope.get("mcp_scope_mode") or "").strip().lower() == "project"
+                and isinstance(mcp_scope.get("mcp_project_slug"), str)
+                and bool(str(mcp_scope.get("mcp_project_slug")).strip())
+            )
+
+            inferred_life_topic: Optional[str] = None
+            if not explicit_project_scope:
+                inferred_life_topic = _infer_life_topic_for_request(
+                    requested_conversation_type,
+                    request.page_context,
+                    latest_user_message_hint,
+                )
+
+            effective_conversation_type = requested_conversation_type
+            if inferred_life_topic and not _extract_life_topic(requested_conversation_type):
+                effective_conversation_type = f"life-{inferred_life_topic}"
+
+            digest_schedule_config = _extract_digest_schedule_config(
+                provider_params,
+                conversation_type=effective_conversation_type,
+            )
+            digest_delivery_send_config = _extract_digest_delivery_send_config(
+                provider_params
+            )
+            digest_delivery_channel = _extract_digest_delivery_channel(
+                effective_conversation_type
+            )
+            explicit_tool_profile_value = provider_params.get("mcp_tool_profile")
+            explicit_tool_profile = (
+                isinstance(explicit_tool_profile_value, str)
+                and bool(explicit_tool_profile_value.strip())
+            )
+            if not explicit_tool_profile:
+                if _is_digest_reply_conversation(effective_conversation_type):
+                    provider_params["mcp_tool_profile"] = TOOL_PROFILE_FULL
+                elif _is_digest_conversation(effective_conversation_type) and not _is_digest_reply_conversation(
+                    effective_conversation_type
+                ):
+                    provider_params["mcp_tool_profile"] = TOOL_PROFILE_DIGEST
+
+            scope_source = _apply_conversation_scope_defaults(effective_conversation_type, mcp_scope)
             mcp_tooling_metadata: Dict[str, Any] = {
+                "conversation_type": effective_conversation_type,
+                "conversation_type_requested": requested_conversation_type,
                 "mcp_tools_enabled": bool(mcp_scope.get("mcp_tools_enabled")),
                 "mcp_scope_mode": mcp_scope.get("mcp_scope_mode"),
                 "mcp_project_slug": mcp_scope.get("mcp_project_slug"),
@@ -1803,10 +9494,97 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 "mcp_project_source": mcp_scope.get("mcp_project_source"),
                 "available_count": 0,
                 "selected_count": 0,
+                "digest_schedule_enabled": bool(digest_schedule_config.get("enabled")),
+                "digest_schedule_due_now": bool(digest_schedule_config.get("due_now")),
+                "digest_sections": digest_schedule_config.get("sections") or list(DEFAULT_DIGEST_SECTIONS),
+                "digest_cadence_hours": int(digest_schedule_config.get("cadence_hours") or 24),
+                "digest_next_due_at_utc": digest_schedule_config.get("next_due_at_utc"),
+                "digest_reply_to_capture_enabled": bool(
+                    digest_schedule_config.get("reply_to_capture_enabled")
+                ),
+                "digest_delivery_channel": digest_delivery_channel,
+                "digest_delivery_send_enabled": bool(digest_delivery_send_config.get("enabled")),
             }
+            if digest_delivery_send_config.get("endpoint_sanitized"):
+                mcp_tooling_metadata["digest_delivery_send_endpoint"] = str(
+                    digest_delivery_send_config["endpoint_sanitized"]
+                )
+            if effective_conversation_type != requested_conversation_type:
+                mcp_tooling_metadata["conversation_type_source"] = "inferred"
+            if scope_source:
+                mcp_tooling_metadata["mcp_scope_source"] = scope_source
+            mcp_tooling_metadata.update(owner_profile_metadata)
+            tool_routing_decision = _resolve_tool_routing_decision(
+                provider=request.provider,
+                model=request.model,
+                provider_params=provider_params,
+            )
+            tool_routing_decision = _apply_dual_path_scope_tool_policy(
+                routing_decision=tool_routing_decision,
+                conversation_type=effective_conversation_type,
+                mcp_scope=mcp_scope,
+                latest_user_message=latest_user_message_hint,
+            )
+            if tool_routing_decision.get("disable_tools"):
+                mcp_scope["mcp_tools_enabled"] = False
+            mcp_tooling_metadata["mcp_tools_enabled"] = bool(mcp_scope.get("mcp_tools_enabled"))
+            mcp_tooling_metadata.update(
+                {
+                    "tool_routing_mode": tool_routing_decision.get("route_mode"),
+                    "tool_execution_mode": tool_routing_decision.get("execution_mode"),
+                    "tool_profile": tool_routing_decision.get("tool_profile"),
+                    "tool_profile_source": tool_routing_decision.get("tool_profile_source"),
+                    "native_tool_calling_model": bool(
+                        tool_routing_decision.get("native_tool_calling")
+                    ),
+                    "routing_capability_source": tool_routing_decision.get("capability_source"),
+                    "dual_path_requested": bool(tool_routing_decision.get("dual_path_requested")),
+                }
+            )
+            if tool_routing_decision.get("policy_mode"):
+                mcp_tooling_metadata["tool_policy_mode"] = tool_routing_decision.get(
+                    "policy_mode"
+                )
+            if tool_routing_decision.get("dual_path_fallback_reason"):
+                mcp_tooling_metadata["dual_path_fallback_reason"] = tool_routing_decision.get(
+                    "dual_path_fallback_reason"
+                )
+
+            logger.info(
+                "chat_conversation_type_resolution requested=%s effective=%s inferred_life_topic=%s scope_mode=%s project_slug=%s",
+                requested_conversation_type,
+                effective_conversation_type,
+                inferred_life_topic,
+                mcp_scope.get("mcp_scope_mode"),
+                mcp_scope.get("mcp_project_slug"),
+            )
+
+            if (
+                hasattr(conversation, "conversation_type")
+                and isinstance(conversation.conversation_type, str)
+                and conversation.conversation_type.strip().lower() in {"", "chat"}
+                and effective_conversation_type != conversation.conversation_type
+            ):
+                conversation.conversation_type = effective_conversation_type
 
             approval_resume_context: Optional[Dict[str, Any]] = None
             approval_action = approval_controls.get("action")
+            approval_action_source = (
+                "explicit" if isinstance(approval_action, str) and approval_action else None
+            )
+            if not approval_action and conversation_id:
+                inferred_action = _parse_chat_approval_action(latest_user_message_hint)
+                if inferred_action:
+                    approval_action = inferred_action
+                    approval_action_source = "message_inferred"
+                    approval_controls["action"] = inferred_action
+                    MODULE_LOGGER.info(
+                        "approval_resume_inferred conversation_id=%s user_id=%s action=%s",
+                        conversation.id,
+                        user_id,
+                        inferred_action,
+                    )
+
             if approval_action:
                 if not conversation_id:
                     raise HTTPException(
@@ -1873,110 +9651,182 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     break
 
                 if pending_message is None or pending_request is None:
-                    raise HTTPException(
-                        status_code=409,
-                        detail="No pending approval request found for this conversation.",
+                    if approval_action_source == "message_inferred":
+                        MODULE_LOGGER.info(
+                            "approval_resume_inferred_no_pending conversation_id=%s user_id=%s action=%s",
+                            conversation.id,
+                            user_id,
+                            approval_action,
+                        )
+                    else:
+                        raise HTTPException(
+                            status_code=409,
+                            detail="No pending approval request found for this conversation.",
+                        )
+                else:
+                    pending_tool = pending_request.get("tool")
+                    if not isinstance(pending_tool, str) or not pending_tool.strip():
+                        raise HTTPException(
+                            status_code=409,
+                            detail="Pending approval request is missing tool metadata.",
+                        )
+
+                    pending_arguments = pending_request.get("arguments")
+                    if not isinstance(pending_arguments, dict):
+                        pending_arguments = {}
+
+                    override_arguments = approval_controls.get("arguments")
+                    effective_arguments = (
+                        override_arguments if isinstance(override_arguments, dict) else pending_arguments
                     )
 
-                pending_tool = pending_request.get("tool")
-                if not isinstance(pending_tool, str) or not pending_tool.strip():
-                    raise HTTPException(
-                        status_code=409,
-                        detail="Pending approval request is missing tool metadata.",
-                    )
-
-                pending_arguments = pending_request.get("arguments")
-                if not isinstance(pending_arguments, dict):
-                    pending_arguments = {}
-
-                override_arguments = approval_controls.get("arguments")
-                effective_arguments = (
-                    override_arguments if isinstance(override_arguments, dict) else pending_arguments
-                )
-
-                resolved_request_id = str(pending_request.get("request_id"))
-                resolution_status = "approved" if approval_action == "approve" else "rejected"
-                pending_request.update(
-                    {
-                        "status": resolution_status,
-                        "resolved_at": _utc_timestamp(),
-                        "resolution_source": "client",
-                        "resolution_message": (
-                            current_messages[-1].get("content")
-                            if current_messages and isinstance(current_messages[-1], dict)
-                            else None
-                        ),
-                    }
-                )
-
-                pending_meta = (
-                    pending_message.message_metadata
-                    if isinstance(pending_message.message_metadata, dict)
-                    else {}
-                )
-                pending_mcp = (
-                    pending_meta.get("mcp")
-                    if isinstance(pending_meta.get("mcp"), dict)
-                    else {}
-                )
-                pending_mcp["approval_request"] = pending_request
-                pending_meta["mcp"] = pending_mcp
-                pending_message.message_metadata = pending_meta
-                await db.commit()
-
-                approval_resume_context = {
-                    "action": approval_action,
-                    "request_id": resolved_request_id,
-                    "tool": pending_tool.strip(),
-                    "arguments": effective_arguments,
-                    "safety_class": pending_request.get("safety_class") or "mutating",
-                    "summary": pending_request.get("summary"),
-                    "scope": pending_request.get("scope")
-                    if isinstance(pending_request.get("scope"), dict)
-                    else {},
-                }
-                mcp_tooling_metadata.update(
-                    {
-                        "approval_resume_action": approval_action,
-                        "approval_resume_request_id": resolved_request_id,
-                        "approval_resume_tool": pending_tool.strip(),
-                    }
-                )
-
-                # If client omitted scope in resume request, reuse stored scope from original approval.
-                pending_scope = approval_resume_context.get("scope") or {}
-                if (
-                    approval_action == "approve"
-                    and str(mcp_scope.get("mcp_scope_mode")) != "project"
-                    and isinstance(pending_scope, dict)
-                    and pending_scope.get("mcp_project_slug")
-                ):
-                    mcp_scope.update(
+                    resolved_request_id = str(pending_request.get("request_id"))
+                    resolution_status = "approved" if approval_action == "approve" else "rejected"
+                    pending_request.update(
                         {
-                            "mcp_tools_enabled": True,
-                            "mcp_scope_mode": "project",
-                            "mcp_project_slug": pending_scope.get("mcp_project_slug"),
-                            "mcp_project_name": pending_scope.get("mcp_project_name"),
-                            "mcp_project_lifecycle": pending_scope.get("mcp_project_lifecycle"),
-                            "mcp_project_source": pending_scope.get("mcp_project_source") or "ui",
-                            "mcp_plugin_slug": pending_scope.get("mcp_plugin_slug"),
+                            "status": resolution_status,
+                            "resolved_at": _utc_timestamp(),
+                            "resolution_source": "client",
+                            "resolution_message": (
+                                current_messages[-1].get("content")
+                                if current_messages and isinstance(current_messages[-1], dict)
+                                else None
+                            ),
                         }
                     )
+
+                    pending_meta = (
+                        copy.deepcopy(pending_message.message_metadata)
+                        if isinstance(pending_message.message_metadata, dict)
+                        else {}
+                    )
+                    pending_mcp = (
+                        pending_meta.get("mcp")
+                        if isinstance(pending_meta.get("mcp"), dict)
+                        else {}
+                    )
+                    pending_mcp["approval_request"] = pending_request
+                    pending_meta["mcp"] = pending_mcp
+                    pending_message.message_metadata = pending_meta
+                    flag_modified(pending_message, "message_metadata")
+                    await db.commit()
+
+                    approval_resume_context = {
+                        "action": approval_action,
+                        "request_id": resolved_request_id,
+                        "tool": pending_tool.strip(),
+                        "arguments": effective_arguments,
+                        "safety_class": pending_request.get("safety_class") or "mutating",
+                        "summary": pending_request.get("summary"),
+                        "synthetic_reason": pending_request.get("synthetic_reason"),
+                        "origin_user_message": pending_request.get("origin_user_message"),
+                        "scope": pending_request.get("scope")
+                        if isinstance(pending_request.get("scope"), dict)
+                        else {},
+                        "prior_tool_calls": [
+                            dict(item)
+                            for item in (
+                                pending_mcp.get("tool_calls_executed")
+                                if isinstance(pending_mcp.get("tool_calls_executed"), list)
+                                else []
+                            )
+                            if isinstance(item, dict)
+                        ],
+                    }
                     mcp_tooling_metadata.update(
                         {
-                            "mcp_tools_enabled": True,
-                            "mcp_scope_mode": "project",
-                            "mcp_project_slug": pending_scope.get("mcp_project_slug"),
-                            "mcp_project_name": pending_scope.get("mcp_project_name"),
-                            "mcp_project_lifecycle": pending_scope.get("mcp_project_lifecycle"),
-                            "mcp_project_source": pending_scope.get("mcp_project_source") or "ui",
+                            "approval_resume_action": approval_action,
+                            "approval_resume_request_id": resolved_request_id,
+                            "approval_resume_tool": pending_tool.strip(),
+                            "approval_resume_source": approval_action_source or "explicit",
                         }
                     )
 
+                    # If client omitted scope in resume request, reuse stored scope from original approval.
+                    pending_scope = approval_resume_context.get("scope") or {}
+                    if (
+                        approval_action == "approve"
+                        and str(mcp_scope.get("mcp_scope_mode")) != "project"
+                        and isinstance(pending_scope, dict)
+                        and pending_scope.get("mcp_project_slug")
+                    ):
+                        mcp_scope.update(
+                            {
+                                "mcp_tools_enabled": True,
+                                "mcp_scope_mode": "project",
+                                "mcp_project_slug": pending_scope.get("mcp_project_slug"),
+                                "mcp_project_name": pending_scope.get("mcp_project_name"),
+                                "mcp_project_lifecycle": pending_scope.get("mcp_project_lifecycle"),
+                                "mcp_project_source": pending_scope.get("mcp_project_source") or "ui",
+                                "mcp_plugin_slug": pending_scope.get("mcp_plugin_slug"),
+                            }
+                        )
+                        mcp_tooling_metadata.update(
+                            {
+                                "mcp_tools_enabled": True,
+                                "mcp_scope_mode": "project",
+                                "mcp_project_slug": pending_scope.get("mcp_project_slug"),
+                                "mcp_project_name": pending_scope.get("mcp_project_name"),
+                                "mcp_project_lifecycle": pending_scope.get("mcp_project_lifecycle"),
+                                "mcp_project_source": pending_scope.get("mcp_project_source") or "ui",
+                            }
+                        )
+
+            capture_intent_message_hint = latest_user_message_hint
+            if approval_resume_context and approval_resume_context.get("action") == "approve":
+                capture_intent_message_hint = None
+                origin_user_message = approval_resume_context.get("origin_user_message")
+                if isinstance(origin_user_message, str) and origin_user_message.strip():
+                    capture_intent_message_hint = origin_user_message.strip()
+
+                if not capture_intent_message_hint:
+                    resume_synthetic_reason = str(
+                        approval_resume_context.get("synthetic_reason") or ""
+                    ).strip().lower()
+                    resume_tool_name = str(approval_resume_context.get("tool") or "").strip()
+                    resume_arguments = (
+                        approval_resume_context.get("arguments")
+                        if isinstance(approval_resume_context.get("arguments"), dict)
+                        else {}
+                    )
+                    if resume_synthetic_reason == "capture_inbox_persist":
+                        resume_content = resume_arguments.get("content")
+                        if isinstance(resume_content, str) and resume_content.strip():
+                            capture_intent_message_hint = resume_content.strip()
+                    if not capture_intent_message_hint:
+                        resume_content = _extract_capture_inbox_content_from_tool_call(
+                            resume_tool_name,
+                            resume_arguments,
+                        )
+                        if isinstance(resume_content, str) and resume_content.strip():
+                            capture_intent_message_hint = resume_content.strip()
+
+                if not capture_intent_message_hint:
+                    capture_intent_message_hint = _latest_non_approval_user_message_text(
+                        combined_messages
+                    )
+                if not capture_intent_message_hint:
+                    capture_intent_message_hint = latest_user_message_hint
+
+            tool_routing_decision = _apply_approval_resume_tool_policy(
+                routing_decision=tool_routing_decision,
+                approval_resume_context=approval_resume_context,
+            )
+            mcp_tooling_metadata.update(
+                {
+                    "tool_profile": tool_routing_decision.get("tool_profile"),
+                    "tool_profile_source": tool_routing_decision.get("tool_profile_source"),
+                }
+            )
+            if tool_routing_decision.get("policy_mode"):
+                mcp_tooling_metadata["tool_policy_mode"] = tool_routing_decision.get(
+                    "policy_mode"
+                )
+
             resolved_tools: List[Dict[str, Any]] = []
+            mcp_user_id = user_id or "current"
             if bool(mcp_scope.get("mcp_tools_enabled")) and str(mcp_scope.get("mcp_scope_mode")) == "project":
                 mcp_service = MCPRegistryService(db)
-                mcp_user_id = user_id or "current"
 
                 if bool(mcp_scope.get("mcp_sync_on_request")) and mcp_user_id != "current":
                     try:
@@ -1997,11 +9847,32 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     mcp_scope_mode=str(mcp_scope.get("mcp_scope_mode") or "none"),
                     mcp_project_slug=mcp_scope.get("mcp_project_slug"),
                     plugin_slug=mcp_scope.get("mcp_plugin_slug"),
+                    tool_profile=str(tool_routing_decision.get("tool_profile") or TOOL_PROFILE_FULL),
+                    allowed_safety_classes=tool_routing_decision.get("allowed_safety_classes"),
+                    tool_name_allowlist=tool_routing_decision.get("tool_name_allowlist"),
+                    priority_tool_names=_resolve_priority_tool_names(
+                        conversation_type=effective_conversation_type,
+                        tool_profile=str(
+                            tool_routing_decision.get("tool_profile") or TOOL_PROFILE_FULL
+                        ),
+                        tool_name_allowlist=tool_routing_decision.get("tool_name_allowlist"),
+                    ),
                     max_tools=int(mcp_scope.get("mcp_max_tools") or 32),
                     max_schema_bytes=int(mcp_scope.get("mcp_max_schema_bytes") or 128_000),
                 )
                 mcp_tooling_metadata.update(resolve_meta)
 
+            resolved_tools, sanitized_schema_count = _sanitize_tools_for_provider(
+                resolved_tools,
+                request.provider,
+            )
+            if sanitized_schema_count > 0:
+                mcp_tooling_metadata["sanitized_tool_schema_count"] = sanitized_schema_count
+                mcp_tooling_metadata["sanitized_tool_schema_provider"] = str(
+                    request.provider or ""
+                ).strip().lower()
+
+            resolved_tool_names = _extract_resolved_tool_names(resolved_tools)
             if resolved_tools:
                 provider_params["tools"] = resolved_tools
                 provider_params["tool_choice"] = provider_params.get("tool_choice", "auto")
@@ -2009,6 +9880,25 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 provider_params.pop("tools", None)
                 if "tool_choice" not in provider_params and bool(mcp_scope.get("mcp_tools_enabled")):
                     provider_params["tool_choice"] = "none"
+
+            orchestration_mode, orchestration_message = _build_conversation_orchestration_prompt(
+                effective_conversation_type,
+                resolved_tools,
+                digest_sections=digest_schedule_config.get("sections")
+                if isinstance(digest_schedule_config, dict)
+                else None,
+                digest_due_now=bool(
+                    digest_schedule_config.get("due_now")
+                    if isinstance(digest_schedule_config, dict)
+                    else False
+                ),
+            )
+            if orchestration_mode:
+                mcp_tooling_metadata["conversation_orchestration"] = orchestration_mode
+            combined_messages = _insert_orchestration_system_message(
+                combined_messages,
+                orchestration_message,
+            )
 
             mcp_max_tool_iterations = _as_int(
                 provider_params.pop("mcp_max_tool_iterations", 5),
@@ -2025,10 +9915,29 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
             if mcp_tool_timeout_seconds > 120:
                 mcp_tool_timeout_seconds = 120.0
 
-            mcp_auto_approve_mutating = _as_bool(
+            mcp_provider_timeout_seconds = float(
+                provider_params.pop(
+                    "mcp_provider_timeout_seconds",
+                    provider_params.pop("provider_timeout_seconds", 90.0),
+                )
+                or 90.0
+            )
+            if mcp_provider_timeout_seconds < 0.1:
+                mcp_provider_timeout_seconds = 0.1
+            if mcp_provider_timeout_seconds > 300:
+                mcp_provider_timeout_seconds = 300.0
+
+            requested_auto_approve_mutating = _as_bool(
                 provider_params.pop("mcp_auto_approve_mutating", False),
                 False,
             )
+            if requested_auto_approve_mutating:
+                logger.warning(
+                    "mcp_auto_approve_mutating_ignored conversation_id=%s user_id=%s",
+                    conversation.id,
+                    user_id,
+                )
+
             approved_mutating_raw = provider_params.pop("mcp_approved_mutating_tools", [])
             if isinstance(approved_mutating_raw, str):
                 approved_mutating_tools = {
@@ -2044,12 +9953,69 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 }
             else:
                 approved_mutating_tools = set()
-            if (
-                approval_resume_context
-                and approval_resume_context.get("action") == "approve"
-                and isinstance(approval_resume_context.get("tool"), str)
-            ):
-                approved_mutating_tools.add(str(approval_resume_context["tool"]))
+            mcp_tooling_metadata["approval_mode_policy"] = APPROVAL_MODE_POLICY
+            mcp_tooling_metadata["provider_timeout_seconds"] = round(
+                mcp_provider_timeout_seconds, 3
+            )
+            pre_compaction_flush_config = _extract_pre_compaction_flush_config(provider_params)
+            mcp_tooling_metadata.update(
+                {
+                    "pre_compaction_flush_enabled": bool(
+                        pre_compaction_flush_config.get("enabled")
+                    ),
+                    "pre_compaction_context_window_tokens": int(
+                        pre_compaction_flush_config.get("context_window_tokens") or 0
+                    ),
+                    "pre_compaction_flush_threshold": round(
+                        float(pre_compaction_flush_config.get("threshold") or 0.9), 3
+                    ),
+                }
+            )
+
+            orchestration_context_payload: Optional[Dict[str, Any]] = None
+            if bool(mcp_scope.get("mcp_tools_enabled")) and str(mcp_scope.get("mcp_scope_mode")) == "project":
+                context_runtime_service = MCPRegistryService(
+                    db,
+                    call_timeout_seconds=mcp_tool_timeout_seconds,
+                )
+                try:
+                    orchestration_context_payload = await _build_orchestration_context_payload(
+                        runtime_service=context_runtime_service,
+                        mcp_user_id=mcp_user_id,
+                        conversation_type=effective_conversation_type,
+                        mcp_scope=mcp_scope,
+                        resolved_tools=resolved_tools,
+                        plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                    )
+                except Exception as context_error:
+                    logger.warning(
+                        "orchestration_context_build_failed conversation_id=%s user_id=%s error=%s",
+                        conversation.id,
+                        user_id,
+                        context_error,
+                    )
+                    orchestration_context_payload = {
+                        "conversation_type": effective_conversation_type,
+                        "page_kind": _infer_page_kind(effective_conversation_type),
+                        "scope_root": None,
+                        "scope_path": None,
+                        "required_file_map": {},
+                        "required_files_missing": [],
+                        "required_files_unverified": [],
+                        "onboarding_state": None,
+                        "tool_safety_metadata": {
+                            "tool_classes": _extract_resolved_tool_safety(resolved_tools),
+                        },
+                        "approval_mode_policy": APPROVAL_MODE_POLICY,
+                        "context_missing": ["orchestration_context_build"],
+                        "context_ready": False,
+                    }
+
+                if isinstance(orchestration_context_payload, dict):
+                    mcp_tooling_metadata["orchestration_context"] = orchestration_context_payload
+                    page_kind_value = orchestration_context_payload.get("page_kind")
+                    if isinstance(page_kind_value, str) and page_kind_value:
+                        mcp_tooling_metadata["page_kind"] = page_kind_value
 
             auto_continue_enabled = _as_bool(provider_params.pop("auto_continue", True), True)
             auto_continue_max_passes = _as_int(
@@ -2086,6 +10052,1500 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     db.add(db_message)
                     print(f"Added {msg.role} message to database: {msg.content[:50]}...")
             
+            deterministic_tool_calls: List[Dict[str, Any]] = []
+            deterministic_response_content: Optional[str] = None
+            deterministic_stage: Optional[str] = None
+            deterministic_state_to_store: Optional[Dict[str, Any]] = None
+            deterministic_state_key: str = "life_onboarding_deterministic"
+            deterministic_orchestration_name: str = "life_onboarding_deterministic"
+            deterministic_stop_reason: str = "deterministic_life_onboarding_turn"
+            life_topic_for_kickoff = _extract_life_topic(effective_conversation_type)
+            latest_user_message = _latest_user_message_text(current_messages)
+            normalized_scope_path = _normalize_project_scope_path(mcp_scope.get("mcp_project_slug"))
+
+            if (
+                not life_topic_for_kickoff
+                and not approval_resume_context
+                and isinstance(normalized_scope_path, str)
+                and normalized_scope_path not in {"capture", "digest"}
+            ):
+                runtime_service = MCPRegistryService(
+                    db,
+                    call_timeout_seconds=mcp_tool_timeout_seconds,
+                )
+                prior_state: Optional[Dict[str, Any]] = None
+                prior_turn = -1
+
+                recent_llm_query = (
+                    select(Message)
+                    .where(
+                        Message.conversation_id == conversation.id,
+                        Message.sender == "llm",
+                    )
+                    .order_by(Message.created_at.desc())
+                    .limit(50)
+                )
+                recent_llm_result = await db.execute(recent_llm_query)
+                for candidate in recent_llm_result.scalars().all():
+                    candidate_meta = (
+                        candidate.message_metadata
+                        if isinstance(candidate.message_metadata, dict)
+                        else {}
+                    )
+                    candidate_state = _extract_new_page_interview_state_from_message_metadata(
+                        candidate_meta,
+                        normalized_scope_path,
+                    )
+                    if not candidate_state:
+                        continue
+                    candidate_turn = _as_int(candidate_state.get("turn"), 0, 0, 1_000_000)
+                    if candidate_turn >= prior_turn:
+                        prior_turn = candidate_turn
+                        prior_state = candidate_state
+
+                if prior_state is None:
+                    if _is_new_page_interview_kickoff_intent(latest_user_message):
+                        seed = await _read_new_page_interview_seed(
+                            runtime_service=runtime_service,
+                            mcp_user_id=user_id or "current",
+                            scope_path=normalized_scope_path,
+                            mcp_plugin_slug=mcp_scope.get("mcp_plugin_slug"),
+                        )
+                        if seed:
+                            question_index = _as_int(seed.get("question_index"), 1, 1, 1000)
+                            question_total = _as_int(seed.get("question_total"), 1, 1, 1000)
+                            questions = seed.get("questions") if isinstance(seed.get("questions"), list) else []
+                            question = (
+                                str(questions[question_index - 1]).strip()
+                                if questions and question_index <= len(questions)
+                                else ""
+                            )
+                            deterministic_stage = "new_page_kickoff"
+                            deterministic_state_key = NEW_PAGE_INTERVIEW_STATE_KEY
+                            deterministic_orchestration_name = "new_page_interview_deterministic"
+                            deterministic_stop_reason = "deterministic_new_page_interview_turn"
+                            deterministic_response_content = (
+                                f"Starting the {seed.get('page_title')} page interview. "
+                                "I will ask one question at a time and evolve your scope files as we go.\n\n"
+                                f"Question {question_index} of {question_total}: {question}"
+                            )
+                            deterministic_state_to_store = {
+                                "mode": "deterministic",
+                                "scope_path": normalized_scope_path,
+                                "page_title": seed.get("page_title"),
+                                "page_kind": seed.get("page_kind"),
+                                "meta_path": seed.get("meta_path"),
+                                "meta_payload": seed.get("meta_payload"),
+                                "first_followup_due_utc": seed.get("first_followup_due_utc"),
+                                "questions": questions,
+                                "question_index": question_index,
+                                "question_total": question_total,
+                                "question": question,
+                                "approved_answers": _as_int(seed.get("approved_answers"), 0, 0, 1000),
+                                "awaiting": "answer",
+                                "updated_at": _utc_timestamp(),
+                                "turn": 1,
+                            }
+                            deterministic_tool_calls.append(
+                                {
+                                    "name": "read_markdown",
+                                    "status": "success",
+                                    "arguments": {"path": seed.get("meta_path")},
+                                    "deterministic": True,
+                                }
+                            )
+                else:
+                    questions_raw = prior_state.get("questions")
+                    questions = (
+                        [str(item).strip() for item in questions_raw if isinstance(item, str) and str(item).strip()]
+                        if isinstance(questions_raw, list)
+                        else []
+                    )
+                    questions = _dedupe_questions(questions)[:NEW_PAGE_INTERVIEW_MAX_QUESTIONS]
+                    question_total = _as_int(prior_state.get("question_total"), len(questions), 1, 1000)
+                    if questions and question_total != len(questions):
+                        question_total = len(questions)
+                    question_index = _as_int(prior_state.get("question_index"), 1, 1, 1000)
+                    question_index = min(max(1, question_index), question_total)
+                    current_question = str(prior_state.get("question") or "").strip()
+                    if questions and (not current_question or question_index <= len(questions)):
+                        current_question = questions[question_index - 1]
+                    awaiting_state = str(prior_state.get("awaiting") or "").strip().lower()
+                    next_turn = _as_int(prior_state.get("turn"), 0, 0, 1_000_000) + 1
+                    page_title = str(prior_state.get("page_title") or "").strip() or _title_from_scope_slug(
+                        normalized_scope_path.split("/")[-1]
+                    )
+                    page_kind = str(prior_state.get("page_kind") or "").strip().lower()
+                    if page_kind not in {"life", "project"}:
+                        page_kind = "life" if normalized_scope_path.startswith("life/") else "project"
+                    first_followup_due = str(prior_state.get("first_followup_due_utc") or "").strip()
+                    deterministic_state_key = NEW_PAGE_INTERVIEW_STATE_KEY
+                    deterministic_orchestration_name = "new_page_interview_deterministic"
+                    deterministic_stop_reason = "deterministic_new_page_interview_turn"
+
+                    if awaiting_state == "answer":
+                        answer_text = (
+                            " ".join(str(latest_user_message or "").split())
+                            if isinstance(latest_user_message, str)
+                            else ""
+                        )
+                        resume_intent = _is_life_onboarding_resume_intent(latest_user_message)
+                        skip_intent = _is_life_onboarding_skip_intent(latest_user_message)
+                        if resume_intent:
+                            deterministic_stage = "new_page_awaiting_answer_resume"
+                            deterministic_response_content = (
+                                f"Resuming your page interview. Question {question_index} of {question_total}: "
+                                f"{current_question}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "scope_path": normalized_scope_path,
+                                "awaiting": "answer",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif skip_intent:
+                            next_index = question_index + 1
+                            if questions and next_index <= len(questions):
+                                next_question = questions[next_index - 1]
+                                deterministic_stage = "new_page_skipped_question_next"
+                                deterministic_response_content = (
+                                    f"Skipped. Question {next_index} of {len(questions)}: {next_question}"
+                                )
+                                deterministic_state_to_store = {
+                                    **prior_state,
+                                    "scope_path": normalized_scope_path,
+                                    "awaiting": "answer",
+                                    "question_index": next_index,
+                                    "question_total": len(questions),
+                                    "question": next_question,
+                                    "approved_answers": max(
+                                        _as_int(prior_state.get("approved_answers"), 0, 0, 1000),
+                                        next_index - 1,
+                                    ),
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                            else:
+                                deterministic_stage = "new_page_interview_complete_skip"
+                                deterministic_response_content = (
+                                    f"Interview complete for {page_title}. "
+                                    f"First follow-up remains due on {first_followup_due or 'the scheduled date'}."
+                                )
+                                deterministic_state_to_store = {
+                                    **prior_state,
+                                    "scope_path": normalized_scope_path,
+                                    "awaiting": "complete",
+                                    "question_index": question_total,
+                                    "question_total": question_total,
+                                    "approved_answers": question_total,
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                        elif not answer_text:
+                            deterministic_stage = "new_page_awaiting_answer"
+                            deterministic_response_content = (
+                                f"Question {question_index} of {question_total}: {current_question}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "scope_path": normalized_scope_path,
+                                "awaiting": "answer",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        else:
+                            operations = _build_new_page_interview_edit_operations(
+                                scope_path=normalized_scope_path,
+                                page_kind=page_kind,
+                                question_index=question_index,
+                                question_total=question_total,
+                                question_text=current_question,
+                                answer_text=answer_text,
+                            )
+                            preview_rows: List[Dict[str, Any]] = []
+                            for operation_payload in operations:
+                                preview_execution = await _execute_tool_with_resync_fallback(
+                                    runtime_service=runtime_service,
+                                    mcp_user_id=user_id or "current",
+                                    tool_name="preview_markdown_change",
+                                    arguments=operation_payload,
+                                    plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                                )
+                                deterministic_tool_calls.append(
+                                    {
+                                        "name": "preview_markdown_change",
+                                        "status": "success" if preview_execution.get("ok") else "error",
+                                        "arguments": operation_payload,
+                                        "deterministic": True,
+                                        "error": None
+                                        if preview_execution.get("ok")
+                                        else preview_execution.get("error"),
+                                    }
+                                )
+                                if not preview_execution.get("ok"):
+                                    continue
+                                preview_payload = _build_markdown_preview_payload(
+                                    preview_execution.get("data")
+                                )
+                                summary = _extract_preview_summary(
+                                    preview_payload or {},
+                                    fallback="Update pending.",
+                                )
+                                preview_rows.append(
+                                    {
+                                        "path": operation_payload.get("path"),
+                                        "summary": summary,
+                                    }
+                                )
+
+                            preview_lines = "\n".join(
+                                f"- `{str(item.get('path') or '').strip()}`: {str(item.get('summary') or '').strip()}"
+                                for item in preview_rows[:NEW_PAGE_INTERVIEW_PREVIEW_MAX_ITEMS]
+                                if str(item.get("path") or "").strip()
+                            )
+                            deterministic_stage = "new_page_awaiting_approval"
+                            deterministic_response_content = (
+                                "I prepared scoped updates from your answer:\n"
+                                f"{preview_lines}\n\n"
+                                f"{NEW_PAGE_INTERVIEW_APPROVAL_TEXT}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "scope_path": normalized_scope_path,
+                                "page_title": page_title,
+                                "page_kind": page_kind,
+                                "questions": questions,
+                                "question_index": question_index,
+                                "question_total": question_total,
+                                "question": current_question,
+                                "awaiting": "approval",
+                                "pending_answer": answer_text,
+                                "pending_operations": operations,
+                                "pending_preview_rows": preview_rows,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                    elif awaiting_state == "approval":
+                        pending_answer = str(prior_state.get("pending_answer") or "").strip()
+                        pending_operations = (
+                            prior_state.get("pending_operations")
+                            if isinstance(prior_state.get("pending_operations"), list)
+                            else []
+                        )
+                        approval_action = _parse_chat_approval_action(latest_user_message)
+                        resume_intent = _is_life_onboarding_resume_intent(latest_user_message)
+                        if approval_action == "reject":
+                            deterministic_stage = "new_page_approval_rejected"
+                            deterministic_response_content = (
+                                "No problem. Share a revised answer and I will recalculate the scoped updates."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "scope_path": normalized_scope_path,
+                                "awaiting": "answer",
+                                "pending_answer": None,
+                                "pending_operations": [],
+                                "pending_preview_rows": [],
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif approval_action == "approve" and pending_answer and pending_operations:
+                            success_count = 0
+                            for operation_payload in pending_operations:
+                                if not isinstance(operation_payload, dict):
+                                    continue
+                                execution = await _execute_tool_with_resync_fallback(
+                                    runtime_service=runtime_service,
+                                    mcp_user_id=user_id or "current",
+                                    tool_name="edit_markdown",
+                                    arguments=operation_payload,
+                                    plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                                )
+                                deterministic_tool_calls.append(
+                                    {
+                                        "name": "edit_markdown",
+                                        "status": "success" if execution.get("ok") else "error",
+                                        "arguments": operation_payload,
+                                        "deterministic": True,
+                                        "error": None if execution.get("ok") else execution.get("error"),
+                                    }
+                                )
+                                if execution.get("ok"):
+                                    success_count += 1
+
+                            if success_count == len(pending_operations):
+                                approved_answers = max(
+                                    _as_int(prior_state.get("approved_answers"), 0, 0, 1000),
+                                    question_index,
+                                )
+                                meta_payload = (
+                                    copy.deepcopy(prior_state.get("meta_payload"))
+                                    if isinstance(prior_state.get("meta_payload"), dict)
+                                    else {}
+                                )
+                                meta_status = (
+                                    meta_payload.get("status")
+                                    if isinstance(meta_payload.get("status"), dict)
+                                    else {}
+                                )
+                                meta_status.update(
+                                    {
+                                        "interview_stage": (
+                                            "complete"
+                                            if approved_answers >= question_total
+                                            else "in_progress"
+                                        ),
+                                        "question_total": question_total,
+                                        "approved_answers": approved_answers,
+                                    }
+                                )
+                                meta_payload["status"] = meta_status
+                                meta_payload["last_interview_at_utc"] = _utc_timestamp()
+                                meta_path = str(prior_state.get("meta_path") or "").strip()
+                                if not meta_path:
+                                    meta_path = f"{normalized_scope_path}/_meta/interview-state.md"
+                                write_meta_result = await _execute_tool_with_resync_fallback(
+                                    runtime_service=runtime_service,
+                                    mcp_user_id=user_id or "current",
+                                    tool_name="write_markdown",
+                                    arguments={
+                                        "path": meta_path,
+                                        "content": json.dumps(meta_payload, ensure_ascii=True, indent=2),
+                                    },
+                                    plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                                )
+                                deterministic_tool_calls.append(
+                                    {
+                                        "name": "write_markdown",
+                                        "status": "success" if write_meta_result.get("ok") else "error",
+                                        "arguments": {"path": meta_path},
+                                        "deterministic": True,
+                                        "error": None
+                                        if write_meta_result.get("ok")
+                                        else write_meta_result.get("error"),
+                                    }
+                                )
+
+                                next_index = question_index + 1
+                                if questions and next_index <= len(questions):
+                                    next_question = questions[next_index - 1]
+                                    deterministic_stage = "new_page_next_question"
+                                    deterministic_response_content = (
+                                        f"Saved scoped updates. Question {next_index} of {len(questions)}: "
+                                        f"{next_question}"
+                                    )
+                                    deterministic_state_to_store = {
+                                        **prior_state,
+                                        "scope_path": normalized_scope_path,
+                                        "page_title": page_title,
+                                        "page_kind": page_kind,
+                                        "meta_path": meta_path,
+                                        "meta_payload": meta_payload,
+                                        "questions": questions,
+                                        "question_index": next_index,
+                                        "question_total": len(questions),
+                                        "question": next_question,
+                                        "approved_answers": approved_answers,
+                                        "awaiting": "answer",
+                                        "pending_answer": None,
+                                        "pending_operations": [],
+                                        "pending_preview_rows": [],
+                                        "updated_at": _utc_timestamp(),
+                                        "turn": next_turn,
+                                    }
+                                else:
+                                    deterministic_stage = "new_page_interview_complete"
+                                    deterministic_response_content = (
+                                        f"Saved scoped updates. {page_title} interview is complete."
+                                        + (
+                                            f" First follow-up is due on {first_followup_due}."
+                                            if first_followup_due
+                                            else ""
+                                        )
+                                    )
+                                    deterministic_state_to_store = {
+                                        **prior_state,
+                                        "scope_path": normalized_scope_path,
+                                        "page_title": page_title,
+                                        "page_kind": page_kind,
+                                        "meta_path": meta_path,
+                                        "meta_payload": meta_payload,
+                                        "questions": questions,
+                                        "question_index": question_total,
+                                        "question_total": question_total,
+                                        "question": current_question,
+                                        "approved_answers": approved_answers,
+                                        "awaiting": "complete",
+                                        "pending_answer": None,
+                                        "pending_operations": [],
+                                        "pending_preview_rows": [],
+                                        "updated_at": _utc_timestamp(),
+                                        "turn": next_turn,
+                                    }
+                            else:
+                                deterministic_stage = "new_page_approval_retry"
+                                deterministic_response_content = (
+                                    "I could not apply all scoped updates yet. "
+                                    "Reply `approve` to retry, or `reject` to revise your answer."
+                                )
+                                deterministic_state_to_store = {
+                                    **prior_state,
+                                    "scope_path": normalized_scope_path,
+                                    "awaiting": "approval",
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                        elif resume_intent:
+                            preview_rows = (
+                                prior_state.get("pending_preview_rows")
+                                if isinstance(prior_state.get("pending_preview_rows"), list)
+                                else []
+                            )
+                            preview_lines = "\n".join(
+                                f"- `{str(item.get('path') or '').strip()}`: {str(item.get('summary') or '').strip()}"
+                                for item in preview_rows[:NEW_PAGE_INTERVIEW_PREVIEW_MAX_ITEMS]
+                                if isinstance(item, dict) and str(item.get("path") or "").strip()
+                            )
+                            deterministic_stage = "new_page_awaiting_approval_resume"
+                            deterministic_response_content = (
+                                "You still have pending scoped updates:\n"
+                                f"{preview_lines}\n\n"
+                                f"{NEW_PAGE_INTERVIEW_APPROVAL_TEXT}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "scope_path": normalized_scope_path,
+                                "awaiting": "approval",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        else:
+                            deterministic_stage = "new_page_awaiting_approval"
+                            deterministic_response_content = NEW_PAGE_INTERVIEW_APPROVAL_TEXT
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "scope_path": normalized_scope_path,
+                                "awaiting": "approval",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                    elif awaiting_state == "complete" and _is_new_page_interview_intent(latest_user_message):
+                        deterministic_stage = "new_page_already_complete"
+                        deterministic_response_content = (
+                            f"{page_title} interview is already complete."
+                            + (
+                                f" First follow-up is due on {first_followup_due}."
+                                if first_followup_due
+                                else ""
+                            )
+                        )
+                        deterministic_state_to_store = {
+                            **prior_state,
+                            "scope_path": normalized_scope_path,
+                            "awaiting": "complete",
+                            "updated_at": _utc_timestamp(),
+                            "turn": next_turn,
+                        }
+
+            if (
+                life_topic_for_kickoff
+                and not approval_resume_context
+                and deterministic_response_content is None
+            ):
+                runtime_service = MCPRegistryService(
+                    db,
+                    call_timeout_seconds=mcp_tool_timeout_seconds,
+                )
+                prior_state: Optional[Dict[str, Any]] = None
+                prior_turn = -1
+
+                recent_llm_query = (
+                    select(Message)
+                    .where(
+                        Message.conversation_id == conversation.id,
+                        Message.sender == "llm",
+                    )
+                    .order_by(Message.created_at.desc())
+                    .limit(50)
+                )
+                recent_llm_result = await db.execute(recent_llm_query)
+                for candidate in recent_llm_result.scalars().all():
+                    candidate_meta = (
+                        candidate.message_metadata
+                        if isinstance(candidate.message_metadata, dict)
+                        else {}
+                    )
+                    candidate_state = _extract_life_onboarding_state_from_message_metadata(
+                        candidate_meta,
+                        life_topic_for_kickoff,
+                    )
+                    if not candidate_state:
+                        continue
+
+                    candidate_turn = _as_int(candidate_state.get("turn"), 0, 0, 1_000_000)
+                    if candidate_turn >= prior_turn:
+                        prior_turn = candidate_turn
+                        prior_state = candidate_state
+
+                if prior_state is None:
+                    onboarding_topic_status = (
+                        orchestration_context_payload.get("onboarding_topic_status")
+                        if isinstance(orchestration_context_payload, dict)
+                        else None
+                    )
+                    resume_question_index = _derive_life_onboarding_resume_index_from_context(
+                        orchestration_context=orchestration_context_payload,
+                        life_topic=life_topic_for_kickoff,
+                    )
+                    resume_intent = _is_life_onboarding_resume_intent(latest_user_message)
+                    auto_start_first_visit = (
+                        bool(conversation_was_created)
+                        and not _is_life_onboarding_topic_complete(onboarding_topic_status)
+                    )
+                    life_onboarding_kickoff = await _build_life_onboarding_kickoff_fallback(
+                        life_topic=life_topic_for_kickoff,
+                        latest_user_message=latest_user_message,
+                        runtime_service=runtime_service,
+                        mcp_user_id=user_id or "current",
+                        mcp_plugin_slug=mcp_scope.get("mcp_plugin_slug"),
+                        auto_start=auto_start_first_visit,
+                        start_question_index=(
+                            resume_question_index
+                            if (auto_start_first_visit or resume_intent)
+                            else None
+                        ),
+                    )
+                    if life_onboarding_kickoff:
+                        deterministic_stage = (
+                            "kickoff_auto_first_visit"
+                            if life_onboarding_kickoff.get("kickoff_mode") == "auto_first_visit"
+                            else "kickoff"
+                        )
+                        deterministic_response_content = life_onboarding_kickoff["response_text"]
+                        deterministic_state_to_store = {
+                            "mode": "deterministic",
+                            "topic": life_onboarding_kickoff["topic"],
+                            "phase": "opening",
+                            "awaiting": "answer",
+                            "question_index": life_onboarding_kickoff["question_index"],
+                            "question_total": life_onboarding_kickoff["question_total"],
+                            "question": life_onboarding_kickoff["question"],
+                            "questions": life_onboarding_kickoff.get("questions", []),
+                            "approved_turns": [],
+                            "updated_at": _utc_timestamp(),
+                            "turn": 1,
+                        }
+                        deterministic_tool_calls.append(
+                            {
+                                "name": "read_markdown",
+                                "status": "success",
+                                "arguments": {
+                                    "path": life_onboarding_kickoff["source_path"],
+                                },
+                                "deterministic": True,
+                            }
+                        )
+                else:
+                    topic_title = LIFE_ONBOARDING_TOPICS.get(
+                        life_topic_for_kickoff,
+                        life_topic_for_kickoff.title(),
+                    )
+                    opening_questions = _extract_opening_questions_from_state(prior_state)
+                    if not opening_questions:
+                        regenerated = await _read_life_agent_questions(
+                            runtime_service=runtime_service,
+                            mcp_user_id=user_id or "current",
+                            life_topic=life_topic_for_kickoff,
+                            mcp_plugin_slug=mcp_scope.get("mcp_plugin_slug"),
+                        )
+                        if not regenerated:
+                            regenerated = await _read_life_seed_questions(
+                                runtime_service=runtime_service,
+                                mcp_user_id=user_id or "current",
+                                life_topic=life_topic_for_kickoff,
+                                mcp_plugin_slug=mcp_scope.get("mcp_plugin_slug"),
+                            )
+                        if regenerated:
+                            opening_questions = regenerated.get("questions", [])
+                            deterministic_tool_calls.append(
+                                {
+                                    "name": "read_markdown",
+                                    "status": "success",
+                                    "arguments": {"path": regenerated["source_path"]},
+                                    "deterministic": True,
+                                }
+                            )
+
+                    total_questions = len(opening_questions)
+                    if total_questions <= 0:
+                        total_questions = _as_int(prior_state.get("question_total"), 1, 1, 1000)
+                    current_index = _as_int(prior_state.get("question_index"), 1, 1, 1000)
+                    if current_index > total_questions and total_questions > 0:
+                        current_index = total_questions
+                    current_question = str(prior_state.get("question") or "").strip()
+                    if opening_questions and (not current_question or current_index <= len(opening_questions)):
+                        current_question = opening_questions[max(0, current_index - 1)]
+
+                    awaiting_state = str(prior_state.get("awaiting") or "").strip().lower()
+                    next_turn = _as_int(prior_state.get("turn"), 0, 0, 1_000_000) + 1
+                    followup_due_iso = (
+                        datetime.now(timezone.utc).replace(microsecond=0) + timedelta(days=3)
+                    ).isoformat()
+                    approved_turns = (
+                        prior_state.get("approved_turns")
+                        if isinstance(prior_state.get("approved_turns"), list)
+                        else []
+                    )
+
+                    if awaiting_state == "answer":
+                        answer_text = latest_user_message.strip() if isinstance(latest_user_message, str) else ""
+                        skip_intent = _is_life_onboarding_skip_intent(latest_user_message)
+                        resume_intent = _is_life_onboarding_resume_intent(latest_user_message)
+                        if resume_intent:
+                            deterministic_stage = "awaiting_answer_resume"
+                            deterministic_response_content = (
+                                "Resuming your onboarding interview. "
+                                f"Question {current_index} of {total_questions}: {current_question}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "opening",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "answer",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif skip_intent:
+                            next_index = current_index + 1
+                            if opening_questions and next_index <= len(opening_questions):
+                                next_question = opening_questions[next_index - 1]
+                                deterministic_stage = "skipped_question_next"
+                                deterministic_response_content = (
+                                    f"Skipped. Question {next_index} of {len(opening_questions)}: {next_question}"
+                                )
+                                deterministic_state_to_store = {
+                                    "mode": "deterministic",
+                                    "topic": life_topic_for_kickoff,
+                                    "phase": "opening",
+                                    "questions": opening_questions,
+                                    "approved_turns": approved_turns,
+                                    "awaiting": "answer",
+                                    "question_index": next_index,
+                                    "question_total": len(opening_questions),
+                                    "question": next_question,
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                            else:
+                                deterministic_stage = "goals_tasks_choice_prompt"
+                                deterministic_response_content = (
+                                    "Skipped. Your opening interview is complete. "
+                                    "Do you want to add initial goals or tasks for this topic now? "
+                                    "Reply `yes` or `no`."
+                                )
+                                deterministic_state_to_store = {
+                                    "mode": "deterministic",
+                                    "topic": life_topic_for_kickoff,
+                                    "phase": "goals_tasks",
+                                    "questions": opening_questions,
+                                    "approved_turns": approved_turns,
+                                    "awaiting": "goals_tasks_choice",
+                                    "question_index": total_questions,
+                                    "question_total": total_questions,
+                                    "question": current_question,
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                        elif not answer_text:
+                            deterministic_stage = "awaiting_answer"
+                            deterministic_response_content = (
+                                f"Question {current_index} of {total_questions}: {current_question}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "opening",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "answer",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        else:
+                            deterministic_stage = "awaiting_approval"
+                            deterministic_response_content = (
+                                "Thanks. I captured your answer. "
+                                "Reply `approve` to save it and continue, or `reject` to revise it."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "opening",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "approval",
+                                "pending_answer": answer_text,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                    elif awaiting_state == "approval":
+                        pending_answer = str(prior_state.get("pending_answer") or "").strip()
+                        approval_action = _parse_chat_approval_action(latest_user_message)
+                        skip_intent = _is_life_onboarding_skip_intent(latest_user_message)
+                        resume_intent = _is_life_onboarding_resume_intent(latest_user_message)
+
+                        if not pending_answer:
+                            deterministic_stage = "awaiting_answer"
+                            deterministic_response_content = (
+                                "I do not have your answer saved yet. "
+                                f"Question {current_index} of {total_questions}: {current_question}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "opening",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "answer",
+                                "pending_answer": None,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif skip_intent:
+                            next_index = current_index + 1
+                            if opening_questions and next_index <= len(opening_questions):
+                                next_question = opening_questions[next_index - 1]
+                                deterministic_stage = "approval_skip_next_question"
+                                deterministic_response_content = (
+                                    "Skipped this pending answer. "
+                                    f"Question {next_index} of {len(opening_questions)}: {next_question}"
+                                )
+                                deterministic_state_to_store = {
+                                    "mode": "deterministic",
+                                    "topic": life_topic_for_kickoff,
+                                    "phase": "opening",
+                                    "questions": opening_questions,
+                                    "approved_turns": approved_turns,
+                                    "awaiting": "answer",
+                                    "question_index": next_index,
+                                    "question_total": len(opening_questions),
+                                    "question": next_question,
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                            else:
+                                deterministic_stage = "goals_tasks_choice_prompt"
+                                deterministic_response_content = (
+                                    "Skipped this pending answer. Your opening interview is complete. "
+                                    "Do you want to add initial goals or tasks for this topic now? "
+                                    "Reply `yes` or `no`."
+                                )
+                                deterministic_state_to_store = {
+                                    "mode": "deterministic",
+                                    "topic": life_topic_for_kickoff,
+                                    "phase": "goals_tasks",
+                                    "questions": opening_questions,
+                                    "approved_turns": approved_turns,
+                                    "awaiting": "goals_tasks_choice",
+                                    "question_index": total_questions,
+                                    "question_total": total_questions,
+                                    "question": current_question,
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                        elif approval_action == "reject":
+                            deterministic_stage = "awaiting_answer"
+                            deterministic_response_content = (
+                                "No problem. Let us revise it. "
+                                f"Question {current_index} of {total_questions}: {current_question}"
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "opening",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "answer",
+                                "pending_answer": None,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif approval_action == "approve":
+                            save_payload = {
+                                "topic": life_topic_for_kickoff,
+                                "question": current_question,
+                                "answer": pending_answer,
+                                "context": pending_answer,
+                                "approved": True,
+                                "phase": "opening",
+                                "question_index": current_index,
+                                "question_total": total_questions,
+                            }
+                            save_result = await _execute_tool_with_resync_fallback(
+                                runtime_service=runtime_service,
+                                mcp_user_id=user_id or "current",
+                                tool_name="save_topic_onboarding_context",
+                                arguments=save_payload,
+                                plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                            )
+                            deterministic_tool_calls.append(
+                                {
+                                    "name": "save_topic_onboarding_context",
+                                    "status": "success" if save_result.get("ok") else "error",
+                                    "arguments": save_payload,
+                                    "deterministic": True,
+                                    "error": None if save_result.get("ok") else save_result.get("error"),
+                                }
+                            )
+
+                            if not save_result.get("ok"):
+                                deterministic_stage = "awaiting_approval"
+                                deterministic_response_content = (
+                                    "I could not save that answer yet. "
+                                    "Reply `approve` to retry save, or `reject` to revise."
+                                )
+                                deterministic_state_to_store = {
+                                    **prior_state,
+                                    "phase": "opening",
+                                    "questions": opening_questions,
+                                    "approved_turns": approved_turns,
+                                    "awaiting": "approval",
+                                    "pending_answer": pending_answer,
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                            else:
+                                approved_turns_next = [
+                                    *approved_turns,
+                                    {
+                                        "question": current_question,
+                                        "answer": pending_answer,
+                                        "approved_at_utc": _utc_timestamp(),
+                                    },
+                                ]
+                                next_index = current_index + 1
+                                if opening_questions and next_index <= len(opening_questions):
+                                    next_question = opening_questions[next_index - 1]
+                                    deterministic_stage = "next_question"
+                                    deterministic_response_content = (
+                                        f"Saved to your library. Question {next_index} of {len(opening_questions)}: "
+                                        f"{next_question}"
+                                    )
+                                    deterministic_state_to_store = {
+                                        "mode": "deterministic",
+                                        "topic": life_topic_for_kickoff,
+                                        "phase": "opening",
+                                        "questions": opening_questions,
+                                        "approved_turns": approved_turns_next,
+                                        "awaiting": "answer",
+                                        "question_index": next_index,
+                                        "question_total": len(opening_questions),
+                                        "question": next_question,
+                                        "updated_at": _utc_timestamp(),
+                                        "turn": next_turn,
+                                    }
+                                else:
+                                    deterministic_stage = "goals_tasks_choice_prompt"
+                                    deterministic_response_content = (
+                                        "Saved. Your opening interview is complete. "
+                                        "Do you want to add initial goals or tasks for this topic now? "
+                                        "Reply `yes` or `no`."
+                                    )
+                                    deterministic_state_to_store = {
+                                        "mode": "deterministic",
+                                        "topic": life_topic_for_kickoff,
+                                        "phase": "goals_tasks",
+                                        "questions": opening_questions,
+                                        "approved_turns": approved_turns_next,
+                                        "awaiting": "goals_tasks_choice",
+                                        "question_index": total_questions,
+                                        "question_total": total_questions,
+                                        "question": current_question,
+                                        "updated_at": _utc_timestamp(),
+                                        "turn": next_turn,
+                                    }
+                        elif resume_intent:
+                            deterministic_stage = "awaiting_approval_resume"
+                            deterministic_response_content = (
+                                f"You still have a pending answer for question {current_index}. "
+                                "Reply `approve` to save it and continue, "
+                                "`reject` to revise, or `skip` to move on without saving."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "opening",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "approval",
+                                "pending_answer": pending_answer,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        else:
+                            deterministic_stage = "awaiting_approval"
+                            deterministic_response_content = (
+                                "Reply `approve` to save this answer and continue, "
+                                "`reject` to revise it, or `skip` to move on without saving."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "opening",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "approval",
+                                "pending_answer": pending_answer,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                    elif awaiting_state == "goals_tasks_choice":
+                        choice = _parse_yes_no(latest_user_message)
+                        if choice is None:
+                            deterministic_stage = "awaiting_goals_tasks_choice"
+                            deterministic_response_content = (
+                                "Reply `yes` to add initial goals/tasks now, "
+                                "or `no` to finish onboarding for now."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "goals_tasks",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "goals_tasks_choice",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif choice is False:
+                            completion_summary = (
+                                f"Completed {topic_title} onboarding interview with approved answers."
+                            )
+                            complete_payload = {
+                                "topic": life_topic_for_kickoff,
+                                "summary": completion_summary,
+                                "next_followup_due_at_utc": followup_due_iso,
+                            }
+                            complete_result = await _execute_tool_with_resync_fallback(
+                                runtime_service=runtime_service,
+                                mcp_user_id=user_id or "current",
+                                tool_name="complete_topic_onboarding",
+                                arguments=complete_payload,
+                                plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                            )
+                            deterministic_tool_calls.append(
+                                {
+                                    "name": "complete_topic_onboarding",
+                                    "status": "success" if complete_result.get("ok") else "error",
+                                    "arguments": complete_payload,
+                                    "deterministic": True,
+                                    "error": None if complete_result.get("ok") else complete_result.get("error"),
+                                }
+                            )
+                            followup_task_payload = _build_onboarding_followup_task_payload(
+                                topic_slug=life_topic_for_kickoff,
+                                topic_title=topic_title,
+                                approved_turns=approved_turns,
+                            )
+                            followup_task_result = (
+                                await _execute_tool_with_resync_fallback(
+                                    runtime_service=runtime_service,
+                                    mcp_user_id=user_id or "current",
+                                    tool_name="create_task",
+                                    arguments=followup_task_payload,
+                                    plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                                )
+                                if complete_result.get("ok")
+                                else {"ok": False, "error": {"code": "SKIPPED_COMPLETE_FAILED"}}
+                            )
+                            deterministic_tool_calls.append(
+                                {
+                                    "name": "create_task",
+                                    "status": "success" if followup_task_result.get("ok") else "error",
+                                    "arguments": followup_task_payload,
+                                    "deterministic": True,
+                                    "error": None
+                                    if followup_task_result.get("ok")
+                                    else followup_task_result.get("error"),
+                                }
+                            )
+                            deterministic_stage = "completed"
+                            if complete_result.get("ok") and followup_task_result.get("ok"):
+                                deterministic_response_content = (
+                                    f"Saved. {topic_title} onboarding is complete. "
+                                    f"I also scheduled a follow-up task for {followup_task_payload['due']}."
+                                )
+                            elif complete_result.get("ok"):
+                                deterministic_response_content = (
+                                    f"Saved. {topic_title} onboarding is complete, "
+                                    "but I could not queue the follow-up task automatically."
+                                )
+                            else:
+                                deterministic_response_content = (
+                                    "I could not mark onboarding complete automatically yet."
+                                )
+                            deterministic_state_to_store = {
+                                "mode": "deterministic",
+                                "topic": life_topic_for_kickoff,
+                                "phase": "complete",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "complete",
+                                "question_index": total_questions,
+                                "question_total": total_questions,
+                                "question": current_question,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        else:
+                            deterministic_stage = "collect_goals_tasks"
+                            deterministic_response_content = (
+                                "Great. Share your initial goals or tasks for this topic. "
+                                "If you mention relative dates like `next Friday`, "
+                                "I will convert them to exact dates before save."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "goals_tasks",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "goals_tasks_details",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                    elif awaiting_state == "goals_tasks_details":
+                        details = latest_user_message.strip() if isinstance(latest_user_message, str) else ""
+                        if not details:
+                            deterministic_stage = "awaiting_goals_tasks_details"
+                            deterministic_response_content = (
+                                "Please share at least one initial goal or task for this topic."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "goals_tasks",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "goals_tasks_details",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        else:
+                            normalized_details, date_resolutions = _normalize_relative_dates_in_text(details)
+                            date_note = ""
+                            if date_resolutions:
+                                rendered = ", ".join(
+                                    f"{item['phrase']} -> {item['resolved_date']}"
+                                    for item in date_resolutions
+                                )
+                                date_note = f" Resolved dates: {rendered}."
+                            deterministic_stage = "awaiting_goals_tasks_approval"
+                            deterministic_response_content = (
+                                "Thanks. I captured your goals/tasks."
+                                f"{date_note} Reply `approve` to save, or `reject` to revise."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "goals_tasks",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "goals_tasks_approval",
+                                "pending_goals_tasks_raw": details,
+                                "pending_goals_tasks_normalized": normalized_details,
+                                "pending_date_resolutions": date_resolutions,
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                    elif awaiting_state == "goals_tasks_approval":
+                        pending_raw = str(prior_state.get("pending_goals_tasks_raw") or "").strip()
+                        pending_normalized = str(
+                            prior_state.get("pending_goals_tasks_normalized") or pending_raw
+                        ).strip()
+                        approval_action = _parse_chat_approval_action(latest_user_message)
+
+                        if not pending_raw:
+                            deterministic_stage = "collect_goals_tasks"
+                            deterministic_response_content = (
+                                "I do not have goals/tasks captured yet. "
+                                "Please share them now."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "goals_tasks",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "goals_tasks_details",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif approval_action == "reject":
+                            deterministic_stage = "collect_goals_tasks"
+                            deterministic_response_content = (
+                                "No problem. Share the revised goals/tasks and I will recapture them."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "goals_tasks",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "goals_tasks_details",
+                                "pending_goals_tasks_raw": None,
+                                "pending_goals_tasks_normalized": None,
+                                "pending_date_resolutions": [],
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                        elif approval_action == "approve":
+                            save_payload = {
+                                "topic": life_topic_for_kickoff,
+                                "question": "What initial goals or tasks do you want to set now?",
+                                "answer": pending_raw,
+                                "context": pending_normalized,
+                                "approved": True,
+                                "phase": "goals_tasks",
+                                "question_index": total_questions,
+                                "question_total": total_questions,
+                                "next_followup_due_at_utc": followup_due_iso,
+                            }
+                            save_result = await _execute_tool_with_resync_fallback(
+                                runtime_service=runtime_service,
+                                mcp_user_id=user_id or "current",
+                                tool_name="save_topic_onboarding_context",
+                                arguments=save_payload,
+                                plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                            )
+                            deterministic_tool_calls.append(
+                                {
+                                    "name": "save_topic_onboarding_context",
+                                    "status": "success" if save_result.get("ok") else "error",
+                                    "arguments": save_payload,
+                                    "deterministic": True,
+                                    "error": None if save_result.get("ok") else save_result.get("error"),
+                                }
+                            )
+
+                            if not save_result.get("ok"):
+                                deterministic_stage = "awaiting_goals_tasks_approval"
+                                deterministic_response_content = (
+                                    "I could not save those goals/tasks yet. "
+                                    "Reply `approve` to retry, or `reject` to revise."
+                                )
+                                deterministic_state_to_store = {
+                                    **prior_state,
+                                    "phase": "goals_tasks",
+                                    "questions": opening_questions,
+                                    "approved_turns": approved_turns,
+                                    "awaiting": "goals_tasks_approval",
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                            else:
+                                approved_turns_with_goals = [
+                                    *approved_turns,
+                                    {
+                                        "question": "What initial goals or tasks do you want to set now?",
+                                        "answer": pending_normalized,
+                                        "approved_at_utc": _utc_timestamp(),
+                                    },
+                                ]
+                                completion_summary = (
+                                    f"Completed {topic_title} onboarding interview with approved answers and "
+                                    "initial goals/tasks."
+                                )
+                                complete_payload = {
+                                    "topic": life_topic_for_kickoff,
+                                    "summary": completion_summary,
+                                    "next_followup_due_at_utc": followup_due_iso,
+                                }
+                                complete_result = await _execute_tool_with_resync_fallback(
+                                    runtime_service=runtime_service,
+                                    mcp_user_id=user_id or "current",
+                                    tool_name="complete_topic_onboarding",
+                                    arguments=complete_payload,
+                                    plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                                )
+                                deterministic_tool_calls.append(
+                                    {
+                                        "name": "complete_topic_onboarding",
+                                        "status": "success" if complete_result.get("ok") else "error",
+                                        "arguments": complete_payload,
+                                        "deterministic": True,
+                                        "error": None if complete_result.get("ok") else complete_result.get("error"),
+                                    }
+                                )
+                                initial_task_payloads = _build_onboarding_initial_task_payloads(
+                                    topic_slug=life_topic_for_kickoff,
+                                    topic_title=topic_title,
+                                    goals_tasks_text=pending_normalized,
+                                )
+                                initial_task_total = len(initial_task_payloads)
+                                initial_task_success = 0
+                                if complete_result.get("ok"):
+                                    for initial_task_payload in initial_task_payloads:
+                                        initial_task_result = await _execute_tool_with_resync_fallback(
+                                            runtime_service=runtime_service,
+                                            mcp_user_id=user_id or "current",
+                                            tool_name="create_task",
+                                            arguments=initial_task_payload,
+                                            plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                                        )
+                                        deterministic_tool_calls.append(
+                                            {
+                                                "name": "create_task",
+                                                "status": "success"
+                                                if initial_task_result.get("ok")
+                                                else "error",
+                                                "arguments": initial_task_payload,
+                                                "deterministic": True,
+                                                "error": None
+                                                if initial_task_result.get("ok")
+                                                else initial_task_result.get("error"),
+                                            }
+                                        )
+                                        if initial_task_result.get("ok"):
+                                            initial_task_success += 1
+                                followup_task_payload = _build_onboarding_followup_task_payload(
+                                    topic_slug=life_topic_for_kickoff,
+                                    topic_title=topic_title,
+                                    approved_turns=approved_turns_with_goals,
+                                )
+                                followup_task_result = (
+                                    await _execute_tool_with_resync_fallback(
+                                        runtime_service=runtime_service,
+                                        mcp_user_id=user_id or "current",
+                                        tool_name="create_task",
+                                        arguments=followup_task_payload,
+                                        plugin_slug_hint=mcp_scope.get("mcp_plugin_slug"),
+                                    )
+                                    if complete_result.get("ok")
+                                    else {"ok": False, "error": {"code": "SKIPPED_COMPLETE_FAILED"}}
+                                )
+                                deterministic_tool_calls.append(
+                                    {
+                                        "name": "create_task",
+                                        "status": "success" if followup_task_result.get("ok") else "error",
+                                        "arguments": followup_task_payload,
+                                        "deterministic": True,
+                                        "error": None
+                                        if followup_task_result.get("ok")
+                                        else followup_task_result.get("error"),
+                                    }
+                                )
+                                deterministic_stage = "completed"
+                                if (
+                                    complete_result.get("ok")
+                                    and followup_task_result.get("ok")
+                                    and initial_task_success == initial_task_total
+                                ):
+                                    if initial_task_total > 0:
+                                        task_word = "task" if initial_task_success == 1 else "tasks"
+                                        deterministic_response_content = (
+                                            f"Saved. {topic_title} onboarding is complete. "
+                                            f"I added {initial_task_success} onboarding {task_word} and scheduled a "
+                                            f"follow-up task for {followup_task_payload['due']}."
+                                        )
+                                    else:
+                                        deterministic_response_content = (
+                                            f"Saved. {topic_title} onboarding is complete. "
+                                            f"I also scheduled a follow-up task for {followup_task_payload['due']}."
+                                        )
+                                elif complete_result.get("ok"):
+                                    deterministic_response_content = (
+                                        f"Saved. {topic_title} onboarding is complete, "
+                                        "but I could not queue all tasks automatically."
+                                    )
+                                else:
+                                    deterministic_response_content = (
+                                        "Saved your goals/tasks, but I could not mark onboarding complete automatically."
+                                    )
+                                deterministic_state_to_store = {
+                                    "mode": "deterministic",
+                                    "topic": life_topic_for_kickoff,
+                                    "phase": "complete",
+                                    "questions": opening_questions,
+                                    "approved_turns": approved_turns_with_goals,
+                                    "awaiting": "complete",
+                                    "question_index": total_questions,
+                                    "question_total": total_questions,
+                                    "question": current_question,
+                                    "updated_at": _utc_timestamp(),
+                                    "turn": next_turn,
+                                }
+                        else:
+                            deterministic_stage = "awaiting_goals_tasks_approval"
+                            deterministic_response_content = (
+                                "Reply `approve` to save these goals/tasks, or `reject` to revise."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "goals_tasks",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "goals_tasks_approval",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+                    elif awaiting_state == "complete":
+                        resume_intent = _is_life_onboarding_resume_intent(latest_user_message)
+                        kickoff_intent = _is_life_onboarding_kickoff_intent(latest_user_message)
+                        if resume_intent or kickoff_intent:
+                            deterministic_stage = "already_complete"
+                            deterministic_response_content = (
+                                f"{topic_title} onboarding is already complete. "
+                                "You can ask me to review your tasks or capture updates anytime."
+                            )
+                            deterministic_state_to_store = {
+                                **prior_state,
+                                "phase": "complete",
+                                "questions": opening_questions,
+                                "approved_turns": approved_turns,
+                                "awaiting": "complete",
+                                "updated_at": _utc_timestamp(),
+                                "turn": next_turn,
+                            }
+
+                    else:
+                        deterministic_stage = "awaiting_answer"
+                        deterministic_response_content = (
+                            f"Question {current_index} of {total_questions}: {current_question}"
+                        )
+                        deterministic_state_to_store = {
+                            **prior_state,
+                            "phase": prior_state.get("phase", "opening"),
+                            "questions": opening_questions,
+                            "approved_turns": approved_turns,
+                            "awaiting": "answer",
+                            "updated_at": _utc_timestamp(),
+                            "turn": next_turn,
+                        }
+
+            if deterministic_response_content and deterministic_state_to_store:
+                awaiting_value = str(deterministic_state_to_store.get("awaiting") or "").strip().lower()
+                approval_pending = awaiting_value in {"approval", "goals_tasks_approval"}
+                question_index = _as_int(deterministic_state_to_store.get("question_index"), 0, 0, 1000)
+                question_total = _as_int(deterministic_state_to_store.get("question_total"), 0, 0, 1000)
+
+                deterministic_metadata: Dict[str, Any] = {
+                    "conversation_orchestration": deterministic_orchestration_name,
+                    "tool_loop_enabled": True,
+                    "tool_loop_iterations": max(1, len(deterministic_tool_calls)),
+                    "tool_loop_stop_reason": deterministic_stop_reason,
+                    "tool_calls_executed_count": len(deterministic_tool_calls),
+                    "approval_required": approval_pending,
+                    "approval_resolved": False,
+                }
+                if deterministic_state_key == NEW_PAGE_INTERVIEW_STATE_KEY:
+                    deterministic_metadata.update(
+                        {
+                            "new_page_interview_stage": deterministic_stage,
+                            "new_page_interview_scope": deterministic_state_to_store.get("scope_path"),
+                            "new_page_interview_question_index": question_index,
+                            "new_page_interview_question_total": question_total,
+                        }
+                    )
+                else:
+                    deterministic_metadata.update(
+                        {
+                            "life_onboarding_stage": deterministic_stage,
+                            "life_onboarding_topic": deterministic_state_to_store.get("topic"),
+                            "life_onboarding_question_index": question_index,
+                            "life_onboarding_question_total": question_total,
+                        }
+                    )
+                mcp_tooling_metadata.update(deterministic_metadata)
+
+                estimated_token_count = max(1, int(len(deterministic_response_content.split()) * 1.3))
+                message_metadata = {
+                    "token_count": estimated_token_count,
+                    "tokens_per_second": None,
+                    "model": request.model,
+                    "temperature": provider_params.get("temperature", 0.7),
+                    "streaming": bool(request.stream),
+                    "mcp": {
+                        **mcp_tooling_metadata,
+                        "tools_passed_count": len(resolved_tools),
+                        "tool_calls_executed": deterministic_tool_calls,
+                        deterministic_state_key: deterministic_state_to_store,
+                    },
+                }
+                db_message = Message(
+                    id=str(uuid.uuid4()),
+                    conversation_id=conversation.id,
+                    sender="llm",
+                    message=deterministic_response_content,
+                    message_metadata=message_metadata,
+                )
+                db.add(db_message)
+                conversation.updated_at = db_message.created_at
+                await db.commit()
+
+                if request.stream:
+                    async def deterministic_stream_generator():
+                        initial_evt = {
+                            "type": "conversation",
+                            "conversation_id": conversation.id,
+                        }
+                        yield f"data: {json.dumps(initial_evt)}\n\n"
+
+                        tooling_evt = {
+                            "type": "tooling_state",
+                            **mcp_tooling_metadata,
+                            "tools_passed_count": len(resolved_tools),
+                        }
+                        yield f"data: {json.dumps(tooling_evt)}\n\n"
+
+                        if (
+                            str(mcp_scope.get("mcp_scope_mode")) == "project"
+                            and mcp_scope.get("mcp_project_slug")
+                        ):
+                            scope_evt = {
+                                "type": "project_scope_selected",
+                                "project": {
+                                    "slug": mcp_scope.get("mcp_project_slug"),
+                                    "name": mcp_scope.get("mcp_project_name"),
+                                    "lifecycle": mcp_scope.get("mcp_project_lifecycle"),
+                                },
+                                "source": mcp_scope.get("mcp_project_source"),
+                            }
+                            yield f"data: {json.dumps(scope_evt)}\n\n"
+
+                        response_chunk = {
+                            "choices": [
+                                {
+                                    "delta": {
+                                        "role": "assistant",
+                                        "content": deterministic_response_content,
+                                    },
+                                    "finish_reason": "stop",
+                                }
+                            ]
+                        }
+                        yield f"data: {json.dumps(response_chunk)}\n\n"
+                        yield "data: [DONE]\n\n"
+
+                    headers = {
+                        "Cache-Control": "no-cache, no-transform",
+                        "X-Accel-Buffering": "no",
+                        "Connection": "keep-alive",
+                        "Content-Type": "text/event-stream",
+                    }
+                    return StreamingResponse(
+                        deterministic_stream_generator(),
+                        media_type="text/event-stream",
+                        headers=headers,
+                    )
+
+                return {
+                    "choices": [
+                        {
+                            "message": {
+                                "role": "assistant",
+                                "content": deterministic_response_content,
+                            },
+                            "finish_reason": "stop",
+                        }
+                    ],
+                    "conversation_id": conversation.id,
+                    "tooling_state": {
+                        **mcp_tooling_metadata,
+                        "tools_passed_count": len(resolved_tools),
+                    },
+                }
+
             # Handle streaming
             if request.stream:
                 async def stream_generator():
@@ -2099,6 +11559,8 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                         auto_continue_attempts = 0
                         truncated_at_least_once = False
                         stopped_by_guardrail: Optional[str] = None
+                        provider_call_latencies_ms: List[int] = []
+                        provider_timeout_count = 0
 
                         # Emit the conversation_id early so clients can persist context
                         try:
@@ -2140,10 +11602,29 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 print(f"Warning: failed to emit project_scope_selected event: {scope_evt_error}")
 
                         pass_index = 1
-                        loop_messages = list(combined_messages)
+                        loop_messages = _apply_digest_schedule_prompt(
+                            messages=list(combined_messages),
+                            config=digest_schedule_config,
+                            conversation_id=str(conversation.id),
+                            tooling_metadata=mcp_tooling_metadata,
+                            seen_event_ids=history_digest_schedule_event_ids,
+                        )
+                        loop_messages = _apply_pre_compaction_flush_prompt(
+                            messages=loop_messages,
+                            config=pre_compaction_flush_config,
+                            conversation_id=str(conversation.id),
+                            tooling_metadata=mcp_tooling_metadata,
+                            seen_event_ids=history_pre_compaction_event_ids,
+                        )
                         tool_loop_iterations = 0
                         tool_loop_stop_reason = "provider_final_response"
                         stream_executed_tool_calls: List[Dict[str, Any]] = []
+                        if approval_resume_context and approval_resume_context.get("action") == "approve":
+                            prior_tool_calls = approval_resume_context.get("prior_tool_calls")
+                            if isinstance(prior_tool_calls, list):
+                                stream_executed_tool_calls.extend(
+                                    dict(item) for item in prior_tool_calls if isinstance(item, dict)
+                                )
                         approval_request_payload: Optional[Dict[str, Any]] = None
                         approval_resolution_payload: Optional[Dict[str, Any]] = None
                         mcp_runtime_service = MCPRegistryService(
@@ -2181,10 +11662,28 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                             yield f"data: {json.dumps(reject_chunk)}\n\n"
                         elif approval_resume_context and approval_resume_context.get("action") == "approve":
                             resume_tool_name = str(approval_resume_context.get("tool") or "").strip()
+                            resume_synthetic_reason = (
+                                str(approval_resume_context.get("synthetic_reason") or "").strip()
+                                if isinstance(approval_resume_context, dict)
+                                else ""
+                            )
+                            resume_synthetic_reason = resume_synthetic_reason or None
                             resume_tool_arguments = (
                                 approval_resume_context.get("arguments")
                                 if isinstance(approval_resume_context.get("arguments"), dict)
                                 else {}
+                            )
+                            resume_tool_arguments = _normalize_capture_tool_arguments(
+                                conversation_type=effective_conversation_type,
+                                mcp_scope=mcp_scope,
+                                tool_name=resume_tool_name,
+                                tool_arguments=resume_tool_arguments,
+                            )
+                            resume_tool_arguments = _normalize_owner_profile_tool_arguments(
+                                latest_user_message=capture_intent_message_hint,
+                                tool_name=resume_tool_name,
+                                tool_arguments=resume_tool_arguments,
+                                synthetic_reason=resume_synthetic_reason,
                             )
                             resume_request_id = approval_resume_context.get("request_id")
                             resume_call_id = (
@@ -2226,15 +11725,53 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                         "arguments": resume_tool_arguments,
                                         "resumed": True,
                                     }
+                                    if resume_synthetic_reason:
+                                        resume_tool_evt["synthetic_reason"] = resume_synthetic_reason
                                     yield f"data: {json.dumps(resume_tool_evt)}\n\n"
                                 except Exception as resume_evt_error:
                                     print(f"Warning: failed to emit resumed tool_call event: {resume_evt_error}")
 
-                                execution = await mcp_runtime_service.execute_tool_call(
+                                resume_tool_record = await mcp_runtime_service.get_enabled_tool(
                                     user_id or "current",
                                     resume_tool_name,
-                                    resume_tool_arguments,
                                 )
+                                resume_guard_error = _capture_task_guard_error(
+                                    conversation_type=effective_conversation_type,
+                                    latest_user_message=capture_intent_message_hint,
+                                    tool_name=resume_tool_name,
+                                    executed_tool_calls=stream_executed_tool_calls,
+                                )
+                                if resume_guard_error:
+                                    execution = {
+                                        "ok": False,
+                                        "error": resume_guard_error,
+                                    }
+                                elif resume_tool_record is None:
+                                    execution = {
+                                        "ok": False,
+                                        "error": {
+                                            "code": "TOOL_NOT_ALLOWED",
+                                            "message": f"Tool '{resume_tool_name}' is not enabled.",
+                                        },
+                                    }
+                                else:
+                                    context_allowed, context_error = _validate_mutating_orchestration_context(
+                                        tool_name=resume_tool_name,
+                                        safety_class=resume_tool_record.safety_class,
+                                        orchestration_context=orchestration_context_payload,
+                                    )
+                                    if not context_allowed:
+                                        execution = {
+                                            "ok": False,
+                                            "error": context_error,
+                                        }
+                                        tool_loop_stop_reason = "missing_orchestration_context"
+                                    else:
+                                        execution = await mcp_runtime_service.execute_tool_call(
+                                            user_id or "current",
+                                            resume_tool_name,
+                                            resume_tool_arguments,
+                                        )
                                 if execution.get("ok"):
                                     tool_result_payload = execution.get("data", {})
                                     stream_executed_tool_calls.append(
@@ -2242,7 +11779,10 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                             "name": resume_tool_name,
                                             "status": "success",
                                             "latency_ms": execution.get("latency_ms"),
+                                            "arguments": resume_tool_arguments,
+                                            "result": tool_result_payload,
                                             "resumed": True,
+                                            "synthetic_reason": resume_synthetic_reason,
                                         }
                                     )
                                 else:
@@ -2250,21 +11790,35 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                         "ok": False,
                                         "error": execution.get("error"),
                                     }
+                                    execution_error = execution.get("error")
+                                    execution_error_code = (
+                                        str(execution_error.get("code") or "").strip()
+                                        if isinstance(execution_error, dict)
+                                        else ""
+                                    )
+                                    execution_status = (
+                                        "blocked_intent"
+                                        if execution_error_code.startswith("CAPTURE_TASK_")
+                                        else "error"
+                                    )
                                     stream_executed_tool_calls.append(
                                         {
                                             "name": resume_tool_name,
-                                            "status": "error",
+                                            "status": execution_status,
+                                            "arguments": resume_tool_arguments,
                                             "error": execution.get("error"),
                                             "resumed": True,
+                                            "synthetic_reason": resume_synthetic_reason,
                                         }
                                     )
 
                                 loop_messages.append(
-                                    {
-                                        "role": "tool",
-                                        "name": resume_tool_name,
-                                        "content": json.dumps(tool_result_payload, ensure_ascii=True),
-                                    }
+                                    _build_tool_result_message(
+                                        provider=request.provider,
+                                        tool_name=resume_tool_name,
+                                        tool_call_id=resume_call_id,
+                                        content=json.dumps(tool_result_payload, ensure_ascii=True),
+                                    )
                                 )
                                 tool_loop_iterations += 1
                                 try:
@@ -2290,49 +11844,87 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 )
 
                         while True:
-                            if tool_loop_stop_reason == "approval_rejected":
+                            if tool_loop_stop_reason in {"approval_rejected", "missing_orchestration_context"}:
                                 break
                             pass_text = ""
                             pass_finish_reason: Optional[str] = None
                             pass_tool_call_buffer: Dict[str, Dict[str, Any]] = {}
 
-                            logger.info(
+                            MODULE_LOGGER.info(
                                 "chat_stream_pass_start provider=%s model=%s conversation_id=%s pass=%s",
                                 request.provider,
                                 request.model,
                                 conversation.id,
                                 pass_index,
                             )
+                            pass_started_at = time.perf_counter()
+                            provider_pass_timed_out = False
+                            try:
+                                async for chunk in iter_provider_stream_with_timeout(
+                                    provider_instance.chat_completion_stream(
+                                        loop_messages,
+                                        request.model,
+                                        provider_params,
+                                    ),
+                                    timeout_seconds=mcp_provider_timeout_seconds,
+                                ):
+                                    if isinstance(chunk, dict) and "error" in chunk:
+                                        provider_error = chunk.get("error")
+                                        if isinstance(provider_error, bool):
+                                            provider_error = None
+                                        raise RuntimeError(
+                                            provider_error or chunk.get("message") or "Unknown provider error"
+                                        )
 
-                            async for chunk in provider_instance.chat_completion_stream(
-                                loop_messages,
-                                request.model,
-                                provider_params
-                            ):
-                                if isinstance(chunk, dict) and "error" in chunk:
-                                    raise RuntimeError(chunk.get("error") or chunk.get("message") or "Unknown provider error")
+                                    content = extract_chunk_content(chunk)
+                                    if content:
+                                        pass_text += content
+                                        full_response += content
 
-                                content = extract_chunk_content(chunk)
-                                if content:
-                                    pass_text += content
-                                    full_response += content
+                                    tool_deltas = extract_chunk_tool_call_deltas(chunk)
+                                    if tool_deltas:
+                                        update_stream_tool_call_buffer(pass_tool_call_buffer, tool_deltas)
 
-                                tool_deltas = extract_chunk_tool_call_deltas(chunk)
-                                if tool_deltas:
-                                    update_stream_tool_call_buffer(pass_tool_call_buffer, tool_deltas)
+                                    detected_finish_reason = extract_finish_reason(chunk)
+                                    if detected_finish_reason:
+                                        pass_finish_reason = detected_finish_reason
 
-                                detected_finish_reason = extract_finish_reason(chunk)
-                                if detected_finish_reason:
-                                    pass_finish_reason = detected_finish_reason
+                                    token_count += 1
 
-                                token_count += 1
+                                    # Yield each chunk and flush immediately
+                                    yield f"data: {json.dumps(chunk)}\n\n"
+                                    # Add an explicit flush marker
+                                    yield ""
+                            except asyncio.TimeoutError:
+                                provider_pass_timed_out = True
+                                provider_timeout_count += 1
+                                tool_loop_stop_reason = "provider_timeout"
+                                MODULE_LOGGER.warning(
+                                    "chat_stream_pass_timeout provider=%s model=%s conversation_id=%s pass=%s timeout=%s",
+                                    request.provider,
+                                    request.model,
+                                    conversation.id,
+                                    pass_index,
+                                    mcp_provider_timeout_seconds,
+                                )
+                            finally:
+                                provider_call_latencies_ms.append(
+                                    int((time.perf_counter() - pass_started_at) * 1000)
+                                )
 
-                                # Yield each chunk and flush immediately
-                                yield f"data: {json.dumps(chunk)}\n\n"
-                                # Add an explicit flush marker
-                                yield ""
+                            if provider_pass_timed_out:
+                                break
 
                             pass_tool_calls = finalize_stream_tool_calls(pass_tool_call_buffer)
+                            if resolved_tool_names and not pass_tool_calls:
+                                pass_tool_calls = _build_orchestration_followthrough_tool_calls(
+                                    conversation_type=effective_conversation_type,
+                                    latest_user_message=capture_intent_message_hint,
+                                    executed_tool_calls=stream_executed_tool_calls,
+                                    available_tool_names=resolved_tool_names,
+                                    mcp_scope=mcp_scope,
+                                    digest_schedule_config=digest_schedule_config,
+                                )
                             finish_reason_final = pass_finish_reason
                             finish_reason_history.append(pass_finish_reason or "unknown")
 
@@ -2342,7 +11934,7 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                             if is_truncated:
                                 truncated_at_least_once = True
 
-                            logger.info(
+                            MODULE_LOGGER.info(
                                 "chat_stream_pass_end provider=%s model=%s conversation_id=%s pass=%s finish_reason=%s chars=%s tool_calls=%s",
                                 request.provider,
                                 request.model,
@@ -2352,6 +11944,25 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 pass_chars,
                                 len(pass_tool_calls),
                             )
+
+                            normalized_pass_tool_calls: List[Dict[str, Any]] = []
+                            for call_index, call in enumerate(pass_tool_calls):
+                                if not isinstance(call, dict):
+                                    continue
+                                tool_name = call.get("name")
+                                if not isinstance(tool_name, str) or not tool_name.strip():
+                                    continue
+                                call_payload = dict(call)
+                                call_id = str(call_payload.get("id") or "").strip()
+                                if not call_id:
+                                    call_id = f"stream_tool_call_{pass_index}_{call_index + 1}"
+                                call_payload["id"] = call_id
+                                normalized_pass_tool_calls.append(call_payload)
+                            pass_tool_calls = normalized_pass_tool_calls
+                            if _is_strict_native_provider(request.provider) and len(pass_tool_calls) > 1:
+                                mcp_tooling_metadata["strict_native_tool_call_limit_applied"] = True
+                                mcp_tooling_metadata["strict_native_tool_call_limit_count"] = len(pass_tool_calls)
+                                pass_tool_calls = pass_tool_calls[:1]
 
                             if pass_tool_calls and resolved_tools:
                                 tool_loop_iterations += 1
@@ -2365,7 +11976,7 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                     "content": pass_text or "",
                                     "tool_calls": [
                                         {
-                                            "id": call.get("id"),
+                                            "id": call["id"],
                                             "type": "function",
                                             "function": {
                                                 "name": call["name"],
@@ -2379,11 +11990,75 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
 
                                 executed_any = False
                                 for tool_call in pass_tool_calls:
+                                    tool_call_id = str(tool_call.get("id") or "").strip()
+                                    if not tool_call_id:
+                                        tool_call_id = (
+                                            f"stream_tool_call_{pass_index}_{tool_call.get('name') or 'unknown'}"
+                                        )
                                     tool_name = tool_call["name"]
+                                    synthetic_reason = (
+                                        str(tool_call.get("reason") or "").strip()
+                                        if isinstance(tool_call, dict)
+                                        else ""
+                                    )
+                                    synthetic_reason = synthetic_reason or None
                                     tool_arguments = (
                                         tool_call.get("arguments")
                                         if isinstance(tool_call.get("arguments"), dict)
                                         else {}
+                                    )
+                                    tool_arguments = _normalize_capture_tool_arguments(
+                                        conversation_type=effective_conversation_type,
+                                        mcp_scope=mcp_scope,
+                                        tool_name=tool_name,
+                                        tool_arguments=tool_arguments,
+                                    )
+                                    (
+                                        tool_name,
+                                        tool_arguments,
+                                        synthetic_reason,
+                                    ) = _maybe_override_capture_provider_tool_call(
+                                        conversation_type=effective_conversation_type,
+                                        latest_user_message=capture_intent_message_hint,
+                                        tool_name=tool_name,
+                                        tool_arguments=tool_arguments,
+                                        synthetic_reason=synthetic_reason,
+                                        executed_tool_calls=stream_executed_tool_calls,
+                                        available_tool_names=resolved_tool_names,
+                                    )
+                                    (
+                                        tool_name,
+                                        tool_arguments,
+                                        synthetic_reason,
+                                    ) = _maybe_override_new_page_provider_tool_call(
+                                        conversation_type=effective_conversation_type,
+                                        latest_user_message=capture_intent_message_hint,
+                                        tool_name=tool_name,
+                                        tool_arguments=tool_arguments,
+                                        synthetic_reason=synthetic_reason,
+                                        executed_tool_calls=stream_executed_tool_calls,
+                                        available_tool_names=resolved_tool_names,
+                                        mcp_scope=mcp_scope,
+                                    )
+                                    (
+                                        tool_name,
+                                        tool_arguments,
+                                        synthetic_reason,
+                                    ) = _maybe_override_compound_edit_provider_tool_call(
+                                        conversation_type=effective_conversation_type,
+                                        latest_user_message=capture_intent_message_hint,
+                                        tool_name=tool_name,
+                                        tool_arguments=tool_arguments,
+                                        synthetic_reason=synthetic_reason,
+                                        executed_tool_calls=stream_executed_tool_calls,
+                                        available_tool_names=resolved_tool_names,
+                                        mcp_scope=mcp_scope,
+                                    )
+                                    tool_arguments = _normalize_owner_profile_tool_arguments(
+                                        latest_user_message=capture_intent_message_hint,
+                                        tool_name=tool_name,
+                                        tool_arguments=tool_arguments,
+                                        synthetic_reason=synthetic_reason,
                                     )
                                     try:
                                         tool_call_event = {
@@ -2395,6 +12070,50 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                     except Exception as tool_call_evt_error:
                                         print(f"Warning: failed to emit tool_call event: {tool_call_evt_error}")
 
+                                    guard_error = _capture_task_guard_error(
+                                        conversation_type=effective_conversation_type,
+                                        latest_user_message=capture_intent_message_hint,
+                                        tool_name=tool_name,
+                                        executed_tool_calls=stream_executed_tool_calls,
+                                    )
+                                    if guard_error:
+                                        error_payload = {
+                                            "ok": False,
+                                            "error": guard_error,
+                                        }
+                                        loop_messages.append(
+                                            _build_tool_result_message(
+                                                provider=request.provider,
+                                                tool_name=tool_name,
+                                                tool_call_id=tool_call_id,
+                                                content=json.dumps(error_payload, ensure_ascii=True),
+                                            )
+                                        )
+                                        stream_executed_tool_calls.append(
+                                            {
+                                                "id": tool_call_id,
+                                                "name": tool_name,
+                                                "status": "blocked_intent",
+                                                "arguments": tool_arguments,
+                                                "error": guard_error,
+                                                "synthetic_reason": synthetic_reason,
+                                            }
+                                        )
+                                        try:
+                                            tool_result_event = {
+                                                "type": "tool_result",
+                                                "name": tool_name,
+                                                "ok": False,
+                                                "error": guard_error,
+                                            }
+                                            yield f"data: {json.dumps(tool_result_event)}\n\n"
+                                        except Exception as tool_result_evt_error:
+                                            print(
+                                                "Warning: failed to emit blocked tool_result event: "
+                                                f"{tool_result_evt_error}"
+                                            )
+                                        continue
+
                                     tool_record = await mcp_runtime_service.get_enabled_tool(user_id or "current", tool_name)
                                     if tool_record is None:
                                         tool_error = {
@@ -2405,32 +12124,87 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                             },
                                         }
                                         loop_messages.append(
-                                            {
-                                                "role": "tool",
-                                                "name": tool_name,
-                                                "content": json.dumps(tool_error, ensure_ascii=True),
-                                            }
+                                            _build_tool_result_message(
+                                                provider=request.provider,
+                                                tool_name=tool_name,
+                                                tool_call_id=tool_call_id,
+                                                content=json.dumps(tool_error, ensure_ascii=True),
+                                            )
                                         )
                                         stream_executed_tool_calls.append(
                                             {
+                                                "id": tool_call_id,
                                                 "name": tool_name,
                                                 "status": "denied",
+                                                "arguments": tool_arguments,
                                                 "reason": "tool_not_enabled",
+                                                "synthetic_reason": synthetic_reason,
                                             }
                                         )
                                         continue
 
+                                    context_allowed, context_error = _validate_mutating_orchestration_context(
+                                        tool_name=tool_name,
+                                        safety_class=tool_record.safety_class,
+                                        orchestration_context=orchestration_context_payload,
+                                    )
+                                    if not context_allowed:
+                                        tool_error = {
+                                            "ok": False,
+                                            "error": context_error,
+                                        }
+                                        loop_messages.append(
+                                            _build_tool_result_message(
+                                                provider=request.provider,
+                                                tool_name=tool_name,
+                                                tool_call_id=tool_call_id,
+                                                content=json.dumps(tool_error, ensure_ascii=True),
+                                            )
+                                        )
+                                        stream_executed_tool_calls.append(
+                                            {
+                                                "id": tool_call_id,
+                                                "name": tool_name,
+                                                "status": "blocked_context",
+                                                "arguments": tool_arguments,
+                                                "error": context_error,
+                                                "synthetic_reason": synthetic_reason,
+                                            }
+                                        )
+                                        tool_loop_stop_reason = "missing_orchestration_context"
+                                        try:
+                                            context_evt = {
+                                                "type": "orchestration_context_error",
+                                                "tool": tool_name,
+                                                "error": context_error,
+                                            }
+                                            yield f"data: {json.dumps(context_evt)}\n\n"
+                                        except Exception as context_evt_error:
+                                            print(f"Warning: failed to emit orchestration_context_error event: {context_evt_error}")
+                                        break
+
                                     if (
                                         tool_record.safety_class == "mutating"
-                                        and not mcp_auto_approve_mutating
                                         and tool_name not in approved_mutating_tools
                                     ):
+                                        approval_context = await _build_mutating_approval_context(
+                                            runtime_service=mcp_runtime_service,
+                                            mcp_user_id=user_id or "current",
+                                            tool_name=tool_name,
+                                            tool_arguments=tool_arguments,
+                                        )
                                         approval_request_payload = _build_approval_request_payload(
                                             tool=tool_name,
                                             safety_class=tool_record.safety_class,
                                             arguments=tool_arguments,
+                                            summary=approval_context.get("summary"),
                                             scope=mcp_scope,
+                                            synthetic_reason=synthetic_reason,
+                                            origin_user_message=capture_intent_message_hint,
                                         )
+                                        approval_preview = approval_context.get("preview")
+                                        if isinstance(approval_preview, dict):
+                                            approval_request_payload["preview"] = approval_preview
                                         tool_loop_stop_reason = "approval_required"
                                         try:
                                             yield f"data: {json.dumps(approval_request_payload)}\n\n"
@@ -2448,9 +12222,13 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                         tool_result_payload = execution.get("data", {})
                                         stream_executed_tool_calls.append(
                                             {
+                                                "id": tool_call_id,
                                                 "name": tool_name,
                                                 "status": "success",
                                                 "latency_ms": execution.get("latency_ms"),
+                                                "arguments": tool_arguments,
+                                                "result": tool_result_payload,
+                                                "synthetic_reason": synthetic_reason,
                                             }
                                         )
                                     else:
@@ -2460,18 +12238,22 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                         }
                                         stream_executed_tool_calls.append(
                                             {
+                                                "id": tool_call_id,
                                                 "name": tool_name,
                                                 "status": "error",
+                                                "arguments": tool_arguments,
                                                 "error": execution.get("error"),
+                                                "synthetic_reason": synthetic_reason,
                                             }
                                         )
 
                                     loop_messages.append(
-                                        {
-                                            "role": "tool",
-                                            "name": tool_name,
-                                            "content": json.dumps(tool_result_payload, ensure_ascii=True),
-                                        }
+                                        _build_tool_result_message(
+                                            provider=request.provider,
+                                            tool_name=tool_name,
+                                            tool_call_id=tool_call_id,
+                                            content=json.dumps(tool_result_payload, ensure_ascii=True),
+                                        )
                                     )
                                     try:
                                         tool_result_event = {
@@ -2486,9 +12268,11 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 if approval_request_payload:
                                     break
 
+                                if tool_loop_stop_reason == "missing_orchestration_context":
+                                    break
+
                                 if not executed_any:
                                     tool_loop_stop_reason = "tool_calls_without_execution"
-
                                 pass_index += 1
                                 continue
 
@@ -2540,10 +12324,116 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 stopped_by_guardrail = "max_passes_reached"
 
                             break
+
+                        if not full_response.strip():
+                            fallback_response: Optional[str] = None
+                            fallback_finish_reason = finish_reason_final or "stop"
+
+                            if approval_request_payload:
+                                fallback_response = APPROVAL_REQUIRED_RESPONSE_TEXT
+                                fallback_finish_reason = "tool_calls"
+                            elif (
+                                isinstance(approval_resolution_payload, dict)
+                                and str(approval_resolution_payload.get("status") or "").strip().lower()
+                                == "approved"
+                            ):
+                                fallback_response = _build_approval_execution_success_message(
+                                    executed_tool_calls=stream_executed_tool_calls,
+                                    approval_resolution_payload=approval_resolution_payload,
+                                )
+                                fallback_finish_reason = "stop"
+                            elif tool_loop_stop_reason == "tool_calls_without_enabled_tools":
+                                fallback_response = (
+                                    "I requested a tool action, but tools are not enabled in this context. "
+                                    "Please try again from a tool-enabled project chat."
+                                )
+                            elif tool_loop_stop_reason == "tool_calls_without_execution":
+                                fallback_response = (
+                                    "I requested a tool action, but it could not be executed. "
+                                    "Please try again or rephrase your request."
+                                )
+                            elif tool_loop_stop_reason == "missing_orchestration_context":
+                                fallback_response = (
+                                    "I need canonical scope context before I can run mutating tools. "
+                                    "Please run scaffold/bootstrap steps or let me create missing required files first."
+                                )
+                            elif tool_loop_stop_reason == "max_tool_iterations_exceeded":
+                                fallback_response = "Tool execution stopped after reaching max iterations."
+                                fallback_finish_reason = "length"
+                            elif tool_loop_stop_reason == "provider_timeout":
+                                fallback_response = _provider_timeout_fallback_response(
+                                    effective_conversation_type
+                                )
+                                fallback_finish_reason = "stop"
+
+                            if fallback_response:
+                                full_response = fallback_response
+                                finish_reason_final = fallback_finish_reason
+                                if (
+                                    not finish_reason_history
+                                    or finish_reason_history[-1] != fallback_finish_reason
+                                ):
+                                    finish_reason_history.append(fallback_finish_reason)
+                                token_count += max(1, len(fallback_response.split()))
+
+                                fallback_chunk = {
+                                    "choices": [
+                                        {
+                                            "delta": {
+                                                "role": "assistant",
+                                                "content": fallback_response,
+                                            },
+                                            "finish_reason": fallback_finish_reason,
+                                        }
+                                    ]
+                                }
+                                yield f"data: {json.dumps(fallback_chunk)}\n\n"
+
+                        (
+                            full_response,
+                            citation_suffix,
+                            citation_paths,
+                            citation_appended,
+                        ) = _apply_grounding_citations_if_needed(
+                            response_content=full_response,
+                            executed_tool_calls=stream_executed_tool_calls,
+                            latest_user_message=capture_intent_message_hint,
+                            tool_loop_stop_reason=tool_loop_stop_reason,
+                            default_scope_path=(
+                                mcp_scope.get("mcp_project_slug")
+                                if isinstance(mcp_scope, dict)
+                                else None
+                            ),
+                        )
+                        if citation_appended and citation_suffix:
+                            token_count += max(1, len(citation_suffix.split()))
+                            citation_chunk = {
+                                "choices": [
+                                    {
+                                        "delta": {
+                                            "role": "assistant",
+                                            "content": citation_suffix,
+                                        },
+                                        "finish_reason": None,
+                                    }
+                                ]
+                            }
+                            yield f"data: {json.dumps(citation_chunk)}\n\n"
                         
                         # Calculate tokens per second
                         elapsed_time = time.time() - start_time
                         tokens_per_second = token_count / elapsed_time if elapsed_time > 0 else 0
+
+                        _finalize_pre_compaction_flush_status(
+                            tooling_metadata=mcp_tooling_metadata,
+                            tool_loop_stop_reason=tool_loop_stop_reason,
+                            tool_calls_executed_count=len(stream_executed_tool_calls),
+                        )
+                        _finalize_digest_schedule_status(
+                            tooling_metadata=mcp_tooling_metadata,
+                            tool_loop_stop_reason=tool_loop_stop_reason,
+                            tool_calls_executed_count=len(stream_executed_tool_calls),
+                        )
                         
                         mcp_tooling_metadata.update(
                             {
@@ -2553,8 +12443,44 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 "tool_calls_executed_count": len(stream_executed_tool_calls),
                                 "approval_required": bool(approval_request_payload),
                                 "approval_resolved": bool(approval_resolution_payload),
+                                **_build_provider_timing_metadata(
+                                    provider_timeout_seconds=mcp_provider_timeout_seconds,
+                                    provider_call_latencies_ms=provider_call_latencies_ms,
+                                    provider_timeout_count=provider_timeout_count,
+                                ),
                             }
                         )
+                        if citation_paths:
+                            mcp_tooling_metadata["response_citations"] = citation_paths
+                            mcp_tooling_metadata["response_citations_appended"] = citation_appended
+
+                        delivery_handoff_payload = _build_digest_delivery_handoff_payload(
+                            conversation_type=effective_conversation_type,
+                            response_content=full_response,
+                            conversation_id=str(conversation.id),
+                            provider=request.provider,
+                            model=request.model,
+                            digest_schedule_config=digest_schedule_config,
+                            tooling_metadata=mcp_tooling_metadata,
+                        )
+                        if isinstance(delivery_handoff_payload, dict):
+                            delivery_handoff_payload = await _attach_digest_delivery_delivery_state(
+                                handoff_payload=delivery_handoff_payload,
+                                user_id=user_id,
+                                tooling_metadata=mcp_tooling_metadata,
+                                send_config=digest_delivery_send_config,
+                            )
+                            mcp_tooling_metadata["digest_delivery_handoff"] = delivery_handoff_payload
+                            try:
+                                handoff_evt = {
+                                    "type": "delivery_handoff",
+                                    **delivery_handoff_payload,
+                                }
+                                yield f"data: {json.dumps(handoff_evt)}\n\n"
+                            except Exception as handoff_evt_error:
+                                print(
+                                    f"Warning: failed to emit delivery_handoff event: {handoff_evt_error}"
+                                )
 
                         # Store the LLM response in the database with persona metadata
                         message_metadata = {
@@ -2650,14 +12576,36 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
             for i, msg in enumerate(combined_messages):
                 print(f"  Message {i+1}: role={msg.get('role', 'unknown')}, content={msg.get('content', '')[:50]}...")
 
-            loop_messages = list(combined_messages)
+            loop_messages = _apply_digest_schedule_prompt(
+                messages=list(combined_messages),
+                config=digest_schedule_config,
+                conversation_id=str(conversation.id),
+                tooling_metadata=mcp_tooling_metadata,
+                seen_event_ids=history_digest_schedule_event_ids,
+            )
+            loop_messages = _apply_pre_compaction_flush_prompt(
+                messages=loop_messages,
+                config=pre_compaction_flush_config,
+                conversation_id=str(conversation.id),
+                tooling_metadata=mcp_tooling_metadata,
+                seen_event_ids=history_pre_compaction_event_ids,
+            )
             tool_loop_enabled = bool(resolved_tools)
             tool_loop_iterations = 0
             tool_loop_stop_reason = "provider_final_response"
             approval_request_payload: Optional[Dict[str, Any]] = None
             approval_resolution_payload: Optional[Dict[str, Any]] = None
             executed_tool_calls: List[Dict[str, Any]] = []
+            if approval_resume_context and approval_resume_context.get("action") == "approve":
+                prior_tool_calls = approval_resume_context.get("prior_tool_calls")
+                if isinstance(prior_tool_calls, list):
+                    executed_tool_calls.extend(
+                        dict(item) for item in prior_tool_calls if isinstance(item, dict)
+                    )
             result: Dict[str, Any] = {}
+            provider_call_latencies_ms: List[int] = []
+            provider_timeout_count = 0
+            forced_tool_calls: List[Dict[str, Any]] = []
 
             mcp_runtime_service = MCPRegistryService(
                 db,
@@ -2689,10 +12637,28 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
             else:
                 if approval_resume_context and approval_resume_context.get("action") == "approve":
                     resume_tool_name = str(approval_resume_context.get("tool") or "").strip()
+                    resume_synthetic_reason = (
+                        str(approval_resume_context.get("synthetic_reason") or "").strip()
+                        if isinstance(approval_resume_context, dict)
+                        else ""
+                    )
+                    resume_synthetic_reason = resume_synthetic_reason or None
                     resume_tool_arguments = (
                         approval_resume_context.get("arguments")
                         if isinstance(approval_resume_context.get("arguments"), dict)
                         else {}
+                    )
+                    resume_tool_arguments = _normalize_capture_tool_arguments(
+                        conversation_type=effective_conversation_type,
+                        mcp_scope=mcp_scope,
+                        tool_name=resume_tool_name,
+                        tool_arguments=resume_tool_arguments,
+                    )
+                    resume_tool_arguments = _normalize_owner_profile_tool_arguments(
+                        latest_user_message=capture_intent_message_hint,
+                        tool_name=resume_tool_name,
+                        tool_arguments=resume_tool_arguments,
+                        synthetic_reason=resume_synthetic_reason,
                     )
                     resume_request_id = approval_resume_context.get("request_id")
                     resume_call_id = (
@@ -2728,11 +12694,47 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 ],
                             }
                         )
-                        execution = await mcp_runtime_service.execute_tool_call(
+                        resume_tool_record = await mcp_runtime_service.get_enabled_tool(
                             user_id or "current",
                             resume_tool_name,
-                            resume_tool_arguments,
                         )
+                        resume_guard_error = _capture_task_guard_error(
+                            conversation_type=effective_conversation_type,
+                            latest_user_message=capture_intent_message_hint,
+                            tool_name=resume_tool_name,
+                            executed_tool_calls=executed_tool_calls,
+                        )
+                        if resume_guard_error:
+                            execution = {
+                                "ok": False,
+                                "error": resume_guard_error,
+                            }
+                        elif resume_tool_record is None:
+                            execution = {
+                                "ok": False,
+                                "error": {
+                                    "code": "TOOL_NOT_ALLOWED",
+                                    "message": f"Tool '{resume_tool_name}' is not enabled.",
+                                },
+                            }
+                        else:
+                            context_allowed, context_error = _validate_mutating_orchestration_context(
+                                tool_name=resume_tool_name,
+                                safety_class=resume_tool_record.safety_class,
+                                orchestration_context=orchestration_context_payload,
+                            )
+                            if not context_allowed:
+                                execution = {
+                                    "ok": False,
+                                    "error": context_error,
+                                }
+                                tool_loop_stop_reason = "missing_orchestration_context"
+                            else:
+                                execution = await mcp_runtime_service.execute_tool_call(
+                                    user_id or "current",
+                                    resume_tool_name,
+                                    resume_tool_arguments,
+                                )
                         if execution.get("ok"):
                             tool_content = execution.get("data", {})
                             executed_tool_calls.append(
@@ -2740,7 +12742,10 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                     "name": resume_tool_name,
                                     "status": "success",
                                     "latency_ms": execution.get("latency_ms"),
+                                    "arguments": resume_tool_arguments,
+                                    "result": tool_content,
                                     "resumed": True,
+                                    "synthetic_reason": resume_synthetic_reason,
                                 }
                             )
                         else:
@@ -2748,38 +12753,121 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 "ok": False,
                                 "error": execution.get("error"),
                             }
+                            execution_error = execution.get("error")
+                            execution_error_code = (
+                                str(execution_error.get("code") or "").strip()
+                                if isinstance(execution_error, dict)
+                                else ""
+                            )
+                            execution_status = (
+                                "blocked_intent"
+                                if execution_error_code.startswith("CAPTURE_TASK_")
+                                else "error"
+                            )
                             executed_tool_calls.append(
                                 {
                                     "name": resume_tool_name,
-                                    "status": "error",
+                                    "status": execution_status,
+                                    "arguments": resume_tool_arguments,
                                     "error": execution.get("error"),
                                     "resumed": True,
+                                    "synthetic_reason": resume_synthetic_reason,
                                 }
                             )
 
                         loop_messages.append(
-                            {
-                                "role": "tool",
-                                "name": resume_tool_name,
-                                "content": json.dumps(tool_content, ensure_ascii=True),
-                            }
+                            _build_tool_result_message(
+                                provider=request.provider,
+                                tool_name=resume_tool_name,
+                                tool_call_id=resume_call_id,
+                                content=json.dumps(tool_content, ensure_ascii=True),
+                            )
                         )
                         tool_loop_iterations += 1
+                        if execution.get("ok"):
+                            forced_tool_calls = _build_orchestration_followthrough_tool_calls(
+                                conversation_type=effective_conversation_type,
+                                latest_user_message=capture_intent_message_hint,
+                                executed_tool_calls=executed_tool_calls,
+                                available_tool_names=resolved_tool_names,
+                                mcp_scope=mcp_scope,
+                                digest_schedule_config=digest_schedule_config,
+                            )
 
                 for iteration in range(1, mcp_max_tool_iterations + 1):
-                    tool_loop_iterations = iteration
-                    result = await provider_instance.chat_completion(
-                        loop_messages,
-                        request.model,
-                        provider_params,
-                    )
-                    if isinstance(result, dict) and result.get("error"):
-                        raise HTTPException(
-                            status_code=502,
-                            detail=f"Provider error: {result.get('error') or result.get('message')}",
-                        )
+                    if tool_loop_stop_reason == "missing_orchestration_context":
+                        break
 
-                    tool_calls = extract_response_tool_calls(result)
+                    tool_loop_iterations = iteration
+                    if forced_tool_calls:
+                        result = {}
+                        tool_calls = forced_tool_calls
+                        forced_tool_calls = []
+                    else:
+                        provider_call_started_at = time.perf_counter()
+                        try:
+                            result = await asyncio.wait_for(
+                                provider_instance.chat_completion(
+                                    loop_messages,
+                                    request.model,
+                                    provider_params,
+                                ),
+                                timeout=mcp_provider_timeout_seconds,
+                            )
+                        except asyncio.TimeoutError:
+                            provider_timeout_count += 1
+                            tool_loop_stop_reason = "provider_timeout"
+                            MODULE_LOGGER.warning(
+                                "chat_non_stream_timeout provider=%s model=%s conversation_id=%s iteration=%s timeout=%s",
+                                request.provider,
+                                request.model,
+                                conversation.id,
+                                iteration,
+                                mcp_provider_timeout_seconds,
+                            )
+                            result = {}
+                            break
+                        finally:
+                            provider_call_latencies_ms.append(
+                                int((time.perf_counter() - provider_call_started_at) * 1000)
+                            )
+                        if isinstance(result, dict) and result.get("error"):
+                            error_value = result.get("error")
+                            message_value = result.get("message")
+                            error_detail = message_value if isinstance(message_value, str) and message_value.strip() else error_value
+                            raise HTTPException(
+                                status_code=502,
+                                detail=f"Provider error: {error_detail}",
+                            )
+
+                        tool_calls = extract_response_tool_calls(result)
+                        if tool_loop_enabled and not tool_calls:
+                            tool_calls = _build_orchestration_followthrough_tool_calls(
+                                conversation_type=effective_conversation_type,
+                                latest_user_message=capture_intent_message_hint,
+                                executed_tool_calls=executed_tool_calls,
+                                available_tool_names=resolved_tool_names,
+                                mcp_scope=mcp_scope,
+                                digest_schedule_config=digest_schedule_config,
+                            )
+                        normalized_tool_calls: List[Dict[str, Any]] = []
+                        for call_index, call in enumerate(tool_calls):
+                            if not isinstance(call, dict):
+                                continue
+                            tool_name = call.get("name")
+                            if not isinstance(tool_name, str) or not tool_name.strip():
+                                continue
+                            call_payload = dict(call)
+                            call_id = str(call_payload.get("id") or "").strip()
+                            if not call_id:
+                                call_id = f"tool_call_{iteration}_{call_index + 1}"
+                            call_payload["id"] = call_id
+                            normalized_tool_calls.append(call_payload)
+                        tool_calls = normalized_tool_calls
+                        if _is_strict_native_provider(request.provider) and len(tool_calls) > 1:
+                            mcp_tooling_metadata["strict_native_tool_call_limit_applied"] = True
+                            mcp_tooling_metadata["strict_native_tool_call_limit_count"] = len(tool_calls)
+                            tool_calls = tool_calls[:1]
                     if not tool_loop_enabled or not tool_calls:
                         tool_loop_stop_reason = (
                             "provider_final_response" if not tool_calls else "tools_disabled"
@@ -2793,7 +12881,7 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     }
                     assistant_payload["tool_calls"] = [
                         {
-                            "id": call.get("id"),
+                            "id": call["id"],
                             "type": "function",
                             "function": {
                                 "name": call["name"],
@@ -2806,12 +12894,104 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
 
                     executed_in_iteration = False
                     for tool_call in tool_calls:
+                        tool_call_id = str(tool_call.get("id") or "").strip()
+                        if not tool_call_id:
+                            tool_call_id = f"tool_call_{iteration}_{tool_call.get('name') or 'unknown'}"
                         tool_name = tool_call["name"]
+                        synthetic_reason = (
+                            str(tool_call.get("reason") or "").strip()
+                            if isinstance(tool_call, dict)
+                            else ""
+                        )
+                        synthetic_reason = synthetic_reason or None
                         tool_arguments = (
                             tool_call.get("arguments")
                             if isinstance(tool_call.get("arguments"), dict)
                             else {}
                         )
+                        tool_arguments = _normalize_capture_tool_arguments(
+                            conversation_type=effective_conversation_type,
+                            mcp_scope=mcp_scope,
+                            tool_name=tool_name,
+                            tool_arguments=tool_arguments,
+                        )
+                        (
+                            tool_name,
+                            tool_arguments,
+                            synthetic_reason,
+                        ) = _maybe_override_capture_provider_tool_call(
+                            conversation_type=effective_conversation_type,
+                            latest_user_message=capture_intent_message_hint,
+                            tool_name=tool_name,
+                            tool_arguments=tool_arguments,
+                            synthetic_reason=synthetic_reason,
+                            executed_tool_calls=executed_tool_calls,
+                            available_tool_names=resolved_tool_names,
+                        )
+                        (
+                            tool_name,
+                            tool_arguments,
+                            synthetic_reason,
+                        ) = _maybe_override_new_page_provider_tool_call(
+                            conversation_type=effective_conversation_type,
+                            latest_user_message=capture_intent_message_hint,
+                            tool_name=tool_name,
+                            tool_arguments=tool_arguments,
+                            synthetic_reason=synthetic_reason,
+                            executed_tool_calls=executed_tool_calls,
+                            available_tool_names=resolved_tool_names,
+                            mcp_scope=mcp_scope,
+                        )
+                        (
+                            tool_name,
+                            tool_arguments,
+                            synthetic_reason,
+                        ) = _maybe_override_compound_edit_provider_tool_call(
+                            conversation_type=effective_conversation_type,
+                            latest_user_message=capture_intent_message_hint,
+                            tool_name=tool_name,
+                            tool_arguments=tool_arguments,
+                            synthetic_reason=synthetic_reason,
+                            executed_tool_calls=executed_tool_calls,
+                            available_tool_names=resolved_tool_names,
+                            mcp_scope=mcp_scope,
+                        )
+                        tool_arguments = _normalize_owner_profile_tool_arguments(
+                            latest_user_message=capture_intent_message_hint,
+                            tool_name=tool_name,
+                            tool_arguments=tool_arguments,
+                            synthetic_reason=synthetic_reason,
+                        )
+                        guard_error = _capture_task_guard_error(
+                            conversation_type=effective_conversation_type,
+                            latest_user_message=capture_intent_message_hint,
+                            tool_name=tool_name,
+                            executed_tool_calls=executed_tool_calls,
+                        )
+                        if guard_error:
+                            error_payload = {
+                                "ok": False,
+                                "error": guard_error,
+                            }
+                            loop_messages.append(
+                                _build_tool_result_message(
+                                    provider=request.provider,
+                                    tool_name=tool_name,
+                                    tool_call_id=tool_call_id,
+                                    content=json.dumps(error_payload, ensure_ascii=True),
+                                )
+                            )
+                            executed_tool_calls.append(
+                                {
+                                    "id": tool_call_id,
+                                    "name": tool_name,
+                                    "status": "blocked_intent",
+                                    "arguments": tool_arguments,
+                                    "error": guard_error,
+                                    "synthetic_reason": synthetic_reason,
+                                }
+                            )
+                            continue
                         tool_record = await mcp_runtime_service.get_enabled_tool(user_id or "current", tool_name)
                         if tool_record is None:
                             error_payload = {
@@ -2822,32 +13002,78 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                                 },
                             }
                             loop_messages.append(
-                                {
-                                    "role": "tool",
-                                    "name": tool_name,
-                                    "content": json.dumps(error_payload, ensure_ascii=True),
-                                }
+                                _build_tool_result_message(
+                                    provider=request.provider,
+                                    tool_name=tool_name,
+                                    tool_call_id=tool_call_id,
+                                    content=json.dumps(error_payload, ensure_ascii=True),
+                                )
                             )
                             executed_tool_calls.append(
                                 {
+                                    "id": tool_call_id,
                                     "name": tool_name,
                                     "status": "denied",
+                                    "arguments": tool_arguments,
                                     "reason": "tool_not_enabled",
+                                    "synthetic_reason": synthetic_reason,
                                 }
                             )
                             continue
 
+                        context_allowed, context_error = _validate_mutating_orchestration_context(
+                            tool_name=tool_name,
+                            safety_class=tool_record.safety_class,
+                            orchestration_context=orchestration_context_payload,
+                        )
+                        if not context_allowed:
+                            error_payload = {
+                                "ok": False,
+                                "error": context_error,
+                            }
+                            loop_messages.append(
+                                _build_tool_result_message(
+                                    provider=request.provider,
+                                    tool_name=tool_name,
+                                    tool_call_id=tool_call_id,
+                                    content=json.dumps(error_payload, ensure_ascii=True),
+                                )
+                            )
+                            executed_tool_calls.append(
+                                {
+                                    "id": tool_call_id,
+                                    "name": tool_name,
+                                    "status": "blocked_context",
+                                    "arguments": tool_arguments,
+                                    "error": context_error,
+                                    "synthetic_reason": synthetic_reason,
+                                }
+                            )
+                            tool_loop_stop_reason = "missing_orchestration_context"
+                            break
+
                         if (
                             tool_record.safety_class == "mutating"
-                            and not mcp_auto_approve_mutating
                             and tool_name not in approved_mutating_tools
                         ):
+                            approval_context = await _build_mutating_approval_context(
+                                runtime_service=mcp_runtime_service,
+                                mcp_user_id=user_id or "current",
+                                tool_name=tool_name,
+                                tool_arguments=tool_arguments,
+                            )
                             approval_request_payload = _build_approval_request_payload(
                                 tool=tool_name,
                                 safety_class=tool_record.safety_class,
                                 arguments=tool_arguments,
+                                summary=approval_context.get("summary"),
                                 scope=mcp_scope,
+                                synthetic_reason=synthetic_reason,
+                                origin_user_message=capture_intent_message_hint,
                             )
+                            approval_preview = approval_context.get("preview")
+                            if isinstance(approval_preview, dict):
+                                approval_request_payload["preview"] = approval_preview
                             tool_loop_stop_reason = "approval_required"
                             break
 
@@ -2860,9 +13086,13 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                             tool_content = execution.get("data", {})
                             executed_tool_calls.append(
                                 {
+                                    "id": tool_call_id,
                                     "name": tool_name,
                                     "status": "success",
                                     "latency_ms": execution.get("latency_ms"),
+                                    "arguments": tool_arguments,
+                                    "result": tool_content,
+                                    "synthetic_reason": synthetic_reason,
                                 }
                             )
                         else:
@@ -2872,32 +13102,52 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                             }
                             executed_tool_calls.append(
                                 {
+                                    "id": tool_call_id,
                                     "name": tool_name,
                                     "status": "error",
+                                    "arguments": tool_arguments,
                                     "error": execution.get("error"),
+                                    "synthetic_reason": synthetic_reason,
                                 }
                             )
 
                         loop_messages.append(
-                            {
-                                "role": "tool",
-                                "name": tool_name,
-                                "content": json.dumps(tool_content, ensure_ascii=True),
-                            }
+                            _build_tool_result_message(
+                                provider=request.provider,
+                                tool_name=tool_name,
+                                tool_call_id=tool_call_id,
+                                content=json.dumps(tool_content, ensure_ascii=True),
+                            )
                         )
                         executed_in_iteration = True
 
                     if approval_request_payload:
                         break
 
+                    if tool_loop_stop_reason == "missing_orchestration_context":
+                        break
+
                     if not executed_in_iteration:
                         # Tool calls were returned but none could execute; feed tool errors back in next pass.
+                        continue
+
+                    forced_tool_calls = _build_orchestration_followthrough_tool_calls(
+                        conversation_type=effective_conversation_type,
+                        latest_user_message=capture_intent_message_hint,
+                        executed_tool_calls=executed_tool_calls,
+                        available_tool_names=resolved_tool_names,
+                        mcp_scope=mcp_scope,
+                        digest_schedule_config=digest_schedule_config,
+                    )
+                    if forced_tool_calls:
+                        # Preserve deterministic synthetic chains (capture/digest/cross-pollination)
+                        # before handing control back to the provider model.
                         continue
                 else:
                     tool_loop_stop_reason = "max_tool_iterations_exceeded"
 
             if approval_request_payload:
-                response_content = "Approval required before executing mutating tool call."
+                response_content = APPROVAL_REQUIRED_RESPONSE_TEXT
                 result = {
                     "choices": [
                         {
@@ -2929,7 +13179,36 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 }
             else:
                 response_content = extract_response_content(result)
-                if not response_content and tool_loop_stop_reason == "max_tool_iterations_exceeded":
+                if (
+                    not response_content
+                    and isinstance(approval_resolution_payload, dict)
+                    and str(approval_resolution_payload.get("status") or "").strip().lower()
+                    == "approved"
+                ):
+                    approval_success_message = _build_approval_execution_success_message(
+                        executed_tool_calls=executed_tool_calls,
+                        approval_resolution_payload=approval_resolution_payload,
+                    )
+                    if approval_success_message:
+                        response_content = approval_success_message
+                        result = _set_result_primary_content(result, response_content)
+                elif not response_content and tool_loop_stop_reason == "missing_orchestration_context":
+                    response_content = (
+                        "I need canonical scope context before I can run mutating tools. "
+                        "Please run scaffold/bootstrap steps or let me create missing required files first."
+                    )
+                    result = result or {
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": response_content,
+                                },
+                                "finish_reason": "tool_calls",
+                            }
+                        ]
+                    }
+                elif not response_content and tool_loop_stop_reason == "max_tool_iterations_exceeded":
                     response_content = "Tool execution stopped after reaching max iterations."
                     result = result or {
                         "choices": [
@@ -2942,7 +13221,51 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                             }
                         ]
                     }
+                elif not response_content and tool_loop_stop_reason == "provider_timeout":
+                    response_content = _provider_timeout_fallback_response(
+                        effective_conversation_type
+                    )
+                    result = result or {
+                        "choices": [
+                            {
+                                "message": {
+                                    "role": "assistant",
+                                    "content": response_content,
+                                },
+                                "finish_reason": "stop",
+                            }
+                        ]
+                    }
 
+            (
+                response_content,
+                _citation_suffix,
+                citation_paths,
+                citation_appended,
+            ) = _apply_grounding_citations_if_needed(
+                response_content=response_content,
+                executed_tool_calls=executed_tool_calls,
+                latest_user_message=capture_intent_message_hint,
+                tool_loop_stop_reason=tool_loop_stop_reason,
+                default_scope_path=(
+                    mcp_scope.get("mcp_project_slug")
+                    if isinstance(mcp_scope, dict)
+                    else None
+                ),
+            )
+            if citation_appended:
+                result = _set_result_primary_content(result, response_content)
+
+            _finalize_pre_compaction_flush_status(
+                tooling_metadata=mcp_tooling_metadata,
+                tool_loop_stop_reason=tool_loop_stop_reason,
+                tool_calls_executed_count=len(executed_tool_calls),
+            )
+            _finalize_digest_schedule_status(
+                tooling_metadata=mcp_tooling_metadata,
+                tool_loop_stop_reason=tool_loop_stop_reason,
+                tool_calls_executed_count=len(executed_tool_calls),
+            )
             mcp_tooling_metadata.update(
                 {
                     "tool_loop_enabled": tool_loop_enabled or bool(executed_tool_calls),
@@ -2951,8 +13274,34 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                     "tool_calls_executed_count": len(executed_tool_calls),
                     "approval_required": bool(approval_request_payload),
                     "approval_resolved": bool(approval_resolution_payload),
+                    **_build_provider_timing_metadata(
+                        provider_timeout_seconds=mcp_provider_timeout_seconds,
+                        provider_call_latencies_ms=provider_call_latencies_ms,
+                        provider_timeout_count=provider_timeout_count,
+                    ),
                 }
             )
+            if citation_paths:
+                mcp_tooling_metadata["response_citations"] = citation_paths
+                mcp_tooling_metadata["response_citations_appended"] = citation_appended
+
+            delivery_handoff_payload = _build_digest_delivery_handoff_payload(
+                conversation_type=effective_conversation_type,
+                response_content=response_content,
+                conversation_id=str(conversation.id),
+                provider=request.provider,
+                model=request.model,
+                digest_schedule_config=digest_schedule_config,
+                tooling_metadata=mcp_tooling_metadata,
+            )
+            if isinstance(delivery_handoff_payload, dict):
+                delivery_handoff_payload = await _attach_digest_delivery_delivery_state(
+                    handoff_payload=delivery_handoff_payload,
+                    user_id=user_id,
+                    tooling_metadata=mcp_tooling_metadata,
+                    send_config=digest_delivery_send_config,
+                )
+                mcp_tooling_metadata["digest_delivery_handoff"] = delivery_handoff_payload
 
             elapsed_time = time.time() - start_time
             print(f"Chat completion result: {result}")
@@ -3012,6 +13361,8 @@ async def chat_completion(request: ChatCompletionRequest, db: AsyncSession = Dep
                 result["approval_request"] = approval_request_payload
             if approval_resolution_payload:
                 result["approval_resolution"] = approval_resolution_payload
+            if isinstance(delivery_handoff_payload, dict):
+                result["delivery_handoff"] = delivery_handoff_payload
             
             return result
     except HTTPException:

--- a/backend/app/api/v1/endpoints/mcp_registry.py
+++ b/backend/app/api/v1/endpoints/mcp_registry.py
@@ -1,0 +1,47 @@
+"""MCP registry and tool sync endpoints."""
+
+from typing import Any, Optional
+
+from fastapi import APIRouter, Depends, Query
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.auth_context import AuthContext
+from app.core.auth_deps import require_user
+from app.core.database import get_db
+from app.services.mcp_registry_service import MCPRegistryService
+
+
+router = APIRouter(prefix="/mcp", tags=["mcp"])
+
+
+@router.post("/sync")
+async def sync_mcp_tools(
+    plugin_slug: Optional[str] = Query(default=None),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_user),
+) -> dict[str, Any]:
+    service = MCPRegistryService(db)
+    summary = await service.sync_user_servers(auth.user_id, plugin_slug_filter=plugin_slug)
+    return {"success": True, "data": summary}
+
+
+@router.get("/servers")
+async def list_mcp_servers(
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_user),
+) -> dict[str, Any]:
+    service = MCPRegistryService(db)
+    servers = await service.list_servers(auth.user_id)
+    return {"success": True, "data": {"servers": [server.to_dict() for server in servers]}}
+
+
+@router.get("/tools")
+async def list_mcp_tools(
+    enabled_only: bool = Query(default=False),
+    db: AsyncSession = Depends(get_db),
+    auth: AuthContext = Depends(require_user),
+) -> dict[str, Any]:
+    service = MCPRegistryService(db)
+    tools = await service.list_tools(auth.user_id, enabled_only=enabled_only)
+    return {"success": True, "data": {"tools": [tool.to_dict() for tool in tools]}}
+

--- a/backend/app/core/user_initializer/initializers/__init__.py
+++ b/backend/app/core/user_initializer/initializers/__init__.py
@@ -9,7 +9,8 @@ Each plugin should inherit from UserInitializerBase and register itself.
 from . import settings_initializer
 from . import components_initializer
 from . import navigation_initializer
-from . import github_plugin_initializer  # GitHub plugin installer (runs first for plugins)
+from . import github_plugin_initializer  # GitHub plugin installer
+from . import library_onboarding_initializer  # User library scaffold bootstrap
 from . import pages_initializer  # Pages initializer (updated for BrainDriveChat)
 # from . import brain_drive_basic_ai_chat_initializer  # Replaced by GitHub installer
 # from . import brain_drive_settings_initializer  # Replaced by GitHub installer

--- a/backend/app/core/user_initializer/initializers/github_plugin_initializer.py
+++ b/backend/app/core/user_initializer/initializers/github_plugin_initializer.py
@@ -14,142 +14,226 @@ from app.core.user_initializer.registry import register_initializer
 
 logger = logging.getLogger(__name__)
 
+
 class GitHubPluginInitializer(UserInitializerBase):
     """
     Initializer that installs plugins from GitHub repositories.
-    
+
     Uses the same install_plugin_from_url() function as the frontend
     to ensure identical installation behavior and error handling.
     """
-    
+
     name = "github_plugin_initializer"
     description = "Installs default plugins from GitHub repositories"
     priority = 400  # Run after core system setup but before pages
     dependencies = ["settings_initializer", "components_initializer", "navigation_initializer"]  # Run after core setup
-    
-    # Default plugins to install for new users
+
+    # Default plugins to install for new users.
+    # Install order is intentional: Library depends on Chat being present.
     DEFAULT_PLUGINS = [
         {
+            "key": "settings",
             "repo_url": "https://github.com/BrainDriveAI/BrainDrive-Settings-Plugin",
             "version": "latest",
-            "name": "BrainDrive Settings"
+            "name": "BrainDrive Settings",
+            "required": True,
+            "depends_on": [],
         },
         {
-            "repo_url": "https://github.com/BrainDriveAI/BrainDrive-Chat-Plugin", 
+            "key": "chat",
+            "repo_url": "https://github.com/BrainDriveAI/BrainDrive-Chat-Plugin",
             "version": "latest",
-            "name": "BrainDrive Chat"
+            "name": "BrainDrive Chat",
+            "required": True,
+            "depends_on": [],
         },
         {
-            "repo_url": "https://github.com/BrainDriveAI/BrainDrive-Ollama-Plugin", 
+            "key": "ollama",
+            "repo_url": "https://github.com/BrainDriveAI/BrainDrive-Ollama-Plugin",
             "version": "latest",
-            "name": "BrainDrive Ollama"
-        }
+            "name": "BrainDrive Ollama",
+            "required": False,
+            "depends_on": [],
+        },
+        {
+            "key": "library",
+            "repo_url": "https://github.com/DJJones66/BrainDrive-Library-Plugin",
+            "version": "latest",
+            "name": "BrainDrive Library",
+            "required": True,
+            "depends_on": ["chat"],
+        },
     ]
-    
+
     async def initialize(self, user_id: str, db: AsyncSession, **kwargs) -> bool:
         """
         Install default GitHub plugins for the new user.
-        
+
         Args:
             user_id: The ID of the newly registered user
             db: Database session
             **kwargs: Additional arguments (unused)
-            
+
         Returns:
-            bool: True if all plugins installed successfully, False otherwise
+            bool: True if all required plugins installed successfully, False otherwise
         """
-        logger.info(f"Starting GitHub plugin installation for user {user_id}")
-        
-        # Import the same function used by the frontend
+        del db, kwargs
+        logger.info("Starting GitHub plugin installation for user %s", user_id)
+
         try:
             from app.plugins.remote_installer import install_plugin_from_url
-        except ImportError as e:
-            logger.error(f"Failed to import install_plugin_from_url: {e}")
+        except ImportError as exc:
+            logger.error("Failed to import install_plugin_from_url: %s", exc)
             return False
-        
-        successful_installs = []
-        failed_installs = []
-        
+
+        successful_installs: List[Dict[str, Any]] = []
+        failed_installs: List[Dict[str, Any]] = []
+        install_results: Dict[str, bool] = {}
+
         for plugin_config in self.DEFAULT_PLUGINS:
-            repo_url = plugin_config["repo_url"]
-            version = plugin_config["version"]
-            name = plugin_config["name"]
-            
-            logger.info(f"Installing {name} from {repo_url} (version: {version}) for user {user_id}")
-            
+            key = str(plugin_config.get("key") or plugin_config.get("name") or "unknown").strip()
+            repo_url = str(plugin_config["repo_url"])
+            version = str(plugin_config.get("version") or "latest")
+            name = str(plugin_config.get("name") or key)
+            required = bool(plugin_config.get("required", True))
+            depends_on = [str(dep).strip() for dep in plugin_config.get("depends_on", []) if str(dep).strip()]
+
+            blocked_dependencies = [dep for dep in depends_on if not install_results.get(dep, False)]
+            if blocked_dependencies:
+                error_msg = f"Dependency not installed: {', '.join(blocked_dependencies)}"
+                failure = {
+                    "key": key,
+                    "name": name,
+                    "repo_url": repo_url,
+                    "error": error_msg,
+                    "required": required,
+                    "dependency_blocked": True,
+                    "depends_on": blocked_dependencies,
+                }
+                failed_installs.append(failure)
+                install_results[key] = False
+
+                if required:
+                    logger.error(
+                        "Skipping required plugin %s for user %s because dependency failed: %s",
+                        name,
+                        user_id,
+                        blocked_dependencies,
+                    )
+                else:
+                    logger.warning(
+                        "Skipping optional plugin %s for user %s because dependency failed: %s",
+                        name,
+                        user_id,
+                        blocked_dependencies,
+                    )
+                continue
+
+            logger.info(
+                "Installing plugin %s from %s (version=%s, required=%s) for user %s",
+                name,
+                repo_url,
+                version,
+                required,
+                user_id,
+            )
+
             try:
-                # Use the exact same function as the frontend
                 result = await install_plugin_from_url(
                     repo_url=repo_url,
                     user_id=user_id,
-                    version=version
+                    version=version,
                 )
-                
+
                 if result.get("success", False):
-                    successful_installs.append({
-                        "name": name,
-                        "repo_url": repo_url,
-                        "plugin_id": result.get("plugin_id"),
-                        "plugin_slug": result.get("plugin_slug")
-                    })
-                    logger.info(f"Successfully installed {name} for user {user_id}")
+                    successful_installs.append(
+                        {
+                            "key": key,
+                            "name": name,
+                            "repo_url": repo_url,
+                            "required": required,
+                            "plugin_id": result.get("plugin_id"),
+                            "plugin_slug": result.get("plugin_slug"),
+                        }
+                    )
+                    install_results[key] = True
+                    logger.info("Successfully installed %s for user %s", name, user_id)
                 else:
-                    error_msg = result.get("error", "Unknown error")
-                    failed_installs.append({
+                    error_msg = str(result.get("error") or "Unknown error")
+                    failed_installs.append(
+                        {
+                            "key": key,
+                            "name": name,
+                            "repo_url": repo_url,
+                            "required": required,
+                            "error": error_msg,
+                            "dependency_blocked": False,
+                        }
+                    )
+                    install_results[key] = False
+                    logger.error("Failed to install %s for user %s: %s", name, user_id, error_msg)
+
+            except Exception as exc:
+                failed_installs.append(
+                    {
+                        "key": key,
                         "name": name,
                         "repo_url": repo_url,
-                        "error": error_msg
-                    })
-                    logger.error(f"Failed to install {name} for user {user_id}: {error_msg}")
-                    
-            except Exception as e:
-                failed_installs.append({
-                    "name": name,
-                    "repo_url": repo_url,
-                    "error": str(e)
-                })
-                logger.error(f"Exception installing {name} for user {user_id}: {str(e)}")
-        
-        # Log summary
-        logger.info(f"GitHub plugin installation complete for user {user_id}: "
-                   f"{len(successful_installs)} successful, {len(failed_installs)} failed")
-        
+                        "required": required,
+                        "error": str(exc),
+                        "dependency_blocked": False,
+                    }
+                )
+                install_results[key] = False
+                logger.error("Exception installing %s for user %s: %s", name, user_id, exc)
+
+        required_failures = [item for item in failed_installs if item.get("required", False)]
+        optional_failures = [item for item in failed_installs if not item.get("required", False)]
+
+        logger.info(
+            "GitHub plugin installation complete for user %s: success=%s required_failures=%s optional_failures=%s",
+            user_id,
+            len(successful_installs),
+            len(required_failures),
+            len(optional_failures),
+        )
+
         if successful_installs:
-            logger.info(f"Successfully installed: {[p['name'] for p in successful_installs]}")
-        
+            logger.info("Successfully installed plugins: %s", [p["name"] for p in successful_installs])
+
         if failed_installs:
-            logger.warning(f"Failed to install: {[p['name'] for p in failed_installs]}")
-        
-        # Return True only if all plugins installed successfully
-        return len(failed_installs) == 0
-    
+            logger.warning(
+                "Failed plugin installs: %s",
+                [{"name": p["name"], "required": p["required"], "error": p["error"]} for p in failed_installs],
+            )
+
+        # Required plugin failures should fail onboarding; optional failures should not.
+        return len(required_failures) == 0
+
     async def cleanup(self, user_id: str, db: AsyncSession, **kwargs) -> bool:
         """
         Clean up any plugins that were installed if initialization fails.
-        
+
         Args:
             user_id: The ID of the user
             db: Database session
             **kwargs: Additional arguments
-            
+
         Returns:
             bool: True if cleanup was successful
         """
-        logger.info(f"Cleaning up GitHub plugins for user {user_id}")
-        
+        del db, kwargs
+        logger.info("Cleaning up GitHub plugins for user %s", user_id)
+
         try:
-            # For now, we'll implement basic cleanup logging
-            # More sophisticated cleanup could be added later if needed
-            logger.info(f"GitHub plugin cleanup initiated for user {user_id}")
-            
-            # Note: The existing plugin system should handle cleanup through
-            # the normal plugin uninstall mechanisms if needed
-            
+            # For now, we'll implement basic cleanup logging.
+            # More sophisticated cleanup can be added later if needed.
+            logger.info("GitHub plugin cleanup initiated for user %s", user_id)
             return True
-            
-        except Exception as e:
-            logger.error(f"Error during GitHub plugin cleanup for user {user_id}: {str(e)}")
+        except Exception as exc:
+            logger.error("Error during GitHub plugin cleanup for user %s: %s", user_id, exc)
             return False
+
 
 # Register the initializer
 register_initializer(GitHubPluginInitializer)

--- a/backend/app/core/user_initializer/initializers/library_onboarding_initializer.py
+++ b/backend/app/core/user_initializer/initializers/library_onboarding_initializer.py
@@ -1,0 +1,87 @@
+"""
+Library onboarding initializer plugin.
+
+Seeds the new user-scoped Library filesystem from a canonical base template.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import shutil
+from pathlib import Path
+
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from app.core.user_initializer.base import UserInitializerBase
+from app.core.user_initializer.library_template import (
+    apply_canonical_schema,
+    copy_base_template_idempotent,
+    resolve_base_template_path,
+    resolve_library_root_path,
+)
+from app.core.user_initializer.registry import register_initializer
+
+logger = logging.getLogger(__name__)
+
+_VALID_USER_ID = re.compile(r"^[A-Za-z0-9_]{3,128}$")
+
+
+class LibraryOnboardingInitializer(UserInitializerBase):
+    """Initializer for deterministic user library onboarding scaffold."""
+
+    name = "library_onboarding_initializer"
+    description = "Initializes user-scoped library structure and onboarding state"
+    priority = 550
+    dependencies = ["github_plugin_initializer"]
+
+    async def initialize(self, user_id: str, db: AsyncSession, **kwargs) -> bool:
+        del db, kwargs  # Filesystem-only initializer.
+
+        try:
+            library_root = resolve_library_root_path()
+            scoped_root = self._resolve_scoped_library_root(library_root, user_id)
+            template_root = resolve_base_template_path()
+
+            scoped_root.mkdir(parents=True, exist_ok=True)
+            copy_result = copy_base_template_idempotent(template_root, scoped_root)
+            schema_result = apply_canonical_schema(scoped_root)
+
+            logger.info(
+                "Library onboarding completed for user %s (copied_files=%s skipped_files=%s schema_changes=%s)",
+                user_id,
+                len(copy_result.copied_files),
+                len(copy_result.skipped_files),
+                len(getattr(schema_result, "changed_paths", []) or []),
+            )
+            return True
+        except Exception as exc:
+            logger.error("Library onboarding initializer failed for user %s: %s", user_id, exc)
+            return False
+
+    async def cleanup(self, user_id: str, db: AsyncSession, **kwargs) -> bool:
+        del db, kwargs
+
+        try:
+            library_root = resolve_library_root_path()
+            scoped_root = self._resolve_scoped_library_root(library_root, user_id)
+            if scoped_root.exists():
+                shutil.rmtree(scoped_root)
+            return True
+        except Exception as exc:
+            logger.error("Library onboarding cleanup failed for user %s: %s", user_id, exc)
+            return False
+
+    def _resolve_scoped_library_root(self, library_root: str | Path, user_id: str) -> Path:
+        normalized_user_id = self._normalize_user_id(user_id)
+        root = Path(library_root).expanduser().resolve()
+        return root / "users" / normalized_user_id
+
+    def _normalize_user_id(self, raw_user_id: str) -> str:
+        normalized = str(raw_user_id).strip().replace("-", "")
+        if not normalized or not _VALID_USER_ID.fullmatch(normalized):
+            raise ValueError(f"Invalid user_id for library onboarding: {raw_user_id}")
+        return normalized
+
+
+register_initializer(LibraryOnboardingInitializer)

--- a/backend/app/core/user_initializer/initializers/pages_initializer.py
+++ b/backend/app/core/user_initializer/initializers/pages_initializer.py
@@ -1,260 +1,281 @@
 """
 Pages initializer plugin.
 
-This plugin initializes pages for a new user.
+This plugin initializes starter pages for a new user.
 """
 
-import logging
-import uuid
+from __future__ import annotations
+
 import datetime
 import json
-from app.core.user_initializer.utils import generate_uuid
-from typing import Dict, Any, List
+import logging
+import re
+from typing import Any, Dict
+
+from sqlalchemy import bindparam, text
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, text
 
 from app.core.user_initializer.base import UserInitializerBase
 from app.core.user_initializer.registry import register_initializer
-from app.core.user_initializer.utils import prepare_record_for_new_user
-from app.models.page import Page
+from app.core.user_initializer.utils import generate_uuid
 
 logger = logging.getLogger(__name__)
 
+
 class PagesInitializer(UserInitializerBase):
-    """Initializer for user pages."""
-    
+    """Initializer for starter user pages."""
+
     name = "pages_initializer"
     description = "Initializes default pages for a new user"
-    priority = 600  # Run after navigation routes
-    dependencies = ["navigation_initializer", "github_plugin_initializer"]  # Depends on navigation routes and GitHub plugin installer
-    
-    # Default pages templates
-    DEFAULT_PAGES = [
-        {
-            "name": "AI Chat",
-            # Generate a unique route based on the name with current timestamp
-            "route": f"ai-chat-{int(datetime.datetime.now().timestamp())}",
-            "is_published": 1,
-            # publish_date will be set at insertion time
-            "description": "",
-            "icon": "",
-            "parent_type": "page",
-            "is_parent_page": 0
-        }
+    priority = 600
+    dependencies = [
+        "navigation_initializer",
+        "github_plugin_initializer",
+        "library_onboarding_initializer",
     ]
-    
-    async def get_module_ids(self, user_id: str, db: AsyncSession) -> Dict[str, str]:
-        """
-        Get the module IDs for a user's BrainDrive Chat plugin (GitHub-installed).
-        
-        Args:
-            user_id: The user ID
-            db: Database session
-            
-        Returns:
-            Dict[str, str]: A dictionary mapping module names to their IDs
-        """
+
+    STARTER_PAGE_SPECS: tuple[Dict[str, Any], ...] = ()
+
+    async def get_module_ids(self, user_id: str, db: AsyncSession) -> Dict[str, Any]:
+        """Get the module IDs for a user's BrainDrive Chat plugin."""
         try:
-            # Get the plugin ID for the user's BrainDrive Chat plugin (GitHub-installed)
-            plugin_stmt = text("""
-            SELECT id FROM plugin
-            WHERE user_id = :user_id AND plugin_slug = 'BrainDriveChat'
-            """)
-            
+            plugin_stmt = text(
+                """
+                SELECT id FROM plugin
+                WHERE user_id = :user_id AND plugin_slug = 'BrainDriveChat'
+                """
+            )
             plugin_result = await db.execute(plugin_stmt, {"user_id": user_id})
             plugin_id = plugin_result.scalar_one_or_none()
-            
             if not plugin_id:
-                logger.error(f"BrainDriveChat plugin not found for user {user_id}")
+                logger.error("BrainDriveChat plugin not found for user %s", user_id)
                 return {}
-            
-            # Get the module IDs for the plugin
-            module_stmt = text("""
-            SELECT id, name FROM module
-            WHERE user_id = :user_id AND plugin_id = :plugin_id
-            """)
-            
-            module_result = await db.execute(module_stmt, {
-                "user_id": user_id,
-                "plugin_id": plugin_id
-            })
-            
-            module_ids = {}
+
+            module_stmt = text(
+                """
+                SELECT id, name FROM module
+                WHERE user_id = :user_id AND plugin_id = :plugin_id
+                """
+            )
+            module_result = await db.execute(
+                module_stmt,
+                {
+                    "user_id": user_id,
+                    "plugin_id": plugin_id,
+                },
+            )
+
+            module_ids: Dict[str, str] = {}
             for row in module_result:
-                module_ids[row.name] = row.id
-            
-            return {
-                "plugin_id": plugin_id,
-                "module_ids": module_ids
-            }
-        except Exception as e:
-            logger.error(f"Error getting module IDs for user {user_id}: {e}")
+                module_ids[str(row.name)] = str(row.id)
+
+            return {"plugin_id": str(plugin_id), "module_ids": module_ids}
+        except Exception as exc:
+            logger.error("Error getting module IDs for user %s: %s", user_id, exc)
             return {}
-    
+
+    def _build_module_args(self, module_id: str, spec: Dict[str, Any]) -> Dict[str, Any]:
+        args: Dict[str, Any] = {
+            "moduleId": module_id,
+            "displayName": f"{spec['name']} Chat",
+            "conversation_type": spec["conversation_type"],
+            "default_library_scope_enabled": bool(
+                spec["default_library_scope_enabled"]
+            ),
+            "default_project_slug": spec.get("default_project_slug"),
+            "default_project_lifecycle": spec.get(
+                "default_project_lifecycle", "active"
+            ),
+            "apply_defaults_on_new_chat": True,
+            "lock_project_scope": False,
+            "lock_persona_selection": False,
+            "lock_model_selection": False,
+            # Forward-compatible root-aware hints for life/project scoping.
+            "default_scope_root": spec.get("default_scope_root"),
+            "default_scope_path": spec.get("default_scope_path"),
+        }
+        return args
+
+    def _normalize_route_slug(self, route_slug: str) -> str:
+        normalized = re.sub(r"[^a-z0-9]+", "-", str(route_slug).strip().lower())
+        normalized = re.sub(r"-+", "-", normalized).strip("-")
+        return normalized or "capture"
+
+    async def _starter_page_exists(
+        self, db: AsyncSession, user_id: str, page_name: str
+    ) -> bool:
+        stmt = text(
+            """
+            SELECT id FROM pages
+            WHERE creator_id = :user_id AND lower(name) = lower(:name)
+            LIMIT 1
+            """
+        )
+        result = await db.execute(stmt, {"user_id": user_id, "name": page_name})
+        return result.scalar_one_or_none() is not None
+
+    async def _resolve_unique_route(
+        self, db: AsyncSession, user_id: str, base_route: str
+    ) -> str:
+        normalized = self._normalize_route_slug(base_route)
+        route = normalized
+        suffix = 2
+        stmt = text(
+            """
+            SELECT id FROM pages
+            WHERE creator_id = :user_id AND route = :route
+            LIMIT 1
+            """
+        )
+
+        while True:
+            result = await db.execute(stmt, {"user_id": user_id, "route": route})
+            if result.scalar_one_or_none() is None:
+                return route
+            route = f"{normalized}-{suffix}"
+            suffix += 1
+
+    def _build_page_content(self, module_id: str, spec: Dict[str, Any]) -> Dict[str, Any]:
+        timestamp_base = int(datetime.datetime.now().timestamp() * 1000)
+        chat_interface_id = f"BrainDriveChat_{module_id}_{timestamp_base}_{generate_uuid()[:8]}"
+        args = self._build_module_args(module_id, spec)
+
+        layout_item = {
+            "i": chat_interface_id,
+            "x": 0,
+            "y": 0,
+            "w": 12,
+            "h": 10,
+            "pluginId": "BrainDriveChat",
+            "args": args,
+        }
+
+        return {
+            "layouts": {
+                "desktop": [layout_item],
+                "tablet": [{**layout_item, "w": 4, "h": 3}],
+                "mobile": [{**layout_item, "w": 4, "h": 3}],
+            },
+            "modules": {},
+        }
+
     async def initialize(self, user_id: str, db: AsyncSession, **kwargs) -> bool:
-        """Initialize pages for a new user."""
+        """Initialize starter pages for a new user."""
+        del kwargs
+
         try:
-            logger.info(f"Initializing pages for user {user_id}")
-            
-            # Get the module IDs for the user's BrainDrive Chat plugin (GitHub-installed)
+            logger.info("Initializing starter pages for user %s", user_id)
+            if not self.STARTER_PAGE_SPECS:
+                logger.info("No starter pages configured; skipping page initialization for user %s", user_id)
+                return True
             module_info = await self.get_module_ids(user_id, db)
-            
             if not module_info:
-                logger.error(f"Failed to get module IDs for user {user_id}")
                 return False
-                
-            plugin_id = module_info.get("plugin_id")
-            module_ids = module_info.get("module_ids", {})
-            
-            if not plugin_id:
-                logger.error(f"BrainDriveChat plugin not found for user {user_id}")
+
+            module_ids: Dict[str, str] = module_info.get("module_ids", {})
+            chat_module_id = None
+            for module_name, module_id in module_ids.items():
+                if "brainDrivechat" in module_name.lower() or "chat" in module_name.lower():
+                    chat_module_id = module_id
+                    break
+
+            if not chat_module_id:
+                logger.error("BrainDriveChat module not found for user %s", user_id)
                 return False
-                
-            # Create pages for the user using default pages
-            for page_data in self.DEFAULT_PAGES:
-                # If this is the AI Chat page, generate dynamic content
-                if page_data["name"] == "AI Chat":
-                    # Generate unique module ID for the BrainDriveChat interface
-                    timestamp_base = int(datetime.datetime.now().timestamp() * 1000)  # Use milliseconds for timestamp
-                    
-                    # Get the BrainDriveChat module ID (should be the only module in the plugin)
-                    brain_drive_chat_module_id = None
-                    for module_name, module_id in module_ids.items():
-                        if 'BrainDriveChat' in module_name:
-                            brain_drive_chat_module_id = module_id
-                            break
-                    
-                    if not brain_drive_chat_module_id:
-                        logger.error(f"BrainDriveChat module not found for user {user_id}")
-                        return False
-                    
-                    # Generate unique identifier for the layout
-                    chat_interface_id = f"BrainDriveChat_{brain_drive_chat_module_id}_{timestamp_base}"
-                    
-                    # Generate the content JSON with the actual module IDs (new BrainDriveChat structure)
-                    page_data["content"] = {
-                        "layouts": {
-                            "desktop": [
-                                {
-                                    "i": chat_interface_id,
-                                    "x": 0,
-                                    "y": 0,
-                                    "w": 12,
-                                    "h": 10,
-                                    "pluginId": "BrainDriveChat",
-                                    "args": {
-                                        "moduleId": brain_drive_chat_module_id,
-                                        "displayName": "AI Chat Interface"
-                                    }
-                                }
-                            ],
-                            "tablet": [
-                                {
-                                    "i": chat_interface_id,
-                                    "x": 1,
-                                    "y": 0,
-                                    "w": 4,
-                                    "h": 3,
-                                    "pluginId": "BrainDriveChat",
-                                    "args": {
-                                        "moduleId": brain_drive_chat_module_id,
-                                        "displayName": "AI Chat Interface"
-                                    }
-                                }
-                            ],
-                            "mobile": [
-                                {
-                                    "i": chat_interface_id,
-                                    "x": 1,
-                                    "y": 0,
-                                    "w": 4,
-                                    "h": 3,
-                                    "pluginId": "BrainDriveChat",
-                                    "args": {
-                                        "moduleId": brain_drive_chat_module_id,
-                                        "displayName": "AI Chat Interface"
-                                    }
-                                }
-                            ]
-                        },
-                        "modules": {}
-                    }
-                # Prepare the page data for the new user
-                # This will:
-                # 1. Generate a new ID
-                # 2. Set the creator_id to the new user's ID
-                # 3. Update created_at and updated_at timestamps
-                prepared_data = prepare_record_for_new_user(
-                    page_data,
-                    user_id,
-                    preserve_fields=["route"],  # Keep the original route path
-                    user_id_field="creator_id"  # Explicitly specify the creator_id field
-                )
-                
-                # Use direct SQL to avoid ORM relationship issues
-                try:
-                    # Get current timestamp
-                    current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-                    
-                    # Create SQL statement
-                    stmt = text("""
-                    INSERT INTO pages
-                    (id, name, route, content, creator_id, created_at, updated_at, is_published, publish_date)
-                    VALUES
-                    (:id, :name, :route, :content, :creator_id, :created_at, :updated_at, :is_published, :publish_date)
-                    """)
-                    
-                    # Use content directly if it's already provided, otherwise construct it
-                    if "content" in prepared_data and isinstance(prepared_data["content"], dict):
-                        content = prepared_data["content"]
-                    else:
-                        # Convert layout and components to content JSON
-                        content = {
-                            "layout": prepared_data.get("layout", {}),
-                            "components": prepared_data.get("components", [])
-                        }
-                    
-                    # Execute statement with parameters
-                    await db.execute(stmt, {
-                        "id": prepared_data.get("id", generate_uuid()),
-                        "name": prepared_data["name"],
-                        "route": prepared_data.get("route"),
+
+            insert_stmt = text(
+                """
+                INSERT INTO pages
+                (id, name, route, content, creator_id, created_at, updated_at, is_published, publish_date, description)
+                VALUES
+                (:id, :name, :route, :content, :creator_id, :created_at, :updated_at, :is_published, :publish_date, :description)
+                """
+            )
+
+            current_time = datetime.datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+            created_count = 0
+            for spec in self.STARTER_PAGE_SPECS:
+                if await self._starter_page_exists(db, user_id, spec["name"]):
+                    logger.info(
+                        "Starter page '%s' already exists for user %s; skipping",
+                        spec["name"],
+                        user_id,
+                    )
+                    continue
+
+                route = await self._resolve_unique_route(db, user_id, spec["route_slug"])
+                content = self._build_page_content(chat_module_id, spec)
+
+                await db.execute(
+                    insert_stmt,
+                    {
+                        "id": generate_uuid(),
+                        "name": spec["name"],
+                        "route": route,
                         "content": json.dumps(content),
                         "creator_id": user_id,
                         "created_at": current_time,
                         "updated_at": current_time,
-                        "is_published": 1,  # Always publish the page
-                        "publish_date": current_time  # Set publish date to current time
-                    })
-                    
-                    logger.info(f"Created page {prepared_data['name']} for user {user_id}")
-                except Exception as e:
-                    logger.error(f"Error creating page {prepared_data.get('name')}: {e}")
-                    raise
-            
+                        "is_published": 1,
+                        "publish_date": current_time,
+                        "description": spec.get("description", ""),
+                    },
+                )
+                created_count += 1
+                logger.info(
+                    "Created starter page '%s' (route=%s) for user %s",
+                    spec["name"],
+                    route,
+                    user_id,
+                )
+
             await db.commit()
-            logger.info(f"Pages initialized successfully for user {user_id}")
+            logger.info(
+                "Starter pages initialized for user %s (created=%s)",
+                user_id,
+                created_count,
+            )
             return True
-            
-        except Exception as e:
-            logger.error(f"Error initializing pages for user {user_id}: {e}")
-            await db.rollback()
-            return False
-    
-    async def cleanup(self, user_id: str, db: AsyncSession, **kwargs) -> bool:
-        """Clean up pages if initialization fails."""
-        try:
-            # Delete all pages created for this user using direct SQL
-            stmt = text("DELETE FROM pages WHERE creator_id = :user_id")
-            await db.execute(stmt, {"user_id": user_id})
-            
-            await db.commit()
-            logger.info(f"Pages cleanup successful for user {user_id}")
-            return True
-        except Exception as e:
-            logger.error(f"Error during pages cleanup for user {user_id}: {e}")
+        except Exception as exc:
+            logger.error("Error initializing pages for user %s: %s", user_id, exc)
             await db.rollback()
             return False
 
-# Register the initializer
+    async def cleanup(self, user_id: str, db: AsyncSession, **kwargs) -> bool:
+        """Clean up pages if initialization fails."""
+        del kwargs
+
+        try:
+            if not self.STARTER_PAGE_SPECS:
+                logger.info("No starter pages configured; skipping pages cleanup for user %s", user_id)
+                return True
+
+            page_names = [spec["name"] for spec in self.STARTER_PAGE_SPECS if spec.get("name")]
+            if not page_names:
+                logger.info("Starter page cleanup found no page names for user %s", user_id)
+                return True
+
+            stmt = text(
+                """
+                DELETE FROM pages
+                WHERE creator_id = :user_id
+                AND lower(name) IN :page_names
+                """
+            ).bindparams(bindparam("page_names", expanding=True))
+            await db.execute(
+                stmt,
+                {
+                    "user_id": user_id,
+                    "page_names": [name.lower() for name in page_names],
+                },
+            )
+            await db.commit()
+            logger.info("Pages cleanup successful for user %s", user_id)
+            return True
+        except Exception as exc:
+            logger.error("Error during pages cleanup for user %s: %s", user_id, exc)
+            await db.rollback()
+            return False
+
+
 register_initializer(PagesInitializer)

--- a/backend/app/core/user_initializer/initializers/settings_initializer.py
+++ b/backend/app/core/user_initializer/initializers/settings_initializer.py
@@ -25,8 +25,8 @@ class SettingsInitializer(UserInitializerBase):
     
     name = "settings_initializer"
     description = "Initializes default settings for a new user"
-    priority = 900  # High priority among post-page initializers
-    dependencies = ["pages_initializer"]
+    priority = 900  # Highest priority among core initializers
+    dependencies = []
     
     # Default settings definitions
     DEFAULT_DEFINITIONS = [

--- a/backend/app/core/user_initializer/initializers/settings_initializer.py
+++ b/backend/app/core/user_initializer/initializers/settings_initializer.py
@@ -25,8 +25,8 @@ class SettingsInitializer(UserInitializerBase):
     
     name = "settings_initializer"
     description = "Initializes default settings for a new user"
-    priority = 900  # High priority - settings should be initialized early
-    dependencies = []  # No dependencies
+    priority = 900  # High priority among post-page initializers
+    dependencies = ["pages_initializer"]
     
     # Default settings definitions
     DEFAULT_DEFINITIONS = [
@@ -177,16 +177,25 @@ class SettingsInitializer(UserInitializerBase):
             # Ensure settings definitions exist
             await self._ensure_settings_definitions(db)
             
-            # Retrieve the AI Chat page ID for this user
-            page_stmt = text("SELECT id FROM pages WHERE name = :name AND creator_id = :uid LIMIT 1")
-            result = await db.execute(page_stmt, {"name": "AI Chat", "uid": user_id})
-            ai_chat_page_id = result.scalar_one_or_none()
+            # Prefer Library Capture as the initial landing page when available.
+            page_stmt = text(
+                "SELECT id FROM pages WHERE name = :name AND creator_id = :uid LIMIT 1"
+            )
+            default_page_id = None
+            for candidate_name in ("Library Capture", "Capture", "AI Chat"):
+                page_result = await db.execute(
+                    page_stmt, {"name": candidate_name, "uid": user_id}
+                )
+                resolved_page_id = page_result.scalar_one_or_none()
+                if resolved_page_id:
+                    default_page_id = resolved_page_id
+                    break
 
             # Create settings instances for the user using hardcoded default settings
             for setting_data in self.DEFAULT_SETTINGS:
                 # If this is the general settings entry, populate the value with the page ID
                 if setting_data["definition_id"] == "general_settings":
-                    default_page_value = ai_chat_page_id if ai_chat_page_id else "Dashboard"
+                    default_page_value = default_page_id if default_page_id else "Dashboard"
                     setting_value = {
                         "settings": [
                             {

--- a/backend/app/core/user_initializer/library_template.py
+++ b/backend/app/core/user_initializer/library_template.py
@@ -1,0 +1,288 @@
+"""
+Utilities for resolving and copying the canonical base library template.
+"""
+
+from __future__ import annotations
+
+import importlib.util
+import os
+import shutil
+import sys
+from dataclasses import dataclass
+from pathlib import Path
+from types import ModuleType
+from typing import Any
+
+
+ENV_LIBRARY_PATH = "BRAINDRIVE_LIBRARY_PATH"
+ENV_BASE_TEMPLATE_PATH = "BRAINDRIVE_LIBRARY_BASE_TEMPLATE_PATH"
+ENV_LIBRARY_SERVICE_ENV_PATH = "BRAINDRIVE_LIBRARY_SERVICE_ENV_PATH"
+ENV_LIBRARY_SCHEMA_MODULE_PATH = "BRAINDRIVE_LIBRARY_SCHEMA_MODULE_PATH"
+
+DEFAULT_BASE_TEMPLATE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "services_runtime"
+    / "Library-Service"
+    / "library_templates"
+    / "Base_Library"
+)
+DEFAULT_LIBRARY_SERVICE_ENV_PATH = (
+    Path(__file__).resolve().parents[3] / "services_runtime" / "Library-Service" / ".env"
+)
+DEFAULT_LIBRARY_SCHEMA_MODULE_PATH = (
+    Path(__file__).resolve().parents[3]
+    / "services_runtime"
+    / "Library-Service"
+    / "app"
+    / "library_schema.py"
+)
+
+_SHARED_SCHEMA_CACHE: tuple[str, ModuleType] | None = None
+
+
+@dataclass(frozen=True)
+class TemplateCopyResult:
+    """Tracks copied/missing files for deterministic onboarding diagnostics."""
+
+    source: Path
+    destination: Path
+    created_directories: tuple[str, ...]
+    copied_files: tuple[str, ...]
+    skipped_files: tuple[str, ...]
+
+
+def _resolve_service_env_path(configured_path: str | Path | None = None) -> Path:
+    candidate = (
+        configured_path
+        or os.environ.get(ENV_LIBRARY_SERVICE_ENV_PATH)
+        or DEFAULT_LIBRARY_SERVICE_ENV_PATH
+    )
+    return Path(str(candidate)).expanduser().resolve()
+
+
+def _read_service_env_values(
+    configured_env_path: str | Path | None = None,
+) -> tuple[dict[str, str], Path]:
+    env_path = _resolve_service_env_path(configured_env_path)
+    if not env_path.is_file():
+        return {}, env_path
+
+    values: dict[str, str] = {}
+    for raw_line in env_path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if not line or line.startswith("#"):
+            continue
+        if line.startswith("export "):
+            line = line[len("export ") :].strip()
+        if "=" not in line:
+            continue
+        key, value = line.split("=", 1)
+        key = key.strip()
+        value = value.strip()
+        if not key:
+            continue
+        if len(value) >= 2 and (
+            (value[0] == value[-1] == '"') or (value[0] == value[-1] == "'")
+        ):
+            value = value[1:-1]
+        values[key] = value
+    return values, env_path
+
+
+def _first_nonempty(*candidates: str | Path | None) -> str:
+    for candidate in candidates:
+        if candidate is None:
+            continue
+        normalized = str(candidate).strip()
+        if normalized:
+            return normalized
+    return ""
+
+
+def _resolve_candidate_path(
+    candidate: str | Path,
+    relative_root: Path | None = None,
+) -> Path:
+    resolved = Path(str(candidate)).expanduser()
+    if not resolved.is_absolute() and relative_root is not None:
+        resolved = relative_root / resolved
+    return resolved.resolve()
+
+
+def resolve_library_root_path(
+    configured_path: str | Path | None = None,
+    configured_env_path: str | Path | None = None,
+) -> Path:
+    """
+    Resolve the user library root with explicit-path > env > Library-Service .env precedence.
+    """
+    direct_candidate = _first_nonempty(configured_path, os.environ.get(ENV_LIBRARY_PATH))
+    if direct_candidate:
+        return _resolve_candidate_path(direct_candidate)
+
+    service_env_values, service_env_path = _read_service_env_values(configured_env_path)
+    service_candidate = _first_nonempty(service_env_values.get(ENV_LIBRARY_PATH))
+    if service_candidate:
+        return _resolve_candidate_path(service_candidate, service_env_path.parent)
+
+    raise ValueError(
+        "Library root path is not configured; set BRAINDRIVE_LIBRARY_PATH or "
+        "provide it in the Library-Service .env file."
+    )
+
+
+def resolve_base_template_path(
+    configured_path: str | Path | None = None,
+    configured_env_path: str | Path | None = None,
+) -> Path:
+    """
+    Resolve the base template path with explicit-path > env > service-env > repo default precedence.
+    """
+    direct_candidate = _first_nonempty(
+        configured_path,
+        os.environ.get(ENV_BASE_TEMPLATE_PATH),
+    )
+    if direct_candidate:
+        resolved = _resolve_candidate_path(direct_candidate)
+    else:
+        service_env_values, service_env_path = _read_service_env_values(configured_env_path)
+        service_candidate = _first_nonempty(service_env_values.get(ENV_BASE_TEMPLATE_PATH))
+        if service_candidate:
+            resolved = _resolve_candidate_path(service_candidate, service_env_path.parent)
+        else:
+            resolved = DEFAULT_BASE_TEMPLATE_PATH.resolve()
+
+    if not resolved.is_dir():
+        raise FileNotFoundError(
+            f"Base library template path does not exist: {resolved}"
+        )
+    return resolved
+
+
+def resolve_library_schema_module_path(
+    configured_path: str | Path | None = None,
+    configured_env_path: str | Path | None = None,
+) -> Path:
+    """Resolve the shared schema module path used by runtime + registration bootstrap."""
+    direct_candidate = _first_nonempty(
+        configured_path,
+        os.environ.get(ENV_LIBRARY_SCHEMA_MODULE_PATH),
+    )
+    if direct_candidate:
+        resolved = _resolve_candidate_path(direct_candidate)
+    else:
+        service_env_values, service_env_path = _read_service_env_values(configured_env_path)
+        service_candidate = _first_nonempty(
+            service_env_values.get(ENV_LIBRARY_SCHEMA_MODULE_PATH)
+        )
+        if service_candidate:
+            resolved = _resolve_candidate_path(service_candidate, service_env_path.parent)
+        else:
+            resolved = DEFAULT_LIBRARY_SCHEMA_MODULE_PATH.resolve()
+
+    if not resolved.is_file():
+        raise FileNotFoundError(
+            f"Library schema module path does not exist: {resolved}"
+        )
+    return resolved
+
+
+def load_library_schema_module(
+    configured_path: str | Path | None = None,
+    configured_env_path: str | Path | None = None,
+) -> ModuleType:
+    """Dynamically load the shared runtime schema module for initializer parity."""
+    global _SHARED_SCHEMA_CACHE
+
+    module_path = resolve_library_schema_module_path(
+        configured_path=configured_path,
+        configured_env_path=configured_env_path,
+    )
+    cache_key = module_path.as_posix()
+
+    if _SHARED_SCHEMA_CACHE and _SHARED_SCHEMA_CACHE[0] == cache_key:
+        return _SHARED_SCHEMA_CACHE[1]
+
+    spec = importlib.util.spec_from_file_location("braindrive_shared_library_schema", module_path)
+    if spec is None or spec.loader is None:
+        raise ImportError(f"Unable to load schema module from {module_path}")
+
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    try:
+        spec.loader.exec_module(module)
+    except Exception:
+        sys.modules.pop(spec.name, None)
+        raise
+    _SHARED_SCHEMA_CACHE = (cache_key, module)
+    return module
+
+
+def apply_canonical_schema(
+    scoped_root: Path,
+    *,
+    include_digest_period_files: bool = True,
+    configured_schema_module_path: str | Path | None = None,
+    configured_env_path: str | Path | None = None,
+) -> Any:
+    """Apply canonical library structure via the shared runtime schema module."""
+    schema_module = load_library_schema_module(
+        configured_path=configured_schema_module_path,
+        configured_env_path=configured_env_path,
+    )
+
+    ensure_fn = getattr(schema_module, "ensure_scoped_library_structure", None)
+    if not callable(ensure_fn):
+        raise AttributeError(
+            "Shared schema module is missing ensure_scoped_library_structure"
+        )
+
+    return ensure_fn(
+        Path(scoped_root),
+        include_digest_period_files=include_digest_period_files,
+    )
+
+
+def copy_base_template_idempotent(
+    source_root: Path, destination_root: Path
+) -> TemplateCopyResult:
+    """
+    Copy the base template into destination without overwriting existing files.
+    """
+    source_root = source_root.expanduser().resolve()
+    destination_root = destination_root.expanduser().resolve()
+
+    if not source_root.is_dir():
+        raise FileNotFoundError(
+            f"Base library template path does not exist: {source_root}"
+        )
+
+    created_directories: list[str] = []
+    copied_files: list[str] = []
+    skipped_files: list[str] = []
+
+    for path in sorted(source_root.rglob("*")):
+        relative_path = path.relative_to(source_root)
+        target = destination_root / relative_path
+
+        if path.is_dir():
+            if not target.exists():
+                target.mkdir(parents=True, exist_ok=True)
+                created_directories.append(relative_path.as_posix())
+            continue
+
+        target.parent.mkdir(parents=True, exist_ok=True)
+        if target.exists():
+            skipped_files.append(relative_path.as_posix())
+            continue
+
+        shutil.copy2(path, target)
+        copied_files.append(relative_path.as_posix())
+
+    return TemplateCopyResult(
+        source=source_root,
+        destination=destination_root,
+        created_directories=tuple(created_directories),
+        copied_files=tuple(copied_files),
+        skipped_files=tuple(skipped_files),
+    )

--- a/backend/app/core/user_initializer/registry.py
+++ b/backend/app/core/user_initializer/registry.py
@@ -17,98 +17,119 @@ logger = logging.getLogger(__name__)
 # Registry of initializer plugins
 _initializers: Dict[str, Type[UserInitializerBase]] = {}
 
+
 def register_initializer(initializer_class: Type[UserInitializerBase]) -> None:
     """
     Register a user initializer plugin.
-    
+
     Args:
         initializer_class: The initializer class to register
     """
     name = initializer_class.name
     if name in _initializers:
         logger.warning(f"Initializer '{name}' already registered. Overwriting.")
-    
+
     _initializers[name] = initializer_class
     logger.info(f"Registered initializer: {name}")
+
 
 def get_initializers() -> Dict[str, Type[UserInitializerBase]]:
     """
     Get all registered initializer plugins.
-    
+
     Returns:
         Dict[str, Type[UserInitializerBase]]: Dictionary of initializer name to class
     """
     return _initializers
 
+
 def _sort_initializers() -> List[Type[UserInitializerBase]]:
     """
     Sort initializers by priority and dependencies.
-    
+
     Returns:
         List[Type[UserInitializerBase]]: Sorted list of initializer classes
+
+    Raises:
+        ValueError: If a circular dependency is detected.
     """
     # Convert to list of (name, class) tuples
     initializers = list(_initializers.items())
-    
+
     # Sort by priority (higher priority first)
     initializers.sort(key=lambda x: x[1].priority, reverse=True)
-    
-    # Create a list to store the sorted initializers
-    sorted_initializers = []
-    processed = set()
-    
-    # Helper function to add an initializer and its dependencies
-    def add_initializer(name, initializer_class):
-        if name in processed:
+
+    sorted_initializers: List[Type[UserInitializerBase]] = []
+    visit_state: Dict[str, str] = {}
+    visit_stack: List[str] = []
+
+    def add_initializer(name: str) -> None:
+        state = visit_state.get(name)
+        if state == "visited":
             return
-        
-        # Add dependencies first
+
+        if state == "visiting":
+            cycle_start = visit_stack.index(name) if name in visit_stack else 0
+            cycle_path = visit_stack[cycle_start:] + [name]
+            cycle_text = " -> ".join(cycle_path)
+            raise ValueError(f"Circular initializer dependency detected: {cycle_text}")
+
+        visit_state[name] = "visiting"
+        visit_stack.append(name)
+        initializer_class = _initializers[name]
+
         for dep in initializer_class.dependencies:
-            if dep in _initializers and dep not in processed:
-                add_initializer(dep, _initializers[dep])
-        
-        # Add the initializer
+            if dep not in _initializers:
+                logger.warning(
+                    "Initializer '%s' depends on unknown initializer '%s'; ignoring dependency",
+                    name,
+                    dep,
+                )
+                continue
+            add_initializer(dep)
+
+        visit_stack.pop()
+        visit_state[name] = "visited"
         sorted_initializers.append(initializer_class)
-        processed.add(name)
-    
-    # Process all initializers
-    for name, initializer_class in initializers:
-        add_initializer(name, initializer_class)
-    
+
+    for name, _initializer_class in initializers:
+        add_initializer(name)
+
     return sorted_initializers
+
 
 async def initialize_user_data(user_id: str, db: AsyncSession, **kwargs) -> bool:
     """
     Initialize data for a new user using all registered initializers.
-    
+
     Args:
         user_id: The ID of the newly registered user
         db: Database session
         **kwargs: Additional arguments to pass to initializers
-        
+
     Returns:
         bool: True if all initializers succeeded, False otherwise
     """
     logger.info(f"Initializing data for user {user_id}")
-    
+
     # Check if there are any initializers registered
     if not _initializers:
         logger.warning("No initializers are registered! Initialization will be skipped.")
         return True
-    
-    # Sort initializers by priority and dependencies
-    sorted_initializers = _sort_initializers()
-    logger.info(f"Found {len(sorted_initializers)} initializers to run")
-    
+
     # Track which initializers have been run successfully
-    successful_initializers = []
-    
+    successful_initializers: List[UserInitializerBase] = []
+
     try:
+        # Sort initializers by priority and dependencies
+        sorted_initializers = _sort_initializers()
+        logger.info(f"Found {len(sorted_initializers)} initializers to run")
+
         # Run each initializer
         for initializer_class in sorted_initializers:
             initializer = initializer_class()
             logger.info(f"Running initializer: {initializer.name}")
-            
+
             success = await initializer.initialize(user_id, db, **kwargs)
             if success:
                 successful_initializers.append(initializer)
@@ -116,29 +137,29 @@ async def initialize_user_data(user_id: str, db: AsyncSession, **kwargs) -> bool
             else:
                 logger.error(f"Initializer {initializer.name} failed")
                 raise Exception(f"Initializer {initializer.name} failed")
-        
+
         logger.info(f"All initializers completed successfully for user {user_id}")
         return True
-        
+
     except Exception as e:
         logger.error(f"Error during user initialization: {e}")
-        
-        # Rollback and cleanup
-        logger.info("Rolling back and cleaning up")
-        
+
         # Run cleanup for successful initializers in reverse order
+        if successful_initializers:
+            logger.info("Rolling back and cleaning up successful initializers")
         for initializer in reversed(successful_initializers):
             try:
                 await initializer.cleanup(user_id, db, **kwargs)
             except Exception as cleanup_error:
                 logger.error(f"Error during cleanup of {initializer.name}: {cleanup_error}")
-        
+
         return False
+
 
 def discover_initializers(package_name: str = "app.core.user_initializer.initializers") -> None:
     """
     Discover and import initializer plugins from a package.
-    
+
     Args:
         package_name: The package to search for initializers
     """
@@ -146,18 +167,18 @@ def discover_initializers(package_name: str = "app.core.user_initializer.initial
         logger.info(f"Attempting to import package: {package_name}")
         package = importlib.import_module(package_name)
         logger.info(f"Successfully imported package: {package_name}")
-        
+
         # List all modules in the package
         modules = list(pkgutil.iter_modules(package.__path__, package.__name__ + "."))
         logger.info(f"Found {len(modules)} modules in package {package_name}: {[name for _, name, _ in modules]}")
-        
+
         for _, name, is_pkg in modules:
             try:
                 # Import the module
                 logger.info(f"Attempting to import module: {name}")
                 importlib.import_module(name)
                 logger.info(f"Successfully imported initializer module: {name}")
-                
+
                 # If it's a package, recursively discover initializers
                 if is_pkg:
                     discover_initializers(name)

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -14,6 +14,7 @@ from app.models.plugin_state import PluginState, PluginStateHistory, PluginState
 from app.models.persona import Persona
 from app.models.settings import SettingDefinition, SettingInstance
 from app.models.message import Message
+from app.models.mcp import MCPServerRegistry, MCPToolRegistry
 from app.models.role import Role
 from app.models.tenant_models import (
     Tenant,

--- a/backend/app/models/mcp.py
+++ b/backend/app/models/mcp.py
@@ -1,0 +1,118 @@
+import json
+import uuid
+from datetime import datetime, UTC
+
+import sqlalchemy
+from sqlalchemy import Boolean, Column, DateTime, ForeignKey, String, Text
+from sqlalchemy.orm import relationship
+from sqlalchemy.types import TEXT, TypeDecorator
+
+from app.models.base import Base
+
+
+class JSONType(TypeDecorator):
+    """Store JSON values as TEXT for SQLite/Postgres compatibility."""
+
+    impl = TEXT
+    cache_ok = True
+
+    def process_bind_param(self, value, dialect):
+        if value is not None:
+            value = json.dumps(value)
+        return value
+
+    def process_result_value(self, value, dialect):
+        if value is not None:
+            return json.loads(value)
+        return value
+
+
+class MCPServerRegistry(Base):
+    __tablename__ = "mcp_server_registry"
+
+    id = Column(String(32), primary_key=True, default=lambda: str(uuid.uuid4()).replace("-", ""))
+    user_id = Column(String(32), ForeignKey("users.id", name="fk_mcp_server_registry_user_id"), nullable=False, index=True)
+
+    plugin_slug = Column(String, nullable=True, index=True)
+    runtime_id = Column(String, ForeignKey("plugin_service_runtime.id", name="fk_mcp_server_registry_runtime_id"), nullable=True, index=True)
+
+    base_url = Column(String, nullable=False)
+    tools_url = Column(String, nullable=False)
+    healthcheck_url = Column(String, nullable=True)
+    tool_call_url_template = Column(String, nullable=False, default="/tool:{name}")
+
+    auth_mode = Column(String, nullable=False, default="none")
+    auth_ref = Column(String, nullable=True)
+    status = Column(String, nullable=False, default="registered")
+    last_sync_at = Column(DateTime, nullable=True)
+    last_error = Column(Text, nullable=True)
+
+    created_at = Column(DateTime, default=datetime.now(UTC))
+    updated_at = Column(DateTime, default=datetime.now(UTC), onupdate=datetime.now(UTC))
+
+    tools = relationship("MCPToolRegistry", back_populates="server", cascade="all, delete-orphan")
+
+    __table_args__ = (
+        sqlalchemy.UniqueConstraint("user_id", "runtime_id", name="uq_mcp_server_registry_user_runtime"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "user_id": self.user_id,
+            "plugin_slug": self.plugin_slug,
+            "runtime_id": self.runtime_id,
+            "base_url": self.base_url,
+            "tools_url": self.tools_url,
+            "healthcheck_url": self.healthcheck_url,
+            "tool_call_url_template": self.tool_call_url_template,
+            "auth_mode": self.auth_mode,
+            "auth_ref": self.auth_ref,
+            "status": self.status,
+            "last_sync_at": self.last_sync_at.isoformat() if self.last_sync_at else None,
+            "last_error": self.last_error,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }
+
+
+class MCPToolRegistry(Base):
+    __tablename__ = "mcp_tool_registry"
+
+    id = Column(String(32), primary_key=True, default=lambda: str(uuid.uuid4()).replace("-", ""))
+    server_id = Column(String(32), ForeignKey("mcp_server_registry.id", name="fk_mcp_tool_registry_server_id"), nullable=False, index=True)
+
+    name = Column(String, nullable=False)
+    description = Column(Text, nullable=True)
+    schema_json = Column(JSONType, nullable=False)
+
+    enabled = Column(Boolean, nullable=False, default=True)
+    stale = Column(Boolean, nullable=False, default=False)
+    source_hash = Column(String(64), nullable=False)
+    version = Column(String, nullable=True)
+    safety_class = Column(String, nullable=False, default="read_only")
+
+    created_at = Column(DateTime, default=datetime.now(UTC))
+    updated_at = Column(DateTime, default=datetime.now(UTC), onupdate=datetime.now(UTC))
+
+    server = relationship("MCPServerRegistry", back_populates="tools")
+
+    __table_args__ = (
+        sqlalchemy.UniqueConstraint("server_id", "name", name="uq_mcp_tool_registry_server_tool"),
+    )
+
+    def to_dict(self) -> dict:
+        return {
+            "id": self.id,
+            "server_id": self.server_id,
+            "name": self.name,
+            "description": self.description,
+            "schema_json": self.schema_json,
+            "enabled": self.enabled,
+            "stale": self.stale,
+            "source_hash": self.source_hash,
+            "version": self.version,
+            "safety_class": self.safety_class,
+            "created_at": self.created_at.isoformat() if self.created_at else None,
+            "updated_at": self.updated_at.isoformat() if self.updated_at else None,
+        }

--- a/backend/app/routers/plugins.py
+++ b/backend/app/routers/plugins.py
@@ -67,22 +67,20 @@ def _is_version_newer(version1: str, version2: str) -> bool:
         logger.error(f"Error comparing versions {version1} vs {version2}: {e}")
         return False
 
-# Initialize plugin manager on startup
-@router.on_event("startup")
-async def startup_event():
-    """Initialize plugin manager on startup."""
+async def initialize_plugin_manager_on_startup() -> None:
+    """Initialize plugin manager and discover plugin metadata for all users."""
     await plugin_manager.initialize()
-    
+
     # Discover plugins for all users
     async for db in get_db():
         # Get all users
         result = await db.execute(select(User))
         users = result.scalars().all()
-        
+
         # Discover plugins for each user
         for user in users:
             await plugin_manager._discover_plugins(user_id=user.id)
-        
+
         break  # Only need one session
 
 @router.get("/plugins/manifest")

--- a/backend/app/services/mcp_registry_service.py
+++ b/backend/app/services/mcp_registry_service.py
@@ -1,0 +1,575 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+import os
+import uuid
+from datetime import datetime, UTC
+from time import perf_counter
+from typing import Any, Dict, List, Optional, Tuple
+from urllib.parse import urlparse
+
+import httpx
+from sqlalchemy import Select, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from app.models.mcp import MCPServerRegistry, MCPToolRegistry
+from app.models.plugin import PluginServiceRuntime
+
+try:
+    from jsonschema import Draft7Validator
+except Exception:  # pragma: no cover - fallback path if jsonschema is unavailable
+    Draft7Validator = None
+
+logger = logging.getLogger(__name__)
+
+READ_ONLY_PREFIXES = (
+    "get",
+    "list",
+    "read",
+    "search",
+    "preview",
+    "project_exists",
+    "digest",
+    "summarize",
+)
+
+MUTATING_PREFIXES = (
+    "create",
+    "write",
+    "edit",
+    "delete",
+    "move",
+    "copy",
+    "rename",
+    "update",
+    "set",
+    "append",
+    "prepend",
+    "complete",
+    "reopen",
+)
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "")
+
+
+def derive_base_url(healthcheck_url: Optional[str]) -> Optional[str]:
+    if not healthcheck_url:
+        return None
+    parsed = urlparse(healthcheck_url.strip())
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def normalize_tools_payload(payload: Any) -> List[Dict[str, Any]]:
+    if isinstance(payload, dict):
+        if isinstance(payload.get("data"), dict) and isinstance(payload["data"].get("tools"), list):
+            tools = payload["data"]["tools"]
+        elif isinstance(payload.get("tools"), list):
+            tools = payload["tools"]
+        else:
+            tools = []
+    elif isinstance(payload, list):
+        tools = payload
+    else:
+        tools = []
+
+    normalized: List[Dict[str, Any]] = []
+    for entry in tools:
+        if not isinstance(entry, dict):
+            continue
+
+        # Accept both OpenAI-style {"type":"function","function":...} and direct function shape.
+        function_obj = entry.get("function") if isinstance(entry.get("function"), dict) else entry
+        if not isinstance(function_obj, dict):
+            continue
+
+        name = function_obj.get("name")
+        if not isinstance(name, str) or not name.strip():
+            continue
+
+        description = function_obj.get("description")
+        if not isinstance(description, str):
+            description = ""
+
+        parameters = function_obj.get("parameters")
+        if not isinstance(parameters, dict):
+            parameters = {"type": "object", "properties": {}}
+
+        normalized.append(
+            {
+                "type": "function",
+                "function": {
+                    "name": name.strip(),
+                    "description": description,
+                    "parameters": parameters,
+                },
+            }
+        )
+
+    return normalized
+
+
+def infer_safety_class(tool_name: str) -> str:
+    lowered = (tool_name or "").strip().lower()
+    if not lowered:
+        return "read_only"
+    if lowered.startswith(MUTATING_PREFIXES):
+        return "mutating"
+    if lowered.startswith(READ_ONLY_PREFIXES):
+        return "read_only"
+    return "read_only"
+
+
+def compute_tool_hash(tool_schema: Dict[str, Any]) -> str:
+    canonical = json.dumps(tool_schema, sort_keys=True, separators=(",", ":"))
+    return hashlib.sha256(canonical.encode("utf-8")).hexdigest()
+
+
+def build_tool_call_url(server: MCPServerRegistry, tool_name: str) -> str:
+    template = (server.tool_call_url_template or "/tool:{name}").strip()
+    if "{name}" not in template:
+        if template.endswith("/"):
+            template = f"{template}tool:{{name}}"
+        else:
+            template = f"{template}/tool:{{name}}"
+
+    rendered = template.replace("{name}", tool_name)
+    if rendered.startswith("http://") or rendered.startswith("https://"):
+        return rendered
+
+    return f"{server.base_url.rstrip('/')}/{rendered.lstrip('/')}"
+
+
+def _validate_tool_arguments(tool_schema: Dict[str, Any], arguments: Dict[str, Any]) -> Tuple[bool, List[str]]:
+    if not isinstance(arguments, dict):
+        return False, ["Tool arguments must be a JSON object."]
+
+    parameters = (
+        tool_schema.get("function", {}).get("parameters")
+        if isinstance(tool_schema.get("function"), dict)
+        else None
+    )
+    if not isinstance(parameters, dict):
+        return True, []
+
+    if Draft7Validator is None:
+        # Fallback to a minimal required-field check when jsonschema is unavailable.
+        required = parameters.get("required") if isinstance(parameters.get("required"), list) else []
+        missing = [key for key in required if key not in arguments]
+        if missing:
+            return False, [f"Missing required argument: {field}" for field in missing]
+        return True, []
+
+    validator = Draft7Validator(parameters)
+    errors = sorted(validator.iter_errors(arguments), key=lambda err: err.path)
+    if not errors:
+        return True, []
+    return False, [error.message for error in errors]
+
+
+def _build_tool_call_headers(user_id: str, request_id: Optional[str] = None) -> Dict[str, str]:
+    headers: Dict[str, str] = {
+        "X-BrainDrive-User-Id": _normalize_user_id(user_id),
+        "X-BrainDrive-Request-Id": request_id or str(uuid.uuid4()),
+    }
+    service_token = os.environ.get("BRAINDRIVE_LIBRARY_SERVICE_TOKEN", "").strip()
+    if service_token:
+        headers["X-BrainDrive-Service-Token"] = service_token
+    return headers
+
+
+class MCPRegistryService:
+    def __init__(self, db: AsyncSession, tools_timeout_seconds: float = 15.0, call_timeout_seconds: float = 15.0):
+        self.db = db
+        self.tools_timeout_seconds = tools_timeout_seconds
+        self.call_timeout_seconds = call_timeout_seconds
+
+    async def _list_runtime_candidates(
+        self,
+        user_id: str,
+        plugin_slug_filter: Optional[str] = None,
+    ) -> List[PluginServiceRuntime]:
+        normalized_user_id = _normalize_user_id(user_id)
+        stmt: Select = select(PluginServiceRuntime).where(
+            PluginServiceRuntime.user_id == normalized_user_id,
+            PluginServiceRuntime.healthcheck_url.isnot(None),
+        )
+        if plugin_slug_filter:
+            stmt = stmt.where(PluginServiceRuntime.plugin_slug == plugin_slug_filter)
+
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def auto_register_managed_servers(
+        self,
+        user_id: str,
+        plugin_slug_filter: Optional[str] = None,
+    ) -> List[MCPServerRegistry]:
+        normalized_user_id = _normalize_user_id(user_id)
+        runtimes = await self._list_runtime_candidates(
+            normalized_user_id, plugin_slug_filter=plugin_slug_filter
+        )
+        if not runtimes:
+            return []
+
+        runtime_ids = [runtime.id for runtime in runtimes]
+        existing_result = await self.db.execute(
+            select(MCPServerRegistry).where(
+                MCPServerRegistry.user_id == normalized_user_id,
+                MCPServerRegistry.runtime_id.in_(runtime_ids),
+            )
+        )
+        existing_by_runtime = {
+            server.runtime_id: server
+            for server in existing_result.scalars().all()
+            if server.runtime_id
+        }
+
+        registered: List[MCPServerRegistry] = []
+        for runtime in runtimes:
+            base_url = derive_base_url(runtime.healthcheck_url)
+            if not base_url:
+                continue
+
+            server = existing_by_runtime.get(runtime.id)
+            if server is None:
+                server = MCPServerRegistry(
+                    user_id=normalized_user_id,
+                    plugin_slug=runtime.plugin_slug,
+                    runtime_id=runtime.id,
+                    base_url=base_url,
+                    tools_url=f"{base_url}/tools",
+                    healthcheck_url=runtime.healthcheck_url,
+                    tool_call_url_template="/tool:{name}",
+                    status="registered",
+                )
+                self.db.add(server)
+            else:
+                server.plugin_slug = runtime.plugin_slug
+                server.base_url = base_url
+                server.tools_url = f"{base_url}/tools"
+                server.healthcheck_url = runtime.healthcheck_url
+                if not server.tool_call_url_template:
+                    server.tool_call_url_template = "/tool:{name}"
+                if server.status == "error":
+                    server.status = "registered"
+
+            registered.append(server)
+
+        await self.db.flush()
+        return registered
+
+    async def sync_server_tools(self, server: MCPServerRegistry) -> Dict[str, Any]:
+        started_at = perf_counter()
+        summary: Dict[str, Any] = {
+            "server_id": server.id,
+            "plugin_slug": server.plugin_slug,
+            "base_url": server.base_url,
+            "tools_url": server.tools_url,
+            "fetched_count": 0,
+            "upserted_count": 0,
+            "stale_disabled_count": 0,
+            "status": "error",
+            "error": None,
+            "duration_ms": 0,
+        }
+
+        try:
+            async with httpx.AsyncClient(timeout=self.tools_timeout_seconds) as client:
+                response = await client.get(server.tools_url)
+                response.raise_for_status()
+                payload = response.json()
+
+            tools = normalize_tools_payload(payload)
+            summary["fetched_count"] = len(tools)
+
+            existing_result = await self.db.execute(
+                select(MCPToolRegistry).where(MCPToolRegistry.server_id == server.id)
+            )
+            existing_tools = list(existing_result.scalars().all())
+            existing_by_name = {tool.name: tool for tool in existing_tools}
+
+            active_tool_names: set[str] = set()
+            upserted_count = 0
+            for tool_schema in tools:
+                function = tool_schema.get("function", {})
+                name = function.get("name")
+                if not isinstance(name, str) or not name:
+                    continue
+
+                description = function.get("description")
+                if not isinstance(description, str):
+                    description = ""
+
+                source_hash = compute_tool_hash(tool_schema)
+                safety_class = infer_safety_class(name)
+                version = source_hash[:12]
+
+                record = existing_by_name.get(name)
+                if record is None:
+                    record = MCPToolRegistry(
+                        server_id=server.id,
+                        name=name,
+                        description=description,
+                        schema_json=tool_schema,
+                        enabled=True,
+                        stale=False,
+                        source_hash=source_hash,
+                        version=version,
+                        safety_class=safety_class,
+                    )
+                    self.db.add(record)
+                else:
+                    record.description = description
+                    record.schema_json = tool_schema
+                    record.source_hash = source_hash
+                    record.version = version
+                    record.safety_class = safety_class
+                    record.stale = False
+                upserted_count += 1
+                active_tool_names.add(name)
+
+            stale_disabled_count = 0
+            for existing in existing_tools:
+                if existing.name in active_tool_names:
+                    continue
+                if not existing.stale or existing.enabled:
+                    stale_disabled_count += 1
+                existing.stale = True
+                existing.enabled = False
+
+            server.status = "healthy"
+            server.last_sync_at = datetime.now(UTC)
+            server.last_error = None
+
+            summary.update(
+                {
+                    "upserted_count": upserted_count,
+                    "stale_disabled_count": stale_disabled_count,
+                    "status": "healthy",
+                }
+            )
+        except Exception as exc:
+            logger.warning(
+                "MCP tools sync failed for server=%s tools_url=%s error=%s",
+                server.id,
+                server.tools_url,
+                exc,
+            )
+            server.status = "error"
+            server.last_error = str(exc)
+            summary["error"] = str(exc)
+        finally:
+            summary["duration_ms"] = int((perf_counter() - started_at) * 1000)
+            await self.db.flush()
+
+        return summary
+
+    async def sync_user_servers(
+        self,
+        user_id: str,
+        plugin_slug_filter: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        normalized_user_id = _normalize_user_id(user_id)
+
+        await self.auto_register_managed_servers(
+            normalized_user_id, plugin_slug_filter=plugin_slug_filter
+        )
+
+        stmt = select(MCPServerRegistry).where(MCPServerRegistry.user_id == normalized_user_id)
+        if plugin_slug_filter:
+            stmt = stmt.where(MCPServerRegistry.plugin_slug == plugin_slug_filter)
+        result = await self.db.execute(stmt)
+        servers = list(result.scalars().all())
+
+        server_summaries: List[Dict[str, Any]] = []
+        for server in servers:
+            summary = await self.sync_server_tools(server)
+            server_summaries.append(summary)
+
+        await self.db.commit()
+
+        total_tools_synced = sum(item.get("upserted_count", 0) for item in server_summaries)
+        total_errors = sum(1 for item in server_summaries if item.get("status") != "healthy")
+        return {
+            "user_id": normalized_user_id,
+            "server_count": len(servers),
+            "tool_upserts": total_tools_synced,
+            "error_count": total_errors,
+            "servers": server_summaries,
+        }
+
+    async def list_servers(self, user_id: str) -> List[MCPServerRegistry]:
+        normalized_user_id = _normalize_user_id(user_id)
+        result = await self.db.execute(
+            select(MCPServerRegistry).where(MCPServerRegistry.user_id == normalized_user_id)
+        )
+        return list(result.scalars().all())
+
+    async def list_tools(self, user_id: str, enabled_only: bool = False) -> List[MCPToolRegistry]:
+        normalized_user_id = _normalize_user_id(user_id)
+        stmt = (
+            select(MCPToolRegistry)
+            .join(MCPServerRegistry, MCPServerRegistry.id == MCPToolRegistry.server_id)
+            .where(MCPServerRegistry.user_id == normalized_user_id)
+        )
+        if enabled_only:
+            stmt = stmt.where(MCPToolRegistry.enabled.is_(True), MCPToolRegistry.stale.is_(False))
+        result = await self.db.execute(stmt)
+        return list(result.scalars().all())
+
+    async def resolve_tools_for_request(
+        self,
+        user_id: str,
+        *,
+        mcp_tools_enabled: bool,
+        mcp_scope_mode: str,
+        mcp_project_slug: Optional[str],
+        plugin_slug: Optional[str] = None,
+        max_tools: int = 32,
+        max_schema_bytes: int = 128_000,
+    ) -> Tuple[List[Dict[str, Any]], Dict[str, Any]]:
+        scope_mode = (mcp_scope_mode or "none").strip().lower()
+        if not mcp_tools_enabled or scope_mode != "project" or not mcp_project_slug:
+            return [], {
+                "enabled": False,
+                "scope_mode": scope_mode,
+                "project_slug": mcp_project_slug,
+                "available_count": 0,
+                "selected_count": 0,
+                "reason": "scope_disabled",
+            }
+
+        normalized_user_id = _normalize_user_id(user_id)
+        stmt = (
+            select(MCPToolRegistry)
+            .join(MCPServerRegistry, MCPServerRegistry.id == MCPToolRegistry.server_id)
+            .where(
+                MCPServerRegistry.user_id == normalized_user_id,
+                MCPToolRegistry.enabled.is_(True),
+                MCPToolRegistry.stale.is_(False),
+            )
+        )
+        if plugin_slug:
+            stmt = stmt.where(MCPServerRegistry.plugin_slug == plugin_slug)
+
+        result = await self.db.execute(stmt)
+        all_tools = list(result.scalars().all())
+
+        selected: List[Dict[str, Any]] = []
+        total_schema_bytes = 0
+        for tool in sorted(all_tools, key=lambda item: item.name):
+            if len(selected) >= max_tools:
+                break
+            schema = tool.schema_json
+            if not isinstance(schema, dict):
+                continue
+            serialized = json.dumps(schema, separators=(",", ":"))
+            encoded_size = len(serialized.encode("utf-8"))
+            if total_schema_bytes + encoded_size > max_schema_bytes:
+                break
+            selected.append(schema)
+            total_schema_bytes += encoded_size
+
+        return selected, {
+            "enabled": bool(selected),
+            "scope_mode": scope_mode,
+            "project_slug": mcp_project_slug,
+            "available_count": len(all_tools),
+            "selected_count": len(selected),
+            "total_schema_bytes": total_schema_bytes,
+        }
+
+    async def get_enabled_tool(
+        self,
+        user_id: str,
+        tool_name: str,
+    ) -> Optional[MCPToolRegistry]:
+        normalized_user_id = _normalize_user_id(user_id)
+        result = await self.db.execute(
+            select(MCPToolRegistry)
+            .options(joinedload(MCPToolRegistry.server))
+            .join(MCPServerRegistry, MCPServerRegistry.id == MCPToolRegistry.server_id)
+            .where(
+                MCPServerRegistry.user_id == normalized_user_id,
+                MCPToolRegistry.name == tool_name,
+                MCPToolRegistry.enabled.is_(True),
+                MCPToolRegistry.stale.is_(False),
+            )
+        )
+        return result.scalars().first()
+
+    async def execute_tool_call(
+        self,
+        user_id: str,
+        tool_name: str,
+        arguments: Dict[str, Any],
+        request_id: Optional[str] = None,
+    ) -> Dict[str, Any]:
+        tool = await self.get_enabled_tool(user_id, tool_name)
+        if tool is None:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "TOOL_NOT_ALLOWED",
+                    "message": f"Tool '{tool_name}' is not enabled for this user.",
+                },
+            }
+
+        schema = tool.schema_json if isinstance(tool.schema_json, dict) else {}
+        is_valid, validation_errors = _validate_tool_arguments(schema, arguments)
+        if not is_valid:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "TOOL_ARGUMENTS_INVALID",
+                    "message": "Tool arguments failed schema validation.",
+                    "details": validation_errors,
+                },
+            }
+
+        call_url = build_tool_call_url(tool.server, tool_name)
+        headers = _build_tool_call_headers(user_id, request_id=request_id)
+        started_at = perf_counter()
+        try:
+            async with httpx.AsyncClient(timeout=self.call_timeout_seconds) as client:
+                response = await client.post(call_url, json=arguments, headers=headers)
+
+            elapsed_ms = int((perf_counter() - started_at) * 1000)
+            try:
+                payload = response.json()
+            except ValueError:
+                payload = {"raw_text": response.text}
+
+            if response.status_code >= 400:
+                return {
+                    "ok": False,
+                    "latency_ms": elapsed_ms,
+                    "http_status": response.status_code,
+                    "error": {
+                        "code": "TOOL_HTTP_ERROR",
+                        "message": f"MCP tool call failed with status {response.status_code}.",
+                        "details": payload,
+                    },
+                }
+
+            return {
+                "ok": True,
+                "latency_ms": elapsed_ms,
+                "http_status": response.status_code,
+                "data": payload,
+            }
+        except Exception as exc:
+            return {
+                "ok": False,
+                "error": {
+                    "code": "TOOL_EXECUTION_ERROR",
+                    "message": str(exc),
+                },
+            }

--- a/backend/migrations/versions/2cb3f0bb9d9d_add_mcp_registry_tables.py
+++ b/backend/migrations/versions/2cb3f0bb9d9d_add_mcp_registry_tables.py
@@ -1,0 +1,101 @@
+"""add mcp registry tables
+
+Revision ID: 2cb3f0bb9d9d
+Revises: 1f4b3a9d7c2e
+Create Date: 2026-02-10 00:00:00
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = "2cb3f0bb9d9d"
+down_revision: Union[str, None] = "1f4b3a9d7c2e"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def _table_exists(name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    return name in inspector.get_table_names()
+
+
+def _index_exists(table_name: str, index_name: str) -> bool:
+    inspector = sa.inspect(op.get_bind())
+    indexes = inspector.get_indexes(table_name) if table_name in inspector.get_table_names() else []
+    return any(index.get("name") == index_name for index in indexes)
+
+
+def upgrade() -> None:
+    if not _table_exists("mcp_server_registry"):
+        op.create_table(
+            "mcp_server_registry",
+            sa.Column("id", sa.String(length=32), nullable=False),
+            sa.Column("user_id", sa.String(length=32), nullable=False),
+            sa.Column("plugin_slug", sa.String(), nullable=True),
+            sa.Column("runtime_id", sa.String(), nullable=True),
+            sa.Column("base_url", sa.String(), nullable=False),
+            sa.Column("tools_url", sa.String(), nullable=False),
+            sa.Column("healthcheck_url", sa.String(), nullable=True),
+            sa.Column("tool_call_url_template", sa.String(), nullable=False, server_default="/tool:{name}"),
+            sa.Column("auth_mode", sa.String(), nullable=False, server_default="none"),
+            sa.Column("auth_ref", sa.String(), nullable=True),
+            sa.Column("status", sa.String(), nullable=False, server_default="registered"),
+            sa.Column("last_sync_at", sa.DateTime(), nullable=True),
+            sa.Column("last_error", sa.Text(), nullable=True),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(["runtime_id"], ["plugin_service_runtime.id"], name="fk_mcp_server_registry_runtime_id"),
+            sa.ForeignKeyConstraint(["user_id"], ["users.id"], name="fk_mcp_server_registry_user_id"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("user_id", "runtime_id", name="uq_mcp_server_registry_user_runtime"),
+        )
+
+    if not _index_exists("mcp_server_registry", "ix_mcp_server_registry_user_id"):
+        op.create_index("ix_mcp_server_registry_user_id", "mcp_server_registry", ["user_id"], unique=False)
+    if not _index_exists("mcp_server_registry", "ix_mcp_server_registry_plugin_slug"):
+        op.create_index("ix_mcp_server_registry_plugin_slug", "mcp_server_registry", ["plugin_slug"], unique=False)
+    if not _index_exists("mcp_server_registry", "ix_mcp_server_registry_runtime_id"):
+        op.create_index("ix_mcp_server_registry_runtime_id", "mcp_server_registry", ["runtime_id"], unique=False)
+
+    if not _table_exists("mcp_tool_registry"):
+        op.create_table(
+            "mcp_tool_registry",
+            sa.Column("id", sa.String(length=32), nullable=False),
+            sa.Column("server_id", sa.String(length=32), nullable=False),
+            sa.Column("name", sa.String(), nullable=False),
+            sa.Column("description", sa.Text(), nullable=True),
+            sa.Column("schema_json", sa.Text(), nullable=False),
+            sa.Column("enabled", sa.Boolean(), nullable=False, server_default=sa.text("1")),
+            sa.Column("stale", sa.Boolean(), nullable=False, server_default=sa.text("0")),
+            sa.Column("source_hash", sa.String(length=64), nullable=False),
+            sa.Column("version", sa.String(), nullable=True),
+            sa.Column("safety_class", sa.String(), nullable=False, server_default="read_only"),
+            sa.Column("created_at", sa.DateTime(), nullable=True),
+            sa.Column("updated_at", sa.DateTime(), nullable=True),
+            sa.ForeignKeyConstraint(["server_id"], ["mcp_server_registry.id"], name="fk_mcp_tool_registry_server_id"),
+            sa.PrimaryKeyConstraint("id"),
+            sa.UniqueConstraint("server_id", "name", name="uq_mcp_tool_registry_server_tool"),
+        )
+
+    if not _index_exists("mcp_tool_registry", "ix_mcp_tool_registry_server_id"):
+        op.create_index("ix_mcp_tool_registry_server_id", "mcp_tool_registry", ["server_id"], unique=False)
+
+
+def downgrade() -> None:
+    if _table_exists("mcp_tool_registry"):
+        if _index_exists("mcp_tool_registry", "ix_mcp_tool_registry_server_id"):
+            op.drop_index("ix_mcp_tool_registry_server_id", table_name="mcp_tool_registry")
+        op.drop_table("mcp_tool_registry")
+
+    if _table_exists("mcp_server_registry"):
+        if _index_exists("mcp_server_registry", "ix_mcp_server_registry_runtime_id"):
+            op.drop_index("ix_mcp_server_registry_runtime_id", table_name="mcp_server_registry")
+        if _index_exists("mcp_server_registry", "ix_mcp_server_registry_plugin_slug"):
+            op.drop_index("ix_mcp_server_registry_plugin_slug", table_name="mcp_server_registry")
+        if _index_exists("mcp_server_registry", "ix_mcp_server_registry_user_id"):
+            op.drop_index("ix_mcp_server_registry_user_id", table_name="mcp_server_registry")
+        op.drop_table("mcp_server_registry")

--- a/backend/scripts/bootstrap_library_user_scope.py
+++ b/backend/scripts/bootstrap_library_user_scope.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 """
-Create user-scoped Library Service directory structure for local development.
+Create canonical user-scoped Library Service directory structure for local development.
 """
 
 from __future__ import annotations
@@ -8,8 +8,19 @@ from __future__ import annotations
 import argparse
 import json
 import re
+import sys
 from pathlib import Path
 from typing import Iterable
+
+BACKEND_ROOT = Path(__file__).resolve().parents[1]
+if str(BACKEND_ROOT) not in sys.path:
+    sys.path.insert(0, str(BACKEND_ROOT))
+
+from app.core.user_initializer.library_template import (  # noqa: E402
+    apply_canonical_schema,
+    copy_base_template_idempotent,
+    resolve_base_template_path,
+)
 
 USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9_]{3,128}$")
 
@@ -25,39 +36,38 @@ def normalize_user_id(raw_user_id: str) -> str:
     return normalized
 
 
-def ensure_user_structure(library_root: Path, user_id: str) -> dict[str, object]:
+def ensure_user_structure(
+    library_root: Path,
+    user_id: str,
+    template_root: Path,
+) -> dict[str, object]:
     normalized_user_id = normalize_user_id(user_id)
     scoped_root = library_root / "users" / normalized_user_id
+    scoped_root.mkdir(parents=True, exist_ok=True)
 
-    created_paths: list[str] = []
-    required_dirs = [
-        scoped_root,
-        scoped_root / "projects" / "active",
-        scoped_root / "transcripts",
-        scoped_root / "pulse",
-        scoped_root / "docs",
-    ]
-    for directory in required_dirs:
-        if not directory.exists():
-            created_paths.append(directory.as_posix())
-        directory.mkdir(parents=True, exist_ok=True)
+    copy_result = copy_base_template_idempotent(template_root, scoped_root)
+    schema_result = apply_canonical_schema(scoped_root)
 
-    activity_log = scoped_root / "activity.log"
-    if not activity_log.exists():
-        activity_log.touch()
-        created_paths.append(activity_log.as_posix())
+    changed_paths = sorted(
+        {
+            *copy_result.copied_files,
+            *(path.as_posix() for path in getattr(schema_result, "changed_paths", []) or []),
+        }
+    )
 
     return {
         "requested_user_id": user_id,
         "normalized_user_id": normalized_user_id,
         "scoped_root": scoped_root.as_posix(),
-        "created_paths": created_paths,
+        "copied_template_files": list(copy_result.copied_files),
+        "skipped_template_files": list(copy_result.skipped_files),
+        "changed_paths": changed_paths,
     }
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Bootstrap user-scoped Library Service directories."
+        description="Bootstrap canonical user-scoped Library Service directories."
     )
     parser.add_argument(
         "--library-root",
@@ -71,23 +81,45 @@ def parse_args() -> argparse.Namespace:
         required=True,
         help="User id to bootstrap (repeat for multiple users).",
     )
+    parser.add_argument(
+        "--template-root",
+        required=False,
+        help="Optional Base_Library template path override.",
+    )
     return parser.parse_args()
 
 
-def run(library_root: Path, user_ids: Iterable[str]) -> dict[str, object]:
+def run(
+    library_root: Path,
+    user_ids: Iterable[str],
+    template_root: Path | None = None,
+) -> dict[str, object]:
     resolved_root = library_root.expanduser().resolve()
     resolved_root.mkdir(parents=True, exist_ok=True)
 
-    users = [ensure_user_structure(resolved_root, user_id) for user_id in user_ids]
+    resolved_template = (
+        template_root.expanduser().resolve()
+        if isinstance(template_root, Path)
+        else resolve_base_template_path()
+    )
+    if not resolved_template.is_dir():
+        raise FileNotFoundError(f"Template root does not exist: {resolved_template}")
+
+    users = [
+        ensure_user_structure(resolved_root, user_id, resolved_template)
+        for user_id in user_ids
+    ]
     return {
         "library_root": resolved_root.as_posix(),
+        "template_root": resolved_template.as_posix(),
         "users": users,
     }
 
 
 def main() -> int:
     args = parse_args()
-    payload = run(Path(args.library_root), args.user_ids)
+    template_root = Path(args.template_root) if args.template_root else None
+    payload = run(Path(args.library_root), args.user_ids, template_root=template_root)
     print(json.dumps(payload, indent=2))
     return 0
 

--- a/backend/scripts/bootstrap_library_user_scope.py
+++ b/backend/scripts/bootstrap_library_user_scope.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+"""
+Create user-scoped Library Service directory structure for local development.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+from pathlib import Path
+from typing import Iterable
+
+USER_ID_PATTERN = re.compile(r"^[A-Za-z0-9_]{3,128}$")
+
+
+def normalize_user_id(raw_user_id: str) -> str:
+    normalized = str(raw_user_id).strip().replace("-", "")
+    if not normalized:
+        raise ValueError("user_id cannot be empty")
+    if not USER_ID_PATTERN.fullmatch(normalized):
+        raise ValueError(
+            f"user_id '{raw_user_id}' contains invalid characters after normalization"
+        )
+    return normalized
+
+
+def ensure_user_structure(library_root: Path, user_id: str) -> dict[str, object]:
+    normalized_user_id = normalize_user_id(user_id)
+    scoped_root = library_root / "users" / normalized_user_id
+
+    created_paths: list[str] = []
+    required_dirs = [
+        scoped_root,
+        scoped_root / "projects" / "active",
+        scoped_root / "transcripts",
+        scoped_root / "pulse",
+        scoped_root / "docs",
+    ]
+    for directory in required_dirs:
+        if not directory.exists():
+            created_paths.append(directory.as_posix())
+        directory.mkdir(parents=True, exist_ok=True)
+
+    activity_log = scoped_root / "activity.log"
+    if not activity_log.exists():
+        activity_log.touch()
+        created_paths.append(activity_log.as_posix())
+
+    return {
+        "requested_user_id": user_id,
+        "normalized_user_id": normalized_user_id,
+        "scoped_root": scoped_root.as_posix(),
+        "created_paths": created_paths,
+    }
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Bootstrap user-scoped Library Service directories."
+    )
+    parser.add_argument(
+        "--library-root",
+        required=True,
+        help="Base BRAINDRIVE_LIBRARY_PATH directory.",
+    )
+    parser.add_argument(
+        "--user-id",
+        dest="user_ids",
+        action="append",
+        required=True,
+        help="User id to bootstrap (repeat for multiple users).",
+    )
+    return parser.parse_args()
+
+
+def run(library_root: Path, user_ids: Iterable[str]) -> dict[str, object]:
+    resolved_root = library_root.expanduser().resolve()
+    resolved_root.mkdir(parents=True, exist_ok=True)
+
+    users = [ensure_user_structure(resolved_root, user_id) for user_id in user_ids]
+    return {
+        "library_root": resolved_root.as_posix(),
+        "users": users,
+    }
+
+
+def main() -> int:
+    args = parse_args()
+    payload = run(Path(args.library_root), args.user_ids)
+    print(json.dumps(payload, indent=2))
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/backend/scripts/install_library_service_runtime_for_testing.py
+++ b/backend/scripts/install_library_service_runtime_for_testing.py
@@ -1,0 +1,805 @@
+#!/usr/bin/env python3
+"""
+Register or remove a Library Service runtime row for local testing.
+
+This script intentionally bypasses full plugin lifecycle installation so service
+runtime behavior can be tested independently.
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import os
+import re
+import shutil
+import sys
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Optional
+
+from sqlalchemy import text
+
+# Add backend to path for app imports.
+BACKEND_ROOT = Path(__file__).resolve().parent.parent
+PROJECT_ROOT = BACKEND_ROOT.parent
+sys.path.insert(0, str(BACKEND_ROOT))
+
+
+def _normalize_sqlite_url(url: str) -> Optional[str]:
+    prefix = "sqlite:///"
+    if not url.startswith(prefix):
+        return None
+    raw_path = url[len(prefix) :].strip()
+    if not raw_path:
+        return None
+    path = Path(raw_path)
+    if path.is_absolute():
+        return None
+    candidate = (BACKEND_ROOT / raw_path).resolve()
+    if candidate.exists():
+        return f"{prefix}{candidate.as_posix()}"
+    return None
+
+
+def _bootstrap_env() -> None:
+    if os.environ.get("USE_JSON_STORAGE", "").lower() in {"1", "true", "yes", "on"}:
+        if not os.environ.get("JSON_DB_PATH"):
+            candidate = BACKEND_ROOT / "storage" / "database.json"
+            if candidate.exists():
+                os.environ["JSON_DB_PATH"] = str(candidate)
+        return
+
+    db_url = os.environ.get("DATABASE_URL", "").strip()
+    normalized = _normalize_sqlite_url(db_url) if db_url else None
+    if normalized:
+        os.environ["DATABASE_URL"] = normalized
+        return
+
+    if not db_url:
+        candidate = BACKEND_ROOT / "braindrive.db"
+        if candidate.exists():
+            os.environ["DATABASE_URL"] = f"sqlite:///{candidate.as_posix()}"
+
+
+_bootstrap_env()
+
+from app.core.database import get_db  # type: ignore
+from app.models.user import User  # type: ignore
+
+DEFAULT_PLUGIN_SLUG = "BrainDriveLibraryService"
+DEFAULT_SERVICE_NAME = "library_service"
+DEFAULT_PLUGIN_NAME = "BrainDrive Library Service (Testing)"
+DEFAULT_PLUGIN_DESCRIPTION = "Testing-only plugin shell for Library Service runtime validation."
+DEFAULT_PLUGIN_VERSION = "0.1.0-testing"
+DEFAULT_RUNTIME_DIR_KEY = "Library-Service"
+DEFAULT_STATUS = "pending"
+DEFAULT_ENV_INHERIT = "minimal"
+DEFAULT_DEFINITION_ID = "braindrive_library_service_settings"
+DEFAULT_PORT = 18170
+DEFAULT_SOURCE_URL = str((PROJECT_ROOT / "PluginBuild" / "Library-Service").resolve())
+DEFAULT_INSTALL_COMMAND = "python service_scripts/install_with_venv.py"
+DEFAULT_START_COMMAND = "python service_scripts/start_with_venv.py"
+DEFAULT_STOP_COMMAND = "python service_scripts/shutdown_with_venv.py"
+DEFAULT_RESTART_COMMAND = "python service_scripts/restart_with_venv.py"
+SERVICES_RUNTIME_ENV_VAR = "BRAINDRIVE_SERVICES_RUNTIME_DIR"
+
+_RUNTIME_KEY_SANITIZER = re.compile(r"[^A-Za-z0-9._-]+")
+_SSH_STYLE_SOURCE = re.compile(r"^[^\s/@]+@[^\s/:]+:.+")
+
+
+def _utc_now() -> datetime:
+    return datetime.now(UTC)
+
+
+def _normalize_definition_id(value: Optional[str]) -> Optional[str]:
+    normalized = (value or "").strip()
+    if not normalized:
+        return None
+    if normalized.lower() in {"none", "null"}:
+        return None
+    return normalized
+
+
+def _build_plugin_id(user_id: str, plugin_slug: str) -> str:
+    return f"{user_id}_{plugin_slug}"
+
+
+def _build_runtime_id(user_id: str, plugin_slug: str, service_name: str) -> str:
+    return f"{user_id}_{plugin_slug}_{service_name}"
+
+
+def _sanitize_runtime_key(value: str) -> str:
+    cleaned = _RUNTIME_KEY_SANITIZER.sub("_", value.strip())
+    cleaned = cleaned.strip("_")
+    return cleaned or "service"
+
+
+def _runtime_key_from_source_url(source_url: str) -> Optional[str]:
+    cleaned = source_url.strip().rstrip("/")
+    if not cleaned:
+        return None
+    if cleaned.endswith(".git"):
+        cleaned = cleaned[:-4]
+    if "://" in cleaned:
+        _, remainder = cleaned.split("://", 1)
+        path = remainder.split("/", 1)[-1] if "/" in remainder else ""
+    else:
+        path = cleaned.split(":", 1)[-1]
+    if not path:
+        return None
+    repo = path.split("/")[-1]
+    return repo or None
+
+
+def _resolve_services_runtime_root() -> Path:
+    override = str(os.environ.get(SERVICES_RUNTIME_ENV_VAR, "")).strip()
+    if override:
+        return Path(override).expanduser().resolve()
+    return (BACKEND_ROOT / "services_runtime").resolve()
+
+
+def _resolve_runtime_target_dir(
+    *,
+    runtime_dir_key: str,
+    source_url: str,
+    plugin_slug: str,
+    service_name: str,
+) -> Path:
+    runtime_root = _resolve_services_runtime_root()
+    explicit_key = (runtime_dir_key or "").strip()
+    legacy_key = f"{plugin_slug}_{service_name}" if plugin_slug and service_name else ""
+    legacy_dir = (runtime_root / legacy_key).resolve() if legacy_key else None
+
+    if explicit_key:
+        explicit_dir = (runtime_root / _sanitize_runtime_key(explicit_key)).resolve()
+        if legacy_dir and legacy_dir.exists() and not explicit_dir.exists():
+            return legacy_dir
+        return explicit_dir
+
+    derived_key = _runtime_key_from_source_url(source_url) or service_name or legacy_key or "service"
+    shared_dir = (runtime_root / _sanitize_runtime_key(derived_key)).resolve()
+    if legacy_dir and legacy_dir.exists() and not shared_dir.exists():
+        return legacy_dir
+    return shared_dir
+
+
+def _is_remote_source_url(value: str) -> bool:
+    cleaned = (value or "").strip()
+    lowered = cleaned.lower()
+    if lowered.startswith(("http://", "https://", "ssh://", "git://")):
+        return True
+    return bool(_SSH_STYLE_SOURCE.match(cleaned))
+
+
+def _resolve_local_source_path(source_url: str) -> Path:
+    cleaned = (source_url or "").strip()
+    if not cleaned:
+        raise RuntimeError("source_url cannot be empty when runtime copy is enabled.")
+    if _is_remote_source_url(cleaned):
+        raise RuntimeError(
+            f"source_url '{cleaned}' is remote. Use a local path or pass --skip-runtime-copy."
+        )
+
+    if cleaned.startswith("file://"):
+        cleaned = cleaned[7:]
+
+    raw = Path(cleaned).expanduser()
+    candidates: list[Path] = []
+    if raw.is_absolute():
+        candidates.append(raw.resolve())
+    else:
+        candidates.extend(
+            [
+                (Path.cwd() / raw).resolve(),
+                (PROJECT_ROOT / raw).resolve(),
+                (BACKEND_ROOT / raw).resolve(),
+            ]
+        )
+
+    for candidate in candidates:
+        if candidate.exists():
+            return candidate
+
+    raise RuntimeError(f"Local source path not found for source_url '{source_url}'.")
+
+
+def _assert_safe_copy_paths(source_dir: Path, target_dir: Path) -> None:
+    source_dir = source_dir.resolve()
+    target_dir = target_dir.resolve()
+    if source_dir == target_dir:
+        raise RuntimeError("Source and runtime target are the same path; refusing to copy.")
+    if target_dir in source_dir.parents:
+        raise RuntimeError(
+            f"Runtime target '{target_dir}' is a parent of source '{source_dir}'; refusing to copy."
+        )
+    if source_dir in target_dir.parents:
+        raise RuntimeError(
+            f"Runtime target '{target_dir}' is inside source '{source_dir}'; refusing recursive copy."
+        )
+
+
+def _copy_runtime_from_local_source(source_url: str, target_dir: Path, copy_mode: str) -> dict[str, Any]:
+    source_dir = _resolve_local_source_path(source_url)
+    if not source_dir.is_dir():
+        raise RuntimeError(f"Local source '{source_dir}' is not a directory.")
+
+    _assert_safe_copy_paths(source_dir, target_dir)
+    target_dir.parent.mkdir(parents=True, exist_ok=True)
+
+    mode = (copy_mode or "replace").strip().lower()
+    ignored = shutil.ignore_patterns(
+        ".git",
+        ".pytest_cache",
+        ".ruff_cache",
+        "__pycache__",
+        "*.pyc",
+        "*.pyo",
+    )
+
+    existed_before = target_dir.exists()
+    if mode == "skip" and existed_before:
+        return {
+            "performed": False,
+            "mode": mode,
+            "skipped": True,
+            "reason": "target_exists",
+            "source": str(source_dir),
+            "target": str(target_dir),
+        }
+
+    if mode == "replace":
+        if target_dir.exists():
+            shutil.rmtree(target_dir)
+        shutil.copytree(source_dir, target_dir, ignore=ignored)
+    elif mode == "merge":
+        shutil.copytree(source_dir, target_dir, dirs_exist_ok=True, ignore=ignored)
+    elif mode == "skip":
+        shutil.copytree(source_dir, target_dir, ignore=ignored)
+    else:
+        raise RuntimeError(f"Unsupported runtime copy mode: {copy_mode}")
+
+    return {
+        "performed": True,
+        "mode": mode,
+        "source": str(source_dir),
+        "target": str(target_dir),
+        "target_exists": target_dir.exists(),
+        "service_scripts_present": (target_dir / "service_scripts").exists(),
+    }
+
+
+def _delete_runtime_dir_if_present(target_dir: Path) -> dict[str, Any]:
+    if not target_dir.exists():
+        return {"deleted": False, "target": str(target_dir), "reason": "not_found"}
+    shutil.rmtree(target_dir)
+    return {"deleted": True, "target": str(target_dir)}
+
+
+async def _resolve_user_id(db, user_id: Optional[str], user_email: Optional[str]) -> str:
+    if user_id:
+        return user_id.strip()
+    if not user_email:
+        raise RuntimeError("Provide --user-id or --user-email.")
+
+    user = await User.get_by_email(db, user_email.strip())
+    if user:
+        if isinstance(user, dict):
+            resolved = user.get("id") or user.get("user_id")
+        else:
+            resolved = getattr(user, "id", None)
+        if resolved:
+            return str(resolved)
+    raise RuntimeError(f"No user found with email: {user_email}")
+
+
+async def _existing_plugin_by_id(db, user_id: str, plugin_id: str):
+    result = await db.execute(
+        text(
+            """
+            SELECT id, plugin_slug
+            FROM plugin
+            WHERE id = :plugin_id AND user_id = :user_id
+            LIMIT 1
+            """
+        ),
+        {"plugin_id": plugin_id, "user_id": user_id},
+    )
+    return result.mappings().first()
+
+
+async def _existing_plugin_by_slug(db, user_id: str, plugin_slug: str):
+    result = await db.execute(
+        text(
+            """
+            SELECT id, plugin_slug
+            FROM plugin
+            WHERE plugin_slug = :plugin_slug AND user_id = :user_id
+            LIMIT 1
+            """
+        ),
+        {"plugin_slug": plugin_slug, "user_id": user_id},
+    )
+    return result.mappings().first()
+
+
+async def _ensure_plugin_row(
+    db,
+    *,
+    user_id: str,
+    plugin_id: str,
+    plugin_slug: str,
+    plugin_name: str,
+    plugin_description: str,
+    plugin_version: str,
+    plugin_source_url: str,
+    service_name: str,
+    skip_plugin_stub: bool,
+) -> tuple[str, str]:
+    existing = await _existing_plugin_by_id(db, user_id, plugin_id)
+    if existing:
+        existing_slug = str(existing["plugin_slug"])
+        if existing_slug != plugin_slug:
+            raise RuntimeError(
+                f"Existing plugin id '{plugin_id}' belongs to slug '{existing_slug}', "
+                f"not '{plugin_slug}'."
+            )
+        return str(existing["id"]), "existing_by_id"
+
+    existing_slug = await _existing_plugin_by_slug(db, user_id, plugin_slug)
+    if existing_slug:
+        return str(existing_slug["id"]), "existing_by_slug"
+
+    if skip_plugin_stub:
+        raise RuntimeError(
+            "Plugin row not found and --skip-plugin-stub was set. "
+            "Install plugin first or remove --skip-plugin-stub."
+        )
+
+    now_iso = _utc_now().isoformat()
+    await db.execute(
+        text(
+            """
+            INSERT INTO plugin (
+                id, plugin_slug, name, description, version,
+                type, plugin_type, enabled, status, official, author,
+                compatibility, scope, is_local, source_type, source_url,
+                installation_type, permissions, config_fields, messages,
+                dependencies, required_services_runtime, backend_dependencies,
+                created_at, updated_at, user_id
+            )
+            VALUES (
+                :id, :plugin_slug, :name, :description, :version,
+                :type, :plugin_type, :enabled, :status, :official, :author,
+                :compatibility, :scope, :is_local, :source_type, :source_url,
+                :installation_type, :permissions, :config_fields, :messages,
+                :dependencies, :required_services_runtime, :backend_dependencies,
+                :created_at, :updated_at, :user_id
+            )
+            """
+        ),
+        {
+            "id": plugin_id,
+            "plugin_slug": plugin_slug,
+            "name": plugin_name,
+            "description": plugin_description,
+            "version": plugin_version,
+            "type": "backend",
+            "plugin_type": "backend",
+            "enabled": True,
+            "status": "activated",
+            "official": False,
+            "author": "BrainDrive Testing",
+            "compatibility": "1.0.0",
+            "scope": plugin_slug,
+            "is_local": True,
+            "source_type": "local-testing",
+            "source_url": plugin_source_url,
+            "installation_type": "local",
+            "permissions": json.dumps(["api.access"]),
+            "config_fields": json.dumps({}),
+            "messages": json.dumps({}),
+            "dependencies": json.dumps([]),
+            "required_services_runtime": json.dumps([service_name]),
+            "backend_dependencies": json.dumps([]),
+            "created_at": now_iso,
+            "updated_at": now_iso,
+            "user_id": user_id,
+        },
+    )
+    return plugin_id, "created_stub"
+
+
+async def _upsert_runtime_row(db, payload: dict[str, Any]) -> None:
+    await db.execute(
+        text(
+            """
+            INSERT INTO plugin_service_runtime (
+                id, plugin_id, plugin_slug, name, source_url, type,
+                install_command, start_command, stop_command, restart_command,
+                healthcheck_url, definition_id, required_env_vars, runtime_dir_key,
+                env_inherit, env_overrides, status, created_at, updated_at, user_id
+            )
+            VALUES (
+                :id, :plugin_id, :plugin_slug, :name, :source_url, :type,
+                :install_command, :start_command, :stop_command, :restart_command,
+                :healthcheck_url, :definition_id, :required_env_vars, :runtime_dir_key,
+                :env_inherit, :env_overrides, :status, :created_at, :updated_at, :user_id
+            )
+            ON CONFLICT(id) DO UPDATE SET
+                plugin_id = excluded.plugin_id,
+                plugin_slug = excluded.plugin_slug,
+                name = excluded.name,
+                source_url = excluded.source_url,
+                type = excluded.type,
+                install_command = excluded.install_command,
+                start_command = excluded.start_command,
+                stop_command = excluded.stop_command,
+                restart_command = excluded.restart_command,
+                healthcheck_url = excluded.healthcheck_url,
+                definition_id = excluded.definition_id,
+                required_env_vars = excluded.required_env_vars,
+                runtime_dir_key = excluded.runtime_dir_key,
+                env_inherit = excluded.env_inherit,
+                env_overrides = excluded.env_overrides,
+                status = excluded.status,
+                updated_at = excluded.updated_at,
+                user_id = excluded.user_id
+            """
+        ),
+        payload,
+    )
+
+
+async def _fetch_runtime_row(db, runtime_id: str):
+    result = await db.execute(
+        text(
+            """
+            SELECT
+                id, plugin_id, plugin_slug, name, source_url, type,
+                install_command, start_command, stop_command, restart_command,
+                healthcheck_url, definition_id, required_env_vars,
+                runtime_dir_key, env_inherit, env_overrides, status,
+                created_at, updated_at, user_id
+            FROM plugin_service_runtime
+            WHERE id = :runtime_id
+            LIMIT 1
+            """
+        ),
+        {"runtime_id": runtime_id},
+    )
+    row = result.mappings().first()
+    if not row:
+        return None
+    data = dict(row)
+    for key in ("required_env_vars", "env_overrides"):
+        value = data.get(key)
+        if isinstance(value, str) and value.strip():
+            try:
+                data[key] = json.loads(value)
+            except json.JSONDecodeError:
+                pass
+    return data
+
+
+async def _delete_runtime_rows(
+    db,
+    *,
+    user_id: str,
+    runtime_id: str,
+    plugin_slug: str,
+    service_name: str,
+) -> int:
+    delete_by_id = await db.execute(
+        text("DELETE FROM plugin_service_runtime WHERE id = :id AND user_id = :user_id"),
+        {"id": runtime_id, "user_id": user_id},
+    )
+    deleted = int(delete_by_id.rowcount or 0)
+    if deleted > 0:
+        return deleted
+
+    delete_by_fields = await db.execute(
+        text(
+            """
+            DELETE FROM plugin_service_runtime
+            WHERE user_id = :user_id
+              AND plugin_slug = :plugin_slug
+              AND name = :service_name
+            """
+        ),
+        {
+            "user_id": user_id,
+            "plugin_slug": plugin_slug,
+            "service_name": service_name,
+        },
+    )
+    return int(delete_by_fields.rowcount or 0)
+
+
+async def _delete_plugin_stub_if_safe(
+    db,
+    *,
+    user_id: str,
+    plugin_id: str,
+    plugin_slug: str,
+) -> dict[str, Any]:
+    plugin_row = await _existing_plugin_by_id(db, user_id, plugin_id)
+    if not plugin_row:
+        return {"deleted": False, "reason": "plugin_not_found"}
+
+    runtime_count_res = await db.execute(
+        text(
+            "SELECT COUNT(*) FROM plugin_service_runtime WHERE plugin_id = :plugin_id AND user_id = :user_id"
+        ),
+        {"plugin_id": plugin_id, "user_id": user_id},
+    )
+    runtime_count = int(runtime_count_res.scalar_one())
+
+    module_count_res = await db.execute(
+        text("SELECT COUNT(*) FROM module WHERE plugin_id = :plugin_id AND user_id = :user_id"),
+        {"plugin_id": plugin_id, "user_id": user_id},
+    )
+    module_count = int(module_count_res.scalar_one())
+
+    if runtime_count > 0 or module_count > 0:
+        return {
+            "deleted": False,
+            "reason": "plugin_has_related_rows",
+            "runtime_count": runtime_count,
+            "module_count": module_count,
+        }
+
+    await db.execute(
+        text(
+            """
+            DELETE FROM plugin
+            WHERE id = :plugin_id
+              AND user_id = :user_id
+              AND plugin_slug = :plugin_slug
+            """
+        ),
+        {
+            "plugin_id": plugin_id,
+            "user_id": user_id,
+            "plugin_slug": plugin_slug,
+        },
+    )
+    return {"deleted": True}
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Install/update/delete Library Service runtime rows for testing."
+    )
+    parser.add_argument("--user-id", help="User ID to target.")
+    parser.add_argument("--user-email", help="User email to resolve user ID.")
+
+    parser.add_argument("--plugin-slug", default=DEFAULT_PLUGIN_SLUG, help="Plugin slug.")
+    parser.add_argument(
+        "--service-name",
+        default=DEFAULT_SERVICE_NAME,
+        help="Service name stored in plugin_service_runtime.name.",
+    )
+    parser.add_argument("--plugin-id", default=None, help="Optional explicit plugin ID.")
+    parser.add_argument("--runtime-id", default=None, help="Optional explicit runtime row ID.")
+    parser.add_argument(
+        "--plugin-name",
+        default=DEFAULT_PLUGIN_NAME,
+        help="Plugin name used when creating a testing plugin stub.",
+    )
+    parser.add_argument(
+        "--plugin-description",
+        default=DEFAULT_PLUGIN_DESCRIPTION,
+        help="Plugin description used when creating a testing plugin stub.",
+    )
+    parser.add_argument(
+        "--plugin-version",
+        default=DEFAULT_PLUGIN_VERSION,
+        help="Plugin version used when creating a testing plugin stub.",
+    )
+    parser.add_argument(
+        "--skip-plugin-stub",
+        action="store_true",
+        help="Fail instead of creating a plugin stub when plugin row is missing.",
+    )
+
+    parser.add_argument("--source-url", default=DEFAULT_SOURCE_URL, help="Service source URL/path.")
+    parser.add_argument(
+        "--definition-id",
+        default=DEFAULT_DEFINITION_ID,
+        help='Definition ID to store (use "none" to store NULL).',
+    )
+    parser.add_argument("--runtime-dir-key", default=DEFAULT_RUNTIME_DIR_KEY, help="runtime_dir_key value.")
+    parser.add_argument("--env-inherit", default=DEFAULT_ENV_INHERIT, help="env_inherit value.")
+    parser.add_argument("--status", default=DEFAULT_STATUS, help="Initial runtime status.")
+    parser.add_argument("--port", type=int, default=DEFAULT_PORT, help="Service PROCESS_PORT and health port.")
+    parser.add_argument("--health-host", default="localhost", help="Host used for health URL.")
+
+    parser.add_argument("--install-command", default=DEFAULT_INSTALL_COMMAND, help="install_command value.")
+    parser.add_argument("--start-command", default=DEFAULT_START_COMMAND, help="start_command value.")
+    parser.add_argument("--stop-command", default=DEFAULT_STOP_COMMAND, help="stop_command value.")
+    parser.add_argument("--restart-command", default=DEFAULT_RESTART_COMMAND, help="restart_command value.")
+    parser.add_argument(
+        "--skip-runtime-copy",
+        action="store_true",
+        help="Skip local source copy into backend/services_runtime before runtime upsert.",
+    )
+    parser.add_argument(
+        "--runtime-copy-mode",
+        choices=["replace", "merge", "skip"],
+        default="replace",
+        help="How to handle an existing runtime directory when copying local source.",
+    )
+
+    parser.add_argument(
+        "--delete",
+        action="store_true",
+        help="Delete runtime row instead of inserting/updating.",
+    )
+    parser.add_argument(
+        "--delete-plugin-stub",
+        action="store_true",
+        help="When used with --delete, also delete plugin stub if no related rows remain.",
+    )
+    parser.add_argument(
+        "--delete-runtime-dir",
+        action="store_true",
+        help="When used with --delete, also remove the resolved runtime directory.",
+    )
+    return parser.parse_args()
+
+
+async def run(args: argparse.Namespace) -> int:
+    plugin_slug = (args.plugin_slug or "").strip()
+    service_name = (args.service_name or "").strip()
+    source_url = (args.source_url or DEFAULT_SOURCE_URL).strip()
+    runtime_dir_key = (args.runtime_dir_key or "").strip()
+    if not plugin_slug:
+        raise RuntimeError("plugin_slug cannot be empty.")
+    if not service_name:
+        raise RuntimeError("service_name cannot be empty.")
+    if args.port <= 0:
+        raise RuntimeError("port must be a positive integer.")
+    runtime_target_dir = _resolve_runtime_target_dir(
+        runtime_dir_key=runtime_dir_key,
+        source_url=source_url,
+        plugin_slug=plugin_slug,
+        service_name=service_name,
+    )
+
+    db_gen = get_db()
+    db = await db_gen.__anext__()
+    try:
+        user_id = await _resolve_user_id(db, args.user_id, args.user_email)
+        plugin_id = (args.plugin_id or _build_plugin_id(user_id, plugin_slug)).strip()
+        runtime_id = (args.runtime_id or _build_runtime_id(user_id, plugin_slug, service_name)).strip()
+
+        if args.delete:
+            removed = await _delete_runtime_rows(
+                db,
+                user_id=user_id,
+                runtime_id=runtime_id,
+                plugin_slug=plugin_slug,
+                service_name=service_name,
+            )
+            runtime_cleanup = None
+            if args.delete_runtime_dir:
+                runtime_cleanup = _delete_runtime_dir_if_present(runtime_target_dir)
+            plugin_cleanup = None
+            if args.delete_plugin_stub:
+                plugin_cleanup = await _delete_plugin_stub_if_safe(
+                    db,
+                    user_id=user_id,
+                    plugin_id=plugin_id,
+                    plugin_slug=plugin_slug,
+                )
+            await db.commit()
+            print(
+                json.dumps(
+                    {
+                        "action": "delete",
+                        "user_id": user_id,
+                        "plugin_id": plugin_id,
+                        "runtime_id": runtime_id,
+                        "deleted_runtime_rows": removed,
+                        "runtime_cleanup": runtime_cleanup,
+                        "plugin_cleanup": plugin_cleanup,
+                    },
+                    indent=2,
+                    default=str,
+                )
+            )
+            return 0
+
+        runtime_copy = None
+        if not args.skip_runtime_copy:
+            runtime_copy = _copy_runtime_from_local_source(
+                source_url=source_url,
+                target_dir=runtime_target_dir,
+                copy_mode=args.runtime_copy_mode,
+            )
+
+        plugin_id, plugin_source = await _ensure_plugin_row(
+            db,
+            user_id=user_id,
+            plugin_id=plugin_id,
+            plugin_slug=plugin_slug,
+            plugin_name=args.plugin_name.strip(),
+            plugin_description=args.plugin_description.strip(),
+            plugin_version=args.plugin_version.strip(),
+            plugin_source_url=source_url,
+            service_name=service_name,
+            skip_plugin_stub=args.skip_plugin_stub,
+        )
+
+        port_str = str(args.port)
+        now = _utc_now()
+        definition_id = _normalize_definition_id(args.definition_id)
+        healthcheck_url = f"http://{args.health_host.strip() or 'localhost'}:{port_str}/health"
+
+        payload: dict[str, Any] = {
+            "id": runtime_id,
+            "plugin_id": plugin_id,
+            "plugin_slug": plugin_slug,
+            "name": service_name,
+            "source_url": source_url,
+            "type": "venv_process",
+            "install_command": args.install_command.strip(),
+            "start_command": args.start_command.strip(),
+            "stop_command": args.stop_command.strip(),
+            "restart_command": args.restart_command.strip(),
+            "healthcheck_url": healthcheck_url,
+            "definition_id": definition_id,
+            "required_env_vars": json.dumps(["PROCESS_PORT"]),
+            "runtime_dir_key": runtime_dir_key,
+            "env_inherit": args.env_inherit.strip(),
+            "env_overrides": json.dumps({"PROCESS_PORT": port_str}),
+            "status": args.status.strip(),
+            "created_at": now,
+            "updated_at": now,
+            "user_id": user_id,
+        }
+        await _upsert_runtime_row(db, payload)
+
+        runtime_row = await _fetch_runtime_row(db, runtime_id)
+        await db.commit()
+
+        print(
+            json.dumps(
+                {
+                    "action": "upsert",
+                    "user_id": user_id,
+                    "plugin_id": plugin_id,
+                    "plugin_source": plugin_source,
+                    "runtime_id": runtime_id,
+                    "runtime_target_dir": str(runtime_target_dir),
+                    "runtime_copy": runtime_copy,
+                    "runtime": runtime_row,
+                },
+                indent=2,
+                default=str,
+            )
+        )
+        return 0
+    finally:
+        try:
+            await db_gen.aclose()
+        except Exception:
+            pass
+
+
+def main() -> int:
+    args = parse_args()
+    if not args.user_id and not args.user_email:
+        print("Error: provide --user-id or --user-email.", file=sys.stderr)
+        return 2
+    try:
+        return asyncio.run(run(args))
+    except Exception as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -36,6 +36,32 @@ conda activate BrainDriveDev
 git clone https://github.com/BrainDriveAI/BrainDrive-Core.git
 cd BrainDrive-Core
 ```
+
+### 2.3 Optional: Run the Cross-Platform Bootstrap Script
+
+If you prefer automation, use the installer script instead of doing each step manually.
+
+macOS/Linux:
+```bash
+python3 scripts/bootstrap_braindrive.py --mode dev
+```
+
+Windows PowerShell:
+```powershell
+python scripts/bootstrap_braindrive.py --mode dev
+```
+
+Production-style (non-Docker, backend-served frontend):
+```bash
+python3 scripts/bootstrap_braindrive.py --mode prod
+```
+
+Safe preview (no changes):
+```bash
+python3 scripts/bootstrap_braindrive.py --mode prod --dry-run
+```
+
+When using the script, jump to **Step 5 (Access and Verify)** after it completes.
  
 ---
  
@@ -113,7 +139,7 @@ Keep this process running to serve the BrainDrive UI.
  
 | Component | URL | What to Expect |
 | --- | --- | --- |
-| Backend API docs | [http://localhost:8005/docs](http://localhost:8005/docs) | FastAPI interactive documentation loads without errors. |
+| Backend API docs | [http://localhost:8005/api/v1/docs](http://localhost:8005/api/v1/docs) | FastAPI interactive documentation loads without errors. |
 | Frontend UI | [http://localhost:5173](http://localhost:5173) | BrainDrive web app loads and can reach the backend. |
  
 If the frontend cannot reach the backend, confirm both servers are running and that CORS settings in `backend/.env` include `http://localhost:5173`.

--- a/frontend/src/components/PageNavigation.tsx
+++ b/frontend/src/components/PageNavigation.tsx
@@ -461,7 +461,7 @@ export const PageNavigation: React.FC<PageNavigationProps> = ({ basePath = '/pag
     // Your Pages navigation item
     const yourPagesNavItem = {
       id: 'your-pages',
-      name: 'Your Pages 2',
+      name: 'Your Pages',
       icon: <CollectionsBookmarkIcon />,
       path: '/pages'
     };

--- a/frontend/src/components/PageNavigation.tsx
+++ b/frontend/src/components/PageNavigation.tsx
@@ -28,6 +28,54 @@ import { NavigationRoute, NavigationRouteTree } from '../types/navigation';
 // Names of pages that should be excluded from the top level
 const excludedPageNames: string[] = [];
 
+const FALLBACK_SYSTEM_ROUTES: NavigationRoute[] = [
+  {
+    id: "fallback-dashboard",
+    name: "Dashboard",
+    route: "dashboard",
+    creator_id: "system",
+    is_system_route: true,
+    is_visible: true,
+    order: 1
+  },
+  {
+    id: "fallback-plugin-studio",
+    name: "Plugin Studio",
+    route: "plugin-studio",
+    creator_id: "system",
+    is_system_route: true,
+    is_visible: true,
+    order: 2
+  },
+  {
+    id: "fallback-settings",
+    name: "Settings",
+    route: "settings",
+    creator_id: "system",
+    is_system_route: true,
+    is_visible: true,
+    order: 3
+  },
+  {
+    id: "fallback-plugin-manager",
+    name: "Plugin Manager",
+    route: "plugin-manager",
+    creator_id: "system",
+    is_system_route: true,
+    is_visible: true,
+    order: 4
+  },
+  {
+    id: "fallback-personas",
+    name: "Personas",
+    route: "personas",
+    creator_id: "system",
+    is_system_route: true,
+    is_visible: true,
+    order: 5
+  }
+];
+
 interface PageNavigationProps {
   basePath?: string; // Optional base path for all page links
 }
@@ -45,6 +93,20 @@ export const PageNavigation: React.FC<PageNavigationProps> = ({ basePath = '/pag
   // Legacy state for backward compatibility
   const [navigationRoutes, setNavigationRoutes] = useState<NavigationRoute[]>([]);
   const [systemRoutes, setSystemRoutes] = useState<NavigationRoute[]>([]);
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
+    dashboard: true,
+    'plugin-studio': true,
+    settings: true,
+    'your-pages': true,
+    'your-pages-builtin': true
+  });
+
+  const toggleSection = (sectionId: string) => {
+    setExpandedSections(prev => ({
+      ...prev,
+      [sectionId]: !prev[sectionId]
+    }));
+  };
 
   // Fetch hierarchical navigation tree
   useEffect(() => {
@@ -397,22 +459,6 @@ export const PageNavigation: React.FC<PageNavigationProps> = ({ basePath = '/pag
   // Render legacy flat navigation (fallback)
   const renderLegacyNavigation = () => {
     // Your Pages navigation item
-    // Move all hooks to top level to avoid conditional hook calls
-    const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
-      dashboard: true,
-      'plugin-studio': true,
-      settings: true,
-      'your-pages': true,
-      'your-pages-builtin': true  // Ensure Your Pages is expanded by default
-    });
-
-    const toggleSection = (sectionId: string) => {
-      setExpandedSections(prev => ({
-        ...prev,
-        [sectionId]: !prev[sectionId]
-      }));
-    };
-
     const yourPagesNavItem = {
       id: 'your-pages',
       name: 'Your Pages 2',
@@ -430,9 +476,13 @@ export const PageNavigation: React.FC<PageNavigationProps> = ({ basePath = '/pag
     );
 
     // Create a combined list of all routes (system and custom)
-    const allRoutes = [...systemRoutes, ...navigationRoutes]
-      .filter(route => route.is_visible)
+    const allRoutesFromApi = [...systemRoutes, ...navigationRoutes]
+      .filter(route => route.is_visible !== false)
       .sort((a, b) => (a.order || 0) - (b.order || 0));
+
+    const allRoutes = allRoutesFromApi.length > 0
+      ? allRoutesFromApi
+      : FALLBACK_SYSTEM_ROUTES;
 
     return (
       <>

--- a/frontend/src/components/PluginCanvas.tsx
+++ b/frontend/src/components/PluginCanvas.tsx
@@ -84,7 +84,7 @@ interface PluginCanvasProps {
   currentPage: Page | null;
   onPageChange: (page: Page) => void;
   onCreatePage: (pageName: string) => void;
-  onDeletePage: (pageId: string) => void;
+  onDeletePage: (pageId: string) => void | Promise<void>;
   onRenamePage: (pageId: string, newName: string) => void;
 }
 
@@ -391,11 +391,8 @@ export const PluginCanvas: React.FC<PluginCanvasProps> = ({
     try {
       console.log(`Deleting page ${pageId}`);
       
-      // Delete the page
-      await pageService.deletePage(pageId);
-      
-      // Call the parent handler to update the UI
-      onDeletePage(pageId);
+      // Delegate deletion to parent handler (which performs backend delete + state update)
+      await Promise.resolve(onDeletePage(pageId));
       
       // If the current page was deleted, switch to another page
       if (currentPage && currentPage.id === pageId && pages.length > 1) {

--- a/frontend/src/components/RouteContentRenderer.tsx
+++ b/frontend/src/components/RouteContentRenderer.tsx
@@ -21,6 +21,18 @@ interface RouteContentRendererProps {
   route?: string;
 }
 
+const FALLBACK_SYSTEM_ROUTES: Record<string, NavigationRoute> = {
+  dashboard: { id: "fallback-dashboard", name: "Dashboard", route: "dashboard", creator_id: "system", is_system_route: true, is_visible: true },
+  "plugin-studio": { id: "fallback-plugin-studio", name: "Plugin Studio", route: "plugin-studio", creator_id: "system", is_system_route: true, is_visible: true },
+  settings: { id: "fallback-settings", name: "Settings", route: "settings", creator_id: "system", is_system_route: true, is_visible: true },
+  "plugin-manager": { id: "fallback-plugin-manager", name: "Plugin Manager", route: "plugin-manager", creator_id: "system", is_system_route: true, is_visible: true },
+  personas: { id: "fallback-personas", name: "Personas", route: "personas", creator_id: "system", is_system_route: true, is_visible: true }
+};
+
+const getFallbackSystemRoute = (routePath: string): NavigationRoute | null => {
+  return FALLBACK_SYSTEM_ROUTES[routePath] || null;
+};
+
 export const RouteContentRenderer: React.FC<RouteContentRendererProps> = ({ route }) => {
   const params = useParams();
   const location = useLocation();
@@ -47,10 +59,14 @@ export const RouteContentRenderer: React.FC<RouteContentRendererProps> = ({ rout
 
         // console.log('Loading route content for:', routePath);
 
-        // Get the navigation route
-        const navRoute = await navigationService.getNavigationRouteByRoute(routePath);
+        // Get the navigation route (fallback to built-in system route when backend rows are missing)
+        const fetchedRoute = await navigationService.getNavigationRouteByRoute(routePath);
+        const navRoute = fetchedRoute || getFallbackSystemRoute(routePath);
         if (!navRoute) {
           throw new Error(`Route not found: ${routePath}`);
+        }
+        if (!fetchedRoute) {
+          console.warn(`Using fallback system route for path: ${routePath}`);
         }
 
         setNavigationRoute(navRoute);

--- a/frontend/src/features/unified-dynamic-page-renderer/components/LayoutEngine.tsx
+++ b/frontend/src/features/unified-dynamic-page-renderer/components/LayoutEngine.tsx
@@ -1055,7 +1055,10 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = React.memo(({
     const extractPluginId = (compositeId: string): string => {
       if (!compositeId) return 'unknown';
       const tokens = compositeId.split('_');
-      if (tokens.length === 1) return tokens[0];
+      if (tokens.length === 1) {
+        const hyphenTokens = compositeId.split('-').filter(Boolean);
+        return hyphenTokens[0] || tokens[0];
+      }
       const idx = tokens.findIndex(t => /^(?:[0-9a-f]{24,}|\d{12,})$/i.test(t));
       const boundary = idx > 0 ? idx : 2; // heuristic: often 2 tokens like ServiceExample_Theme
       return tokens.slice(0, boundary).join('_');
@@ -1064,9 +1067,6 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = React.memo(({
     const normalizeItems = (items: any[] = []): LayoutItem[] => {
       return (items || []).map((it: any) => {
         const id = it?.i ?? '';
-        const pluginId = it?.pluginId || extractPluginId(typeof id === 'string' ? id : '');
-        
-        // CRITICAL: Preserve moduleId from config if available (from args)
         let moduleId = it?.moduleId;
         if (!moduleId && it?.config?.moduleId) {
           moduleId = it.config.moduleId;
@@ -1074,6 +1074,14 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = React.memo(({
         if (!moduleId) {
           moduleId = id; // Last resort fallback
         }
+
+        // Prefer explicit pluginId, then module map metadata, then extracted fallback.
+        const moduleConfig = moduleMap[moduleId] || moduleMap[id];
+        const pluginId =
+          it?.pluginId ||
+          moduleConfig?.pluginId ||
+          moduleConfig?._legacy?.pluginId ||
+          extractPluginId(typeof id === 'string' ? id : '');
         
         return {
           i: id,
@@ -1733,17 +1741,23 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = React.memo(({
         const extractPluginIdFromComposite = (compositeId: string): string => {
           if (!compositeId) return 'unknown';
           const tokens = compositeId.split('_');
-          if (tokens.length === 1) return tokens[0];
+          if (tokens.length === 1) {
+            const hyphenTokens = compositeId.split('-').filter(Boolean);
+            return hyphenTokens[0] || tokens[0];
+          }
           const idx = tokens.findIndex(t => /^(?:[0-9a-f]{24,}|\d{12,})$/i.test(t));
           const boundary = idx > 0 ? idx : 2;
           return tokens.slice(0, boundary).join('_');
         };
 
-        // Try to extract pluginId from moduleId if item.pluginId is 'unknown'
-        let fallbackPluginId = item.pluginId;
+        // Prefer explicit pluginId first, then module metadata, then extracted fallback.
+        const mappedModule = moduleMap[item.moduleId]
+          || Object.values(moduleMap).find((moduleConfig: any) => moduleConfig?._legacy?.moduleId === item.moduleId);
+        let fallbackPluginId = (item as any)?.config?._originalItem?.pluginId
+          || item.pluginId
+          || mappedModule?.pluginId
+          || mappedModule?._legacy?.pluginId;
         if (!fallbackPluginId || fallbackPluginId === 'unknown') {
-          // Try to extract plugin ID from the module ID pattern
-          // e.g., "BrainDriveChat_1830586da8834501bea1ef1d39c3cbe8_BrainDriveChat_BrainDriveChat_1754404718788"
           const potentialPluginId = extractPluginIdFromComposite(item.moduleId || '');
           fallbackPluginId = potentialPluginId || fallbackPluginId;
         }
@@ -1902,19 +1916,27 @@ export const LayoutEngine: React.FC<LayoutEngineProps> = React.memo(({
             const extractPluginIdLocal = (compositeId: string): string => {
               if (!compositeId) return 'unknown';
               const tokens = compositeId.split('_');
-              if (tokens.length === 1) return tokens[0];
+              if (tokens.length === 1) {
+                const hyphenTokens = compositeId.split('-').filter(Boolean);
+                return hyphenTokens[0] || tokens[0];
+              }
               const idx = tokens.findIndex(t => /^(?:[0-9a-f]{24,}|\d{12,})$/i.test(t));
               const boundary = idx > 0 ? idx : 2;
               return tokens.slice(0, boundary).join('_');
             };
 
-            // Normalize current candidates
-            const candidatePluginId =
-              (item as any)?.config?._originalItem?.pluginId ||
-              (item.pluginId && item.pluginId !== 'unknown' && item.pluginId.includes('_')
-                ? item.pluginId
-                : extractPluginIdLocal(item.moduleId || (item as any)?.config?._originalItem?.moduleId || (item.i || '')));
             const candidateModuleId = (item.config as any)?.moduleId || (item as any)?.config?._originalItem?.moduleId || item.moduleId;
+            const mappedModule = moduleMap[candidateModuleId]
+              || Object.values(moduleMap).find((moduleConfig: any) => moduleConfig?._legacy?.moduleId === candidateModuleId);
+            const directPluginId = (item as any)?.config?._originalItem?.pluginId || item.pluginId;
+            const hasDirectPluginId = typeof directPluginId === 'string'
+              && directPluginId.trim().length > 0
+              && directPluginId !== 'unknown';
+            const candidatePluginId = hasDirectPluginId
+              ? directPluginId
+              : (mappedModule?.pluginId
+                || mappedModule?._legacy?.pluginId
+                || extractPluginIdLocal(item.moduleId || (item as any)?.config?._originalItem?.moduleId || (item.i || '')));
 
             // Use last known-good identity if it is more specific/complete
             const prev = stableIdentityRef.current.get(item.i);

--- a/frontend/src/pages/PluginStudio.tsx
+++ b/frontend/src/pages/PluginStudio.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect } from 'react';
+import React, { useState, useEffect, useCallback } from 'react';
 import { Box, CircularProgress } from '@mui/material';
 import { PluginCanvas } from '../components/PluginCanvas';
 import { PluginToolbar } from '../components/PluginToolbar';
@@ -10,6 +10,8 @@ import { useTheme } from '../contexts/ServiceContext';
 import ComponentErrorBoundary from '../components/ComponentErrorBoundary';
 import { pageService } from '../services/pageService';
 
+const GLOBAL_PAGES_REFRESH_EVENT = 'braindrive:pages:refresh';
+
 const PluginStudio = () => {
   const [allPages, setAllPages] = useState<Page[]>([]);
   const [currentPage, setCurrentPage] = useState<Page | null>(null);
@@ -17,6 +19,14 @@ const PluginStudio = () => {
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
   const theme = useTheme();
+
+  const broadcastGlobalPageRefresh = useCallback(() => {
+    if (typeof window === 'undefined') {
+      return;
+    }
+
+    window.dispatchEvent(new Event(GLOBAL_PAGES_REFRESH_EVENT));
+  }, []);
   
   // Use a ref to track if we've already created a default page
   // This ensures we only create one default page even if the component re-renders
@@ -225,6 +235,7 @@ const PluginStudio = () => {
       
       // Switch to the new page
       setCurrentPage(transformedPage);
+      broadcastGlobalPageRefresh();
       
       return transformedPage;
     } catch (error) {
@@ -254,6 +265,7 @@ const PluginStudio = () => {
       // Update the local state
       setAllPages(prev => [...prev, localPage]);
       setCurrentPage(localPage);
+      broadcastGlobalPageRefresh();
       
       return localPage;
     }
@@ -276,6 +288,7 @@ const PluginStudio = () => {
         }
         return newPages;
       });
+      broadcastGlobalPageRefresh();
     } catch (error) {
       console.error('Error deleting page:', error);
     }
@@ -312,6 +325,7 @@ const PluginStudio = () => {
         
         return newPages;
       });
+      broadcastGlobalPageRefresh();
     } catch (error) {
       console.error('Error renaming page:', error);
     }

--- a/frontend/src/services/navigationService.ts
+++ b/frontend/src/services/navigationService.ts
@@ -2,6 +2,14 @@ import ApiService from './ApiService';
 import { NavigationRoute, NavigationRouteTree, NavigationRouteMove, NavigationRouteBatchUpdate } from '../types/navigation';
 
 const API_PATH = '/api/v1/navigation-routes';
+const FALLBACK_SYSTEM_ROUTES: Record<string, NavigationRoute> = {
+  dashboard: { id: "fallback-dashboard", name: "Dashboard", route: "dashboard", creator_id: "system", is_system_route: true, is_visible: true },
+  "plugin-studio": { id: "fallback-plugin-studio", name: "Plugin Studio", route: "plugin-studio", creator_id: "system", is_system_route: true, is_visible: true },
+  settings: { id: "fallback-settings", name: "Settings", route: "settings", creator_id: "system", is_system_route: true, is_visible: true },
+  "plugin-manager": { id: "fallback-plugin-manager", name: "Plugin Manager", route: "plugin-manager", creator_id: "system", is_system_route: true, is_visible: true },
+  personas: { id: "fallback-personas", name: "Personas", route: "personas", creator_id: "system", is_system_route: true, is_visible: true }
+};
+
 
 export const navigationService = {
   // Get all navigation routes
@@ -189,19 +197,23 @@ export const navigationService = {
   // Get a navigation route by route path
   async getNavigationRouteByRoute(route: string): Promise<NavigationRoute | null> {
     try {
-      // console.log(`Fetching navigation route with route path: ${route}`);
-      
       // First get all routes
       const routes = await this.getNavigationRoutes();
-      
+
       // Find the route with the matching route path
       const matchingRoute = routes.find(r => r.route === route);
-      
+
       if (!matchingRoute) {
+        const fallbackRoute = FALLBACK_SYSTEM_ROUTES[route];
+        if (fallbackRoute) {
+          console.info(`Using fallback system navigation route for path: ${route}`);
+          return fallbackRoute;
+        }
+
         console.warn(`No navigation route found with route path: ${route}`);
         return null;
       }
-      
+
       // console.log(`Found navigation route for path ${route}:`, matchingRoute);
       return matchingRoute;
     } catch (error) {

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_default_fixture_loop_scope = function

--- a/scripts/README_INSTALL.md
+++ b/scripts/README_INSTALL.md
@@ -1,0 +1,72 @@
+# BrainDrive Bootstrap Installer
+
+Cross-platform installer for BrainDrive local setup and non-Docker production-style setup.
+
+Primary script:
+- `scripts/bootstrap_braindrive.py`
+
+Wrappers:
+- `scripts/bootstrap.sh` (macOS/Linux)
+- `scripts/bootstrap.ps1` (Windows PowerShell)
+
+## What It Automates
+1. Creates or reuses a conda environment with `python`, `nodejs`, and `git`.
+2. Creates `backend/.env` from `backend/.env-dev` (if needed).
+3. Creates `frontend/.env` from `frontend/.env.example` (if needed).
+4. Generates secure backend secrets when placeholders are detected.
+5. Applies mode-specific env values:
+   - `dev`: split frontend/backend setup
+   - `prod`: backend-served frontend assumptions (`SERVE_FRONTEND=true`, frontend build path, `/api` base)
+6. Installs backend (`pip`) and frontend (`npm`) dependencies.
+7. Builds frontend in `prod` mode unless skipped.
+
+## Prerequisite
+Conda (Miniconda/Anaconda) must be installed and available in `PATH`.
+
+## Usage
+
+### macOS/Linux
+```bash
+python3 scripts/bootstrap_braindrive.py --mode dev
+```
+or
+```bash
+bash scripts/bootstrap.sh --mode dev
+```
+
+### Windows PowerShell
+```powershell
+python scripts/bootstrap_braindrive.py --mode dev
+```
+or
+```powershell
+.\scripts\bootstrap.ps1 --mode dev
+```
+
+### Production-style (non-Docker)
+```bash
+python3 scripts/bootstrap_braindrive.py --mode prod
+```
+
+Optional domain example:
+```bash
+python3 scripts/bootstrap_braindrive.py --mode prod --domain https://brain.example.com
+```
+
+## Useful Flags
+1. `--env-name BrainDriveDev`
+2. `--skip-conda-create`
+3. `--skip-backend-install`
+4. `--skip-frontend-install`
+5. `--skip-frontend-build`
+6. `--overwrite-env-files`
+7. `--dry-run`
+
+Example dry run:
+```bash
+python3 scripts/bootstrap_braindrive.py --mode prod --dry-run
+```
+
+## Notes
+1. The script uses `conda run -n <env>` to avoid shell-specific activation differences across OSes.
+2. Service-runtime installs can still use backend-local `venv` when required; this script does not remove that pattern.

--- a/scripts/bootstrap.ps1
+++ b/scripts/bootstrap.ps1
@@ -1,0 +1,10 @@
+param(
+    [Parameter(ValueFromRemainingArguments = $true)]
+    [string[]]$CliArgs
+)
+
+$ScriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+python "$ScriptDir\bootstrap_braindrive.py" @CliArgs
+if ($LASTEXITCODE -ne 0) {
+    exit $LASTEXITCODE
+}

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+python3 "${SCRIPT_DIR}/bootstrap_braindrive.py" "$@"

--- a/scripts/bootstrap_braindrive.py
+++ b/scripts/bootstrap_braindrive.py
@@ -1,0 +1,336 @@
+#!/usr/bin/env python3
+"""
+BrainDrive cross-platform bootstrap installer.
+
+Designed for macOS, Windows, and Linux with a conda-first baseline:
+- Creates or reuses a conda environment with Python + Node.js + Git
+- Prepares backend/frontend .env files
+- Generates secure backend secrets when placeholders are detected
+- Installs backend/frontend dependencies
+- Optionally builds frontend for production-like non-Docker runtime
+
+Examples:
+  python scripts/bootstrap_braindrive.py --mode dev
+  python scripts/bootstrap_braindrive.py --mode prod
+  python scripts/bootstrap_braindrive.py --mode prod --dry-run
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import re
+import secrets
+import shutil
+import subprocess
+import sys
+from pathlib import Path
+from typing import Dict, Iterable
+
+
+ENV_LINE_RE = re.compile(r"^\s*(?:export\s+)?([A-Za-z_][A-Za-z0-9_]*)\s*=\s*(.*)$")
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Bootstrap BrainDrive with a conda-first workflow.")
+    parser.add_argument("--mode", choices=["dev", "prod"], default="dev", help="Install mode.")
+    parser.add_argument("--env-name", default="BrainDriveDev", help="Conda environment name.")
+    parser.add_argument(
+        "--python-version",
+        default="3.11",
+        help="Python version for conda env creation (default: 3.11).",
+    )
+    parser.add_argument("--backend-host", default=None, help="Backend host override.")
+    parser.add_argument("--backend-port", type=int, default=8005, help="Backend port.")
+    parser.add_argument("--frontend-port", type=int, default=5173, help="Frontend dev port.")
+    parser.add_argument(
+        "--domain",
+        default="",
+        help="Optional production domain for CORS_ORIGINS (example: https://brain.yourdomain.com).",
+    )
+    parser.add_argument("--skip-conda-create", action="store_true", help="Skip conda environment creation.")
+    parser.add_argument("--skip-backend-install", action="store_true", help="Skip backend dependency install.")
+    parser.add_argument("--skip-frontend-install", action="store_true", help="Skip frontend dependency install.")
+    parser.add_argument("--skip-frontend-build", action="store_true", help="Skip frontend production build.")
+    parser.add_argument("--overwrite-env-files", action="store_true", help="Overwrite existing .env files.")
+    parser.add_argument("--dry-run", action="store_true", help="Show actions without making changes.")
+    return parser.parse_args()
+
+
+def run_command(cmd: Iterable[str], cwd: Path | None = None, dry_run: bool = False) -> None:
+    command_text = " ".join(cmd)
+    prefix = "[dry-run]" if dry_run else "[run]"
+    print(f"{prefix} {command_text}")
+    if dry_run:
+        return
+    subprocess.run(list(cmd), cwd=str(cwd) if cwd else None, check=True)
+
+
+def resolve_repo_root() -> Path:
+    # Supports script location in repo-root subfolders (for example: scripts/).
+    script_path = Path(__file__).resolve()
+    for candidate in [script_path.parent, *script_path.parents]:
+        if (candidate / "backend").exists() and (candidate / "frontend").exists():
+            return candidate
+    raise RuntimeError("Could not resolve repo root from script location.")
+
+
+def get_conda_executable() -> str:
+    conda = shutil.which("conda")
+    if not conda:
+        raise RuntimeError("Conda was not found in PATH. Install Miniconda/Anaconda first.")
+    return conda
+
+
+def conda_env_exists(conda_exe: str, env_name: str) -> bool:
+    result = subprocess.run(
+        [conda_exe, "env", "list", "--json"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    payload = json.loads(result.stdout)
+    for env_path in payload.get("envs", []):
+        if Path(env_path).name == env_name:
+            return True
+    return False
+
+
+def copy_if_needed(source: Path, target: Path, overwrite: bool, dry_run: bool) -> None:
+    if not source.exists():
+        raise FileNotFoundError(f"Missing template file: {source}")
+    if target.exists() and not overwrite:
+        print(f"[skip] {target} already exists")
+        return
+    print(f"[copy] {source} -> {target}")
+    if dry_run:
+        return
+    shutil.copyfile(source, target)
+
+
+def parse_env_file(path: Path) -> Dict[str, str]:
+    data: Dict[str, str] = {}
+    if not path.exists():
+        return data
+    for line in path.read_text(encoding="utf-8").splitlines():
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = ENV_LINE_RE.match(line)
+        if not match:
+            continue
+        key, value = match.group(1), match.group(2).strip()
+        if value and value[0] == value[-1] and value[0] in {'"', "'"}:
+            value = value[1:-1]
+        data[key] = value
+    return data
+
+
+def format_env_value(value: object) -> str:
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    return str(value)
+
+
+def update_env_file(path: Path, updates: Dict[str, object], dry_run: bool) -> None:
+    lines = path.read_text(encoding="utf-8").splitlines() if path.exists() else []
+    pending = {k: format_env_value(v) for k, v in updates.items()}
+    output_lines = list(lines)
+
+    for idx, line in enumerate(output_lines):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        match = ENV_LINE_RE.match(line)
+        if not match:
+            continue
+        key = match.group(1)
+        if key in pending:
+            output_lines[idx] = f"{key}={pending.pop(key)}"
+
+    for key, value in pending.items():
+        output_lines.append(f"{key}={value}")
+
+    print(f"[update] {path}")
+    if dry_run:
+        return
+    path.write_text("\n".join(output_lines) + "\n", encoding="utf-8")
+
+
+def needs_generated_secret(value: str | None) -> bool:
+    if not value:
+        return True
+    probe = value.strip().lower()
+    return probe in {
+        "your-secret-key-here",
+        "your-encryption-master-key-here",
+        "generate-a-secure-token-here",
+    }
+
+
+def generate_secret(length: int) -> str:
+    # URL-safe token to avoid shell/INI escaping issues.
+    token = secrets.token_urlsafe(length)
+    return token[:length]
+
+
+def build_backend_updates(
+    mode: str,
+    current_env: Dict[str, str],
+    backend_host: str,
+    backend_port: int,
+    frontend_port: int,
+    repo_root: Path,
+    domain: str,
+) -> Dict[str, object]:
+    updates: Dict[str, object] = {
+        "HOST": backend_host,
+        "PORT": backend_port,
+        "APP_ENV": "dev" if mode == "dev" else "prod",
+        "DEBUG": mode == "dev",
+        "RELOAD": False,
+        "ENABLE_TEST_ROUTES": mode == "dev",
+        "CORS_DEV_HOSTS": "localhost,127.0.0.1,[::1]",
+        "ALLOWED_HOSTS": "localhost,127.0.0.1",
+    }
+
+    if mode == "dev":
+        updates["SERVE_FRONTEND"] = False
+        updates["CORS_ORIGINS"] = f"http://127.0.0.1:{frontend_port},http://localhost:{frontend_port}"
+    else:
+        updates["SERVE_FRONTEND"] = True
+        updates["FRONTEND_DIST_PATH"] = str((repo_root / "frontend" / "dist").resolve())
+        if domain.strip():
+            updates["CORS_ORIGINS"] = domain.strip()
+            updates["ALLOWED_HOSTS"] = f"localhost,127.0.0.1,{domain.strip().replace('https://', '').replace('http://', '')}"
+        else:
+            updates["CORS_ORIGINS"] = ""
+
+    if needs_generated_secret(current_env.get("SECRET_KEY")):
+        updates["SECRET_KEY"] = generate_secret(64)
+    if needs_generated_secret(current_env.get("ENCRYPTION_MASTER_KEY")):
+        updates["ENCRYPTION_MASTER_KEY"] = generate_secret(64)
+
+    return updates
+
+
+def build_frontend_updates(mode: str, backend_port: int, frontend_port: int) -> Dict[str, object]:
+    updates: Dict[str, object] = {
+        "VITE_PORT": frontend_port,
+        "VITE_DEV_AUTO_LOGIN": False,
+    }
+    if mode == "dev":
+        updates["VITE_API_URL"] = f"http://localhost:{backend_port}"
+    else:
+        updates["VITE_API_URL"] = "/api"
+        updates["VITE_PLUGIN_STUDIO_DEV_MODE"] = False
+        updates["VITE_SHOW_EDITING_CONTROLS"] = False
+    return updates
+
+
+def print_next_steps(mode: str, env_name: str, backend_port: int, frontend_port: int) -> None:
+    print("\nNext steps:")
+    if mode == "dev":
+        print(f"1) conda activate {env_name}")
+        print(f"2) Terminal A: cd backend && uvicorn main:app --host localhost --port {backend_port}")
+        print("3) Terminal B: cd frontend && npm run dev")
+        print(f"4) Open http://localhost:{frontend_port}")
+    else:
+        print(f"1) conda activate {env_name}")
+        print(f"2) cd backend && uvicorn main:app --host 0.0.0.0 --port {backend_port} --workers 4")
+        print(f"3) Open http://localhost:{backend_port}")
+        print(f"4) API docs: http://localhost:{backend_port}/api/v1/docs")
+    print("\nNote: service-runtime installs can still create/use backend-local venvs when needed.")
+
+
+def main() -> int:
+    args = parse_args()
+    repo_root = resolve_repo_root()
+    conda_exe = get_conda_executable()
+
+    backend_host = args.backend_host or ("localhost" if args.mode == "dev" else "0.0.0.0")
+    backend_dir = repo_root / "backend"
+    frontend_dir = repo_root / "frontend"
+
+    backend_env_template = backend_dir / ".env-dev"
+    frontend_env_template = frontend_dir / ".env.example"
+    backend_env_file = backend_dir / ".env"
+    frontend_env_file = frontend_dir / ".env"
+
+    print("BrainDrive bootstrap")
+    print(f"- Mode: {args.mode}")
+    print(f"- Repo: {repo_root}")
+    print(f"- Conda env: {args.env_name}")
+    print(f"- Dry run: {args.dry_run}")
+
+    if not args.skip_conda_create:
+        if conda_env_exists(conda_exe, args.env_name):
+            print(f"[skip] conda env '{args.env_name}' already exists")
+        else:
+            run_command(
+                [
+                    conda_exe,
+                    "create",
+                    "-n",
+                    args.env_name,
+                    "-c",
+                    "conda-forge",
+                    f"python={args.python_version}",
+                    "nodejs",
+                    "git",
+                    "-y",
+                ],
+                cwd=repo_root,
+                dry_run=args.dry_run,
+            )
+
+    copy_if_needed(backend_env_template, backend_env_file, args.overwrite_env_files, args.dry_run)
+    copy_if_needed(frontend_env_template, frontend_env_file, args.overwrite_env_files, args.dry_run)
+
+    backend_current = parse_env_file(backend_env_file)
+    backend_updates = build_backend_updates(
+        mode=args.mode,
+        current_env=backend_current,
+        backend_host=backend_host,
+        backend_port=args.backend_port,
+        frontend_port=args.frontend_port,
+        repo_root=repo_root,
+        domain=args.domain,
+    )
+    update_env_file(backend_env_file, backend_updates, args.dry_run)
+
+    frontend_updates = build_frontend_updates(args.mode, args.backend_port, args.frontend_port)
+    update_env_file(frontend_env_file, frontend_updates, args.dry_run)
+
+    if not args.skip_backend_install:
+        run_command(
+            [conda_exe, "run", "-n", args.env_name, "python", "-m", "pip", "install", "--upgrade", "pip"],
+            cwd=backend_dir,
+            dry_run=args.dry_run,
+        )
+        run_command(
+            [conda_exe, "run", "-n", args.env_name, "python", "-m", "pip", "install", "-r", "requirements.txt"],
+            cwd=backend_dir,
+            dry_run=args.dry_run,
+        )
+
+    if not args.skip_frontend_install:
+        run_command([conda_exe, "run", "-n", args.env_name, "npm", "install"], cwd=frontend_dir, dry_run=args.dry_run)
+
+    should_build_frontend = args.mode == "prod" and not args.skip_frontend_build
+    if should_build_frontend:
+        run_command([conda_exe, "run", "-n", args.env_name, "npm", "run", "build"], cwd=frontend_dir, dry_run=args.dry_run)
+
+    print_next_steps(args.mode, args.env_name, args.backend_port, args.frontend_port)
+    return 0
+
+
+if __name__ == "__main__":
+    try:
+        raise SystemExit(main())
+    except subprocess.CalledProcessError as error:
+        print(f"\nError: command failed with exit code {error.returncode}", file=sys.stderr)
+        raise SystemExit(error.returncode)
+    except Exception as exc:  # pylint: disable=broad-except
+        print(f"\nError: {exc}", file=sys.stderr)
+        raise SystemExit(1)

--- a/scripts/e2e_onboarding_interview_rng.py
+++ b/scripts/e2e_onboarding_interview_rng.py
@@ -1,0 +1,868 @@
+#!/usr/bin/env python3
+"""Repeatable RNG onboarding interview test harness.
+
+This script is designed for rapid dev loops:
+1) run interview scenarios,
+2) inspect artifacts,
+3) adjust code/template,
+4) rerun.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import random
+import re
+import shutil
+import subprocess
+import sys
+import time
+import traceback
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+QUESTION_PATTERN = re.compile(r"Question\s+(\d+)\s+of\s+(\d+):", re.IGNORECASE)
+
+KICKOFF_VARIANTS = [
+    "Start my Finance onboarding interview.",
+    "Begin my finances interview.",
+    "Let's start finance onboarding.",
+]
+
+APPROVE_VARIANTS = ["approve", "yes approve", "looks good", "go ahead"]
+REJECT_VARIANTS = ["reject", "no, revise", "change it"]
+
+ANSWER_VARIANTS = {
+    "short": [
+        "I want clear spending limits and less debt stress.",
+        "I need better monthly planning and a savings habit.",
+    ],
+    "narrative": [
+        "I keep up with bills but overspend in a few categories, and I want a cleaner monthly plan.",
+        "I feel like my income is okay but my spending rhythm is inconsistent, so I want structure.",
+    ],
+    "bullets": [
+        "- Goal: reduce credit card balance\n- Goal: build emergency fund\n- Constraint: variable expenses",
+        "- Keep spending visible\n- Cut non-essential expenses\n- Build weekly review habit",
+    ],
+}
+
+GOALS_TASKS_ABSOLUTE_VARIANTS = [
+    "Goal: Save $600 by 2026-03-15. Task: weekly budget review every Monday.",
+    "Goal: Pay $400 toward card balance by 2026-03-01. Task: track spending nightly.",
+]
+
+GOALS_TASKS_RELATIVE_VARIANTS = [
+    "Goal: Save $150 by next Friday. Task: review spending by next week.",
+    "Goal: Put $200 into emergency fund by month end. Task: adjust categories tomorrow.",
+]
+
+_ACTIVE_RUN: Optional["RunResult"] = None
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+class HarnessError(RuntimeError):
+    """User-facing deterministic harness failure."""
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class RunResult:
+    run_id: str
+    seed: int
+    topic: str
+    kickoff_phrase: str
+    question_total: int = 0
+    goals_branch: str = "unknown"
+    used_relative_dates: bool = False
+    rejected_opening_turns: int = 0
+    rejected_goals_turns: int = 0
+    expected_followup_due_date: str = ""
+    followup_task_persisted: bool = False
+    conversation_id: Optional[str] = None
+    success: bool = False
+    assertions: List[AssertionResult] = field(default_factory=list)
+    transcript: List[Dict[str, Any]] = field(default_factory=list)
+    error: Optional[str] = None
+
+
+@dataclass
+class HarnessConfig:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    topic: str
+    runs: int
+    seed: int
+    output_dir: Path
+    reset_from_template: bool
+    library_root: Optional[Path]
+    template_root: Optional[Path]
+    reject_prob: float
+    goals_yes_prob: float
+    relative_date_prob: float
+    timeout_seconds: int
+    allow_legacy_completion_without_goals_prompt: bool
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+
+
+def _http_post(
+    url: str,
+    payload: Dict[str, Any],
+    *,
+    timeout_seconds: int,
+    token: Optional[str] = None,
+    request_delay_seconds: float = 0.0,
+    max_retries: int = 0,
+    retry_base_seconds: float = 1.0,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                if not body.strip():
+                    return {}
+                return json.loads(body)
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                retry_after_header = exc.headers.get("Retry-After")
+                retry_after_seconds: Optional[float] = None
+                if retry_after_header:
+                    try:
+                        retry_after_seconds = float(retry_after_header.strip())
+                    except ValueError:
+                        retry_after_seconds = None
+                backoff_seconds = retry_after_seconds or (
+                    max(0.1, retry_base_seconds) * (2 ** attempt)
+                )
+                jitter_seconds = random.uniform(0.0, min(1.0, backoff_seconds * 0.25))
+                time.sleep(min(backoff_seconds + jitter_seconds, 120.0))
+                attempt += 1
+                continue
+            raise HarnessError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff_seconds = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter_seconds = random.uniform(0.0, min(1.0, backoff_seconds * 0.25))
+                time.sleep(min(backoff_seconds + jitter_seconds, 120.0))
+                attempt += 1
+                continue
+            raise HarnessError(f"Request failed for {url}: {exc}") from exc
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _login(config: HarnessConfig) -> Tuple[str, str]:
+    login_url = f"{config.base_url.rstrip('/')}/api/v1/auth/login"
+    payload = {"email": config.email, "password": config.password}
+    login_max_retries = max(config.http_max_retries, 6)
+    login_retry_base_seconds = max(config.http_retry_base_seconds, 5.0)
+    response = _http_post(
+        login_url,
+        payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=login_max_retries,
+        retry_base_seconds=login_retry_base_seconds,
+    )
+
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise HarnessError("Login response did not include access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise HarnessError("Login response did not include user_id")
+    return token, user_id
+
+
+def _bootstrap_user_scope(config: HarnessConfig, user_id: str) -> Dict[str, Any]:
+    if not config.library_root:
+        raise HarnessError(
+            "--reset-from-template requires --library-root or BRAINDRIVE_LIBRARY_PATH"
+        )
+
+    normalized = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = Path(__file__).resolve().parents[1] / "backend" / "scripts" / "bootstrap_library_user_scope.py"
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized,
+    ]
+    if config.template_root:
+        cmd.extend(["--template-root", str(config.template_root)])
+
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise HarnessError(
+            "Template reset/bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise HarnessError(
+            f"Bootstrap script returned non-JSON output: {completed.stdout.strip()}"
+        ) from exc
+
+
+def _extract_question_state(text: str) -> Tuple[int, int]:
+    match = QUESTION_PATTERN.search(text or "")
+    if not match:
+        raise HarnessError(f"Expected question pattern in assistant response, got: {text}")
+    return int(match.group(1)), int(match.group(2))
+
+
+def _pick_answer(rng: random.Random) -> str:
+    style = rng.choice(list(ANSWER_VARIANTS.keys()))
+    return rng.choice(ANSWER_VARIANTS[style])
+
+
+def _build_chat_payload(
+    *,
+    config: HarnessConfig,
+    user_id: str,
+    message: str,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": f"life-{config.topic}",
+        "params": {
+            "mcp_tools_enabled": False,
+            "mcp_scope_mode": "none",
+            "mcp_sync_on_request": False,
+        },
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _send_chat(
+    *,
+    config: HarnessConfig,
+    token: str,
+    user_id: str,
+    message: str,
+    conversation_id: Optional[str],
+    run: RunResult,
+) -> Dict[str, Any]:
+    run.transcript.append({"role": "user", "content": message, "at": dt.datetime.now(dt.timezone.utc).isoformat()})
+
+    chat_url = f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat"
+    payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message=message,
+        conversation_id=conversation_id,
+    )
+    response = _http_post(
+        chat_url,
+        payload,
+        timeout_seconds=config.timeout_seconds,
+        token=token,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+    )
+
+    assistant = (
+        response.get("choices", [{}])[0]
+        .get("message", {})
+        .get("content", "")
+    )
+    run.transcript.append({"role": "assistant", "content": assistant, "at": dt.datetime.now(dt.timezone.utc).isoformat()})
+    if not run.conversation_id:
+        candidate_id = response.get("conversation_id")
+        if isinstance(candidate_id, str) and candidate_id:
+            run.conversation_id = candidate_id
+    return response
+
+
+def _assert(run: RunResult, name: str, condition: bool, detail: str = "") -> None:
+    run.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise HarnessError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _as_assistant_text(response: Dict[str, Any]) -> str:
+    return (
+        response.get("choices", [{}])[0]
+        .get("message", {})
+        .get("content", "")
+    )
+
+
+def _expected_followup_due_date_iso() -> str:
+    return (dt.datetime.now(dt.timezone.utc) + dt.timedelta(days=3)).date().isoformat()
+
+
+def _assert_followup_completion_text(run: RunResult, text: str, expected_due: str) -> None:
+    lowered = (text or "").lower()
+    _assert(run, "followup_task_mentioned", "follow-up task" in lowered or "followup task" in lowered, text)
+    _assert(run, "followup_task_not_failed", "could not queue" not in lowered, text)
+    _assert(run, "followup_due_date_is_plus_3_days", expected_due in (text or ""), text)
+
+
+def _assert_followup_task_persisted(
+    *,
+    config: HarnessConfig,
+    user_id: str,
+    expected_due: str,
+    run: RunResult,
+) -> None:
+    if not config.library_root:
+        _assert(run, "followup_task_persisted_skipped_no_library_root", True, "")
+        return
+
+    normalized = _normalize_user_id(user_id)
+    pulse_path = config.library_root / "users" / normalized / "pulse" / "index.md"
+    _assert(run, "followup_pulse_index_exists", pulse_path.is_file(), str(pulse_path))
+    content = pulse_path.read_text(encoding="utf-8")
+    task_lines = [line.strip() for line in content.splitlines() if line.strip().startswith("- [")]
+    _assert(run, "pulse_task_line_present", bool(task_lines), content)
+    followup_lines = [line for line in task_lines if "follow-up interview check-in" in line.lower()]
+    _assert(run, "followup_task_line_present", bool(followup_lines), content)
+    followup_line = followup_lines[-1]
+    lowered = followup_line.lower()
+    _assert(run, "followup_task_scope_finances", f"scope:life/{config.topic}" in lowered, followup_line)
+    _assert(run, "followup_task_due_plus_3_days", f"due:{expected_due}" in lowered, followup_line)
+    _assert(run, "followup_task_title_present", "follow-up interview check-in" in lowered, followup_line)
+    run.followup_task_persisted = True
+
+
+def _run_single(
+    *,
+    config: HarnessConfig,
+    token: str,
+    user_id: str,
+    run_index: int,
+) -> RunResult:
+    global _ACTIVE_RUN
+    run_seed = config.seed + run_index
+    rng = random.Random(run_seed)
+    run_id = f"run-{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{run_index:02d}"
+    kickoff = rng.choice(KICKOFF_VARIANTS)
+
+    run = RunResult(
+        run_id=run_id,
+        seed=run_seed,
+        topic=config.topic,
+        kickoff_phrase=kickoff,
+        expected_followup_due_date=_expected_followup_due_date_iso(),
+    )
+    _ACTIVE_RUN = run
+
+    # Kickoff
+    kickoff_response = _send_chat(
+        config=config,
+        token=token,
+        user_id=user_id,
+        message=kickoff,
+        conversation_id=None,
+        run=run,
+    )
+    conversation_id = run.conversation_id
+    _assert(run, "conversation_id_created", isinstance(conversation_id, str) and bool(conversation_id))
+
+    kickoff_text = _as_assistant_text(kickoff_response)
+    q_index, q_total = _extract_question_state(kickoff_text)
+    run.question_total = q_total
+    _assert(run, "opening_question_index_starts_at_1", q_index == 1, kickoff_text)
+    _assert(run, "opening_question_cap_le_6", q_total <= 6, kickoff_text)
+
+    current_question_text = kickoff_text
+    for expected_index in range(1, q_total + 1):
+        _assert(
+            run,
+            f"question_{expected_index}_present",
+            f"Question {expected_index} of {q_total}" in current_question_text,
+            current_question_text,
+        )
+
+        answer = _pick_answer(rng)
+        answer_response = _send_chat(
+            config=config,
+            token=token,
+            user_id=user_id,
+            message=answer,
+            conversation_id=conversation_id,
+            run=run,
+        )
+        answer_text = _as_assistant_text(answer_response)
+        _assert(run, f"question_{expected_index}_asks_for_approval", "approve" in answer_text.lower(), answer_text)
+
+        # Optional reject/revise branch for opening answers
+        if rng.random() < config.reject_prob:
+            run.rejected_opening_turns += 1
+            reject_msg = rng.choice(REJECT_VARIANTS)
+            reject_response = _send_chat(
+                config=config,
+                token=token,
+                user_id=user_id,
+                message=reject_msg,
+                conversation_id=conversation_id,
+                run=run,
+            )
+            reject_text = _as_assistant_text(reject_response)
+            _assert(
+                run,
+                f"question_{expected_index}_reject_keeps_turn_open",
+                "question" in reject_text.lower() or "revise" in reject_text.lower(),
+                reject_text,
+            )
+
+            revised_answer = _pick_answer(rng)
+            revised_response = _send_chat(
+                config=config,
+                token=token,
+                user_id=user_id,
+                message=revised_answer,
+                conversation_id=conversation_id,
+                run=run,
+            )
+            revised_text = _as_assistant_text(revised_response)
+            _assert(
+                run,
+                f"question_{expected_index}_revised_asks_for_approval",
+                "approve" in revised_text.lower(),
+                revised_text,
+            )
+
+        approve_msg = rng.choice(APPROVE_VARIANTS)
+        approve_response = _send_chat(
+            config=config,
+            token=token,
+            user_id=user_id,
+            message=approve_msg,
+            conversation_id=conversation_id,
+            run=run,
+        )
+        current_question_text = _as_assistant_text(approve_response)
+
+    # Post-opening branch
+    if "initial goals" in current_question_text.lower() or "goals or tasks" in current_question_text.lower():
+        choose_goals = rng.random() < config.goals_yes_prob
+        if choose_goals:
+            run.goals_branch = "yes"
+            yes_response = _send_chat(
+                config=config,
+                token=token,
+                user_id=user_id,
+                message="yes",
+                conversation_id=conversation_id,
+                run=run,
+            )
+            yes_text = _as_assistant_text(yes_response)
+            _assert(run, "goals_yes_branch_prompts_details", "goal" in yes_text.lower() or "task" in yes_text.lower(), yes_text)
+
+            use_relative = rng.random() < config.relative_date_prob
+            run.used_relative_dates = use_relative
+            goals_text = rng.choice(
+                GOALS_TASKS_RELATIVE_VARIANTS if use_relative else GOALS_TASKS_ABSOLUTE_VARIANTS
+            )
+            goals_response = _send_chat(
+                config=config,
+                token=token,
+                user_id=user_id,
+                message=goals_text,
+                conversation_id=conversation_id,
+                run=run,
+            )
+            goals_capture_text = _as_assistant_text(goals_response)
+            _assert(run, "goals_capture_requests_approval", "approve" in goals_capture_text.lower(), goals_capture_text)
+            if use_relative:
+                _assert(
+                    run,
+                    "relative_dates_are_resolved",
+                    "resolved dates:" in goals_capture_text.lower(),
+                    goals_capture_text,
+                )
+
+            if rng.random() < config.reject_prob:
+                run.rejected_goals_turns += 1
+                reject_goals = _send_chat(
+                    config=config,
+                    token=token,
+                    user_id=user_id,
+                    message=rng.choice(REJECT_VARIANTS),
+                    conversation_id=conversation_id,
+                    run=run,
+                )
+                reject_goals_text = _as_assistant_text(reject_goals)
+                _assert(
+                    run,
+                    "goals_reject_requests_reentry",
+                    "share" in reject_goals_text.lower() or "revise" in reject_goals_text.lower(),
+                    reject_goals_text,
+                )
+                # Re-enter with absolute date to keep deterministic completion
+                goals_retry = _send_chat(
+                    config=config,
+                    token=token,
+                    user_id=user_id,
+                    message=rng.choice(GOALS_TASKS_ABSOLUTE_VARIANTS),
+                    conversation_id=conversation_id,
+                    run=run,
+                )
+                retry_text = _as_assistant_text(goals_retry)
+                _assert(run, "goals_retry_requests_approval", "approve" in retry_text.lower(), retry_text)
+
+            finish_response = _send_chat(
+                config=config,
+                token=token,
+                user_id=user_id,
+                message=rng.choice(APPROVE_VARIANTS),
+                conversation_id=conversation_id,
+                run=run,
+            )
+            finish_text = _as_assistant_text(finish_response)
+            _assert(run, "goals_yes_branch_completes", "onboarding is complete" in finish_text.lower(), finish_text)
+            _assert_followup_completion_text(run, finish_text, run.expected_followup_due_date)
+            _assert_followup_task_persisted(
+                config=config,
+                user_id=user_id,
+                expected_due=run.expected_followup_due_date,
+                run=run,
+            )
+        else:
+            run.goals_branch = "no"
+            no_response = _send_chat(
+                config=config,
+                token=token,
+                user_id=user_id,
+                message="no",
+                conversation_id=conversation_id,
+                run=run,
+            )
+            no_text = _as_assistant_text(no_response)
+            _assert(run, "goals_no_branch_completes", "onboarding is complete" in no_text.lower(), no_text)
+            _assert_followup_completion_text(run, no_text, run.expected_followup_due_date)
+            _assert_followup_task_persisted(
+                config=config,
+                user_id=user_id,
+                expected_due=run.expected_followup_due_date,
+                run=run,
+            )
+    else:
+        run.goals_branch = "skipped"
+        if config.allow_legacy_completion_without_goals_prompt:
+            _assert(
+                run,
+                "opening_completion_prompt_present_or_legacy_completion",
+                "onboarding is complete" in current_question_text.lower() or "goals" in current_question_text.lower(),
+                current_question_text,
+            )
+        else:
+            _assert(
+                run,
+                "opening_goals_prompt_present",
+                "initial goals" in current_question_text.lower() or "goals or tasks" in current_question_text.lower(),
+                current_question_text,
+            )
+
+    run.success = all(assertion.passed for assertion in run.assertions)
+    _ACTIVE_RUN = None
+    return run
+
+
+def _write_run_artifacts(config: HarnessConfig, run: RunResult) -> Path:
+    run_dir = config.output_dir / run.run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = {
+        "run_id": run.run_id,
+        "seed": run.seed,
+        "topic": run.topic,
+        "success": run.success,
+        "kickoff_phrase": run.kickoff_phrase,
+        "question_total": run.question_total,
+        "goals_branch": run.goals_branch,
+        "used_relative_dates": run.used_relative_dates,
+        "rejected_opening_turns": run.rejected_opening_turns,
+        "rejected_goals_turns": run.rejected_goals_turns,
+        "expected_followup_due_date": run.expected_followup_due_date,
+        "followup_task_persisted": run.followup_task_persisted,
+        "conversation_id": run.conversation_id,
+        "error": run.error,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in run.assertions
+        ],
+        "created_at_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+    }
+
+    (run_dir / "summary.json").write_text(json.dumps(summary, indent=2) + "\n", encoding="utf-8")
+    (run_dir / "transcript.json").write_text(json.dumps(run.transcript, indent=2) + "\n", encoding="utf-8")
+
+    transcript_lines = [f"# Transcript {run.run_id}", ""]
+    for item in run.transcript:
+        role = item.get("role", "unknown")
+        at = item.get("at", "")
+        content = item.get("content", "")
+        transcript_lines.append(f"## {role} @ {at}")
+        transcript_lines.append("")
+        transcript_lines.append(str(content))
+        transcript_lines.append("")
+    (run_dir / "transcript.md").write_text("\n".join(transcript_lines) + "\n", encoding="utf-8")
+
+    latest_pointer = {
+        "latest_run_id": run.run_id,
+        "summary_path": str((run_dir / "summary.json").resolve()),
+        "updated_at_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+    }
+    (config.output_dir / "latest-run.json").write_text(
+        json.dumps(latest_pointer, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return run_dir
+
+
+def _parse_args() -> HarnessConfig:
+    parser = argparse.ArgumentParser(description="RNG onboarding interview test harness")
+    parser.add_argument("--base-url", default=os.getenv("BRAINDRIVE_E2E_BASE_URL", "http://localhost:8000"))
+    parser.add_argument("--email", default=os.getenv("BRAINDRIVE_E2E_EMAIL", ""))
+    parser.add_argument("--password", default=os.getenv("BRAINDRIVE_E2E_PASSWORD", ""))
+    parser.add_argument("--provider", default=os.getenv("BRAINDRIVE_E2E_PROVIDER", "ollama"))
+    parser.add_argument("--settings-id", default=os.getenv("BRAINDRIVE_E2E_SETTINGS_ID", "ollama_settings"))
+    parser.add_argument("--server-id", default=os.getenv("BRAINDRIVE_E2E_SERVER_ID", "ollama_default_server"))
+    parser.add_argument("--model", default=os.getenv("BRAINDRIVE_E2E_MODEL", "qwen3:8b"))
+    parser.add_argument("--topic", default="finances")
+    parser.add_argument("--runs", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--output-dir", default="tmp/onboarding-test-runs")
+    parser.add_argument("--reset-from-template", action="store_true")
+    parser.add_argument("--library-root", default=os.getenv("BRAINDRIVE_LIBRARY_PATH", ""))
+    parser.add_argument("--template-root", default="")
+    parser.add_argument("--reject-prob", type=float, default=0.25)
+    parser.add_argument("--goals-yes-prob", type=float, default=0.6)
+    parser.add_argument("--relative-date-prob", type=float, default=0.6)
+    parser.add_argument("--timeout-seconds", type=int, default=90)
+    parser.add_argument(
+        "--request-delay-seconds",
+        type=float,
+        default=1.25,
+        help="Minimum delay between HTTP requests to avoid hitting chat rate limits.",
+    )
+    parser.add_argument(
+        "--http-max-retries",
+        type=int,
+        default=6,
+        help="Maximum retries for HTTP 429 responses.",
+    )
+    parser.add_argument(
+        "--http-retry-base-seconds",
+        type=float,
+        default=2.0,
+        help="Base exponential backoff seconds for HTTP 429 retries.",
+    )
+    parser.add_argument(
+        "--allow-legacy-completion-without-goals-prompt",
+        action="store_true",
+        help="Allow old completion behavior that skips goals/tasks prompt and follow-up assertions.",
+    )
+    parser.add_argument("--headful", action="store_true", help="Compatibility flag (no-op for API harness).")
+
+    args = parser.parse_args()
+
+    if not args.email or not args.password:
+        raise SystemExit("Email/password are required. Use --email/--password or BRAINDRIVE_E2E_EMAIL/BRAINDRIVE_E2E_PASSWORD.")
+    if args.runs < 1:
+        raise SystemExit("--runs must be >= 1")
+    if args.topic != "finances":
+        raise SystemExit("Initial harness currently supports --topic finances only.")
+
+    library_root = Path(args.library_root).expanduser().resolve() if args.library_root else None
+    template_root = Path(args.template_root).expanduser().resolve() if args.template_root else None
+
+    return HarnessConfig(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        topic=args.topic,
+        runs=args.runs,
+        seed=args.seed,
+        output_dir=Path(args.output_dir).expanduser().resolve(),
+        reset_from_template=bool(args.reset_from_template),
+        library_root=library_root,
+        template_root=template_root,
+        reject_prob=max(0.0, min(1.0, args.reject_prob)),
+        goals_yes_prob=max(0.0, min(1.0, args.goals_yes_prob)),
+        relative_date_prob=max(0.0, min(1.0, args.relative_date_prob)),
+        timeout_seconds=max(10, args.timeout_seconds),
+        allow_legacy_completion_without_goals_prompt=bool(
+            args.allow_legacy_completion_without_goals_prompt
+        ),
+        request_delay_seconds=max(0.0, args.request_delay_seconds),
+        http_max_retries=max(0, args.http_max_retries),
+        http_retry_base_seconds=max(0.1, args.http_retry_base_seconds),
+    )
+
+
+def main() -> int:
+    global _ACTIVE_RUN
+    config = _parse_args()
+    config.output_dir.mkdir(parents=True, exist_ok=True)
+
+    if config.reset_from_template and not config.library_root:
+        raise SystemExit("--reset-from-template requires --library-root (or BRAINDRIVE_LIBRARY_PATH).")
+
+    token, user_id = _login(config)
+    print(f"Logged in user_id={user_id}")
+    print(
+        "Using response model configuration: "
+        f"provider={config.provider}, settings_id={config.settings_id}, "
+        f"server_id={config.server_id}, model={config.model}"
+    )
+    print(
+        "Expected orchestration behavior: Granite handles tool-calling while the "
+        "selected model handles natural-language response."
+    )
+    print(
+        "Rate-limit pacing: "
+        f"request_delay_seconds={config.request_delay_seconds}, "
+        f"http_max_retries={config.http_max_retries}, "
+        f"http_retry_base_seconds={config.http_retry_base_seconds}"
+    )
+    print(
+        "Backend limits to respect: auth/login is 5 requests per 300s (IP), "
+        "chat is 100 requests per 60s (user)."
+    )
+    print(
+        "Login retry policy: "
+        f"max_retries={max(config.http_max_retries, 6)}, "
+        f"retry_base_seconds={max(config.http_retry_base_seconds, 5.0)}"
+    )
+
+    bootstrap_payload: Optional[Dict[str, Any]] = None
+    if config.reset_from_template:
+        bootstrap_payload = _bootstrap_user_scope(config, user_id)
+        print("Template reset/bootstrap complete")
+
+    aggregate: List[Dict[str, Any]] = []
+    failed = 0
+
+    for run_index in range(config.runs):
+        if config.reset_from_template and run_index > 0:
+            bootstrap_payload = _bootstrap_user_scope(config, user_id)
+
+        run: Optional[RunResult] = None
+        run_failed_via_exception = False
+        try:
+            run = _run_single(config=config, token=token, user_id=user_id, run_index=run_index)
+        except Exception as exc:  # pragma: no cover - failure path capture
+            if _ACTIVE_RUN is not None:
+                run = _ACTIVE_RUN
+                run.error = f"{exc}\n{traceback.format_exc()}"
+                run.success = False
+                _ACTIVE_RUN = None
+            else:
+                run_id = f"run-{dt.datetime.now(dt.timezone.utc).strftime('%Y%m%dT%H%M%SZ')}-{run_index:02d}"
+                run = RunResult(
+                    run_id=run_id,
+                    seed=config.seed + run_index,
+                    topic=config.topic,
+                    kickoff_phrase="n/a",
+                    success=False,
+                    error=f"{exc}\n{traceback.format_exc()}",
+                )
+            run_failed_via_exception = True
+            failed += 1
+
+        if run and not run.success and not run_failed_via_exception:
+            failed += 1
+
+        run_dir = _write_run_artifacts(config, run)
+        summary_path = run_dir / "summary.json"
+        aggregate.append(
+            {
+                "run_id": run.run_id,
+                "success": run.success,
+                "seed": run.seed,
+                "summary_path": str(summary_path),
+            }
+        )
+        print(f"[{run.run_id}] success={run.success} summary={summary_path}")
+
+    aggregate_payload = {
+        "topic": config.topic,
+        "runs": config.runs,
+        "seed": config.seed,
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "reset_from_template": config.reset_from_template,
+        "allow_legacy_completion_without_goals_prompt": config.allow_legacy_completion_without_goals_prompt,
+        "bootstrap": bootstrap_payload,
+        "results": aggregate,
+        "created_at_utc": dt.datetime.now(dt.timezone.utc).isoformat(),
+    }
+    aggregate_path = config.output_dir / "aggregate-results.json"
+    aggregate_path.write_text(json.dumps(aggregate_payload, indent=2) + "\n", encoding="utf-8")
+
+    print(f"Aggregate results: {aggregate_path}")
+    if failed:
+        print(f"Completed with failures: {failed}")
+        return 1
+    print("All runs passed")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_g1_g2_g3.py
+++ b/scripts/e2e_process_g1_g2_g3.py
@@ -1,0 +1,785 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process G.1, G.2, and G.3.
+
+G.1: VS-11 / TR-1 new-page engine scaffold approval + execution.
+G.2: VS-5 / VS-6 edit-preview approval payload + execution follow-through.
+G.3: TR-4 / VS-12 mixed-flow runtime sweep (capture + digest + normal chat)
+      with duplicate-guard checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _http_post(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                if not body.strip():
+                    return {}
+                return json.loads(body)
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    response = _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _run_g1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    prompt = "Create a new project page for side business."
+
+    create_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message=prompt,
+        conversation_type="chat",
+        mcp_scope_mode="project",
+        mcp_project_slug="projects/active/finance",
+        mcp_project_name="Finance",
+    )
+    create_response = _chat(config, token, create_payload)
+    scenario["create_response"] = {
+        "approval_required": create_response.get("approval_required"),
+        "approval_request": create_response.get("approval_request"),
+        "conversation_id": create_response.get("conversation_id"),
+        "tooling_state": create_response.get("tooling_state"),
+    }
+
+    _assert(summary, "g1_approval_required", create_response.get("approval_required") is True, str(create_response))
+    approval_request = create_response.get("approval_request") or {}
+    _assert(summary, "g1_tool_create_project", approval_request.get("tool") == "create_project", str(approval_request))
+    _assert(
+        summary,
+        "g1_reason_new_page_engine",
+        approval_request.get("synthetic_reason") == "new_page_engine_scaffold",
+        str(approval_request),
+    )
+
+    approval_args = approval_request.get("arguments") or {}
+    create_path = str(approval_args.get("path") or "")
+    files = approval_args.get("files") or []
+    file_paths = {entry.get("path") for entry in files if isinstance(entry, dict)}
+    _assert(summary, "g1_path_side_business", create_path == "projects/active/side-business", create_path)
+    _assert(
+        summary,
+        "g1_required_seed_files",
+        {"AGENT.md", "interview.md", "spec.md", "build-plan.md"}.issubset(file_paths),
+        str(sorted(file_paths)),
+    )
+
+    conversation_id = create_response.get("conversation_id")
+    request_id = approval_request.get("request_id")
+    _assert(summary, "g1_has_conversation_id", isinstance(conversation_id, str) and bool(conversation_id), str(conversation_id))
+    _assert(summary, "g1_has_request_id", isinstance(request_id, str) and bool(request_id), str(request_id))
+
+    approve_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="approve",
+        conversation_type="chat",
+        mcp_scope_mode="project",
+        mcp_project_slug="projects/active/finance",
+        mcp_project_name="Finance",
+        conversation_id=conversation_id,
+        params_extra={
+            "mcp_approval": {
+                "action": "approve",
+                "request_id": request_id,
+            }
+        },
+    )
+    approve_response = _chat(config, token, approve_payload)
+    scenario["approve_response"] = {
+        "approval_resolution": approve_response.get("approval_resolution"),
+        "tooling_state": approve_response.get("tooling_state"),
+        "choice": (approve_response.get("choices") or [{}])[0],
+    }
+    resolution = approve_response.get("approval_resolution") or {}
+    _assert(summary, "g1_approval_resolution_approved", resolution.get("status") == "approved", str(resolution))
+    tooling_state = approve_response.get("tooling_state") or {}
+    _assert(
+        summary,
+        "g1_tool_call_executed_after_approval",
+        int(tooling_state.get("tool_calls_executed_count") or 0) >= 1,
+        str(tooling_state),
+    )
+    _assert(
+        summary,
+        "g1_approval_marked_resolved",
+        bool(tooling_state.get("approval_resolved")),
+        str(tooling_state),
+    )
+
+    return scenario
+
+
+def _run_g2(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {"attempts": []}
+    marker = f"G2 preview marker {summary.run_id}"
+    prompts = [
+        (
+            "Return ONLY a tool call to edit_markdown. "
+            "Path: projects/active/side-business/spec.md. "
+            f"Operation: append line '- {marker}'. No prose."
+        ),
+        (
+            "You are required to call edit_markdown now on "
+            "projects/active/side-business/spec.md and append this exact line: "
+            f"- {marker}"
+        ),
+        (
+            "Append this line to projects/active/side-business/spec.md and use a tool call only: "
+            f"- {marker}"
+        ),
+    ]
+
+    selected_response: Optional[Dict[str, Any]] = None
+    selected_prompt: Optional[str] = None
+    for prompt in prompts:
+        response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=prompt,
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="projects/active/side-business",
+                mcp_project_name="Side Business",
+                params_extra={"mcp_native_tool_calling": True},
+            ),
+        )
+        approval = response.get("approval_request") or {}
+        preview = approval.get("preview") if isinstance(approval, dict) else None
+        attempt = {
+            "prompt": prompt,
+            "approval_required": response.get("approval_required"),
+            "approval_tool": approval.get("tool") if isinstance(approval, dict) else None,
+            "has_preview": isinstance(preview, dict),
+            "conversation_id": response.get("conversation_id"),
+            "approval_request": approval,
+        }
+        scenario["attempts"].append(attempt)
+        if (
+            response.get("approval_required") is True
+            and isinstance(approval, dict)
+            and str(approval.get("tool") or "").strip() in {"edit_markdown", "write_markdown"}
+            and isinstance(preview, dict)
+        ):
+            selected_response = response
+            selected_prompt = prompt
+            break
+
+    _assert(summary, "g2_found_preview_approval", selected_response is not None, json.dumps(scenario["attempts"], indent=2))
+    assert selected_response is not None
+    approval_request = selected_response.get("approval_request") or {}
+    preview = approval_request.get("preview") or {}
+    _assert(
+        summary,
+        "g2_preview_contains_diff_or_summary",
+        bool(str(preview.get("diff") or "").strip()) or bool(str(preview.get("summary") or "").strip()),
+        str(preview),
+    )
+    _assert(summary, "g2_preview_tool_marker", preview.get("previewTool") == "preview_markdown_change", str(preview))
+
+    conversation_id = selected_response.get("conversation_id")
+    request_id = approval_request.get("request_id")
+    _assert(summary, "g2_has_conversation_id", isinstance(conversation_id, str) and bool(conversation_id), str(conversation_id))
+    _assert(summary, "g2_has_request_id", isinstance(request_id, str) and bool(request_id), str(request_id))
+
+    approve_response = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/side-business",
+            mcp_project_name="Side Business",
+            conversation_id=conversation_id,
+            params_extra={
+                "mcp_approval": {
+                    "action": "approve",
+                    "request_id": request_id,
+                }
+            },
+        ),
+    )
+    scenario["selected_prompt"] = selected_prompt
+    scenario["approve_response"] = {
+        "approval_resolution": approve_response.get("approval_resolution"),
+        "tooling_state": approve_response.get("tooling_state"),
+        "choice": (approve_response.get("choices") or [{}])[0],
+    }
+    resolution = approve_response.get("approval_resolution") or {}
+    _assert(summary, "g2_approval_resolution_approved", resolution.get("status") == "approved", str(resolution))
+
+    final_text = str((((approve_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+    _assert(summary, "g2_resume_has_confirmation_text", bool(final_text.strip()), str(approve_response))
+    tooling_state = approve_response.get("tooling_state") or {}
+    _assert(
+        summary,
+        "g2_tool_call_executed_after_approval",
+        int(tooling_state.get("tool_calls_executed_count") or 0) >= 1,
+        str(tooling_state),
+    )
+    _assert(
+        summary,
+        "g2_approval_marked_resolved",
+        bool(tooling_state.get("approval_resolved")),
+        str(tooling_state),
+    )
+
+    return scenario
+
+
+def _run_g3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    normal_response = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="What are the top priorities for my side business page right now?",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/side-business",
+            mcp_project_name="Side Business",
+        ),
+    )
+    scenario["normal_chat"] = {
+        "conversation_id": normal_response.get("conversation_id"),
+        "tooling_state": normal_response.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "g3_normal_chat_has_tooling_state",
+        isinstance(normal_response.get("tooling_state"), dict),
+        str(normal_response),
+    )
+
+    capture_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Capture this note: review subscription spend and recurring fees this week.",
+            conversation_type="capture",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+        ),
+    )
+    capture_request = capture_start.get("approval_request") or {}
+    scenario["capture_start"] = {
+        "approval_required": capture_start.get("approval_required"),
+        "approval_request": capture_request,
+        "conversation_id": capture_start.get("conversation_id"),
+    }
+    _assert(summary, "g3_capture_approval_required", capture_start.get("approval_required") is True, str(capture_start))
+    _assert(summary, "g3_capture_tool_create_markdown", capture_request.get("tool") == "create_markdown", str(capture_request))
+
+    capture_approve = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type="capture",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+            conversation_id=capture_start.get("conversation_id"),
+            params_extra={
+                "mcp_approval": {
+                    "action": "approve",
+                    "request_id": capture_request.get("request_id"),
+                }
+            },
+        ),
+    )
+    scenario["capture_approve"] = {
+        "approval_resolution": capture_approve.get("approval_resolution"),
+        "tooling_state": capture_approve.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "g3_capture_approval_resolution_approved",
+        (capture_approve.get("approval_resolution") or {}).get("status") == "approved",
+        str(capture_approve.get("approval_resolution")),
+    )
+
+    digest_event_id = "g3-digest-event-1"
+    digest_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest now.",
+            conversation_type="digest",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+            },
+        ),
+    )
+    digest_conversation_id = digest_start.get("conversation_id")
+    scenario["digest_start"] = {
+        "conversation_id": digest_conversation_id,
+        "tooling_state": digest_start.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "g3_digest_has_conversation_id",
+        isinstance(digest_conversation_id, str) and bool(digest_conversation_id),
+        str(digest_conversation_id),
+    )
+
+    digest_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest now.",
+            conversation_type="digest",
+            mcp_scope_mode="none",
+            conversation_id=digest_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+            },
+        ),
+    )
+    digest_repeat_state = digest_repeat.get("tooling_state") or {}
+    scenario["digest_repeat"] = {
+        "tooling_state": digest_repeat_state,
+    }
+    _assert(
+        summary,
+        "g3_digest_duplicate_guard_status",
+        digest_repeat_state.get("digest_schedule_status") == "duplicate_guard",
+        str(digest_repeat_state),
+    )
+    _assert(
+        summary,
+        "g3_digest_duplicate_guard_history_seen",
+        digest_repeat_state.get("digest_schedule_duplicate_guard") == "history_seen",
+        str(digest_repeat_state),
+    )
+
+    preflush_event_id = "g3-preflush-event-1"
+    long_message = " ".join(["context-overflow-check"] * 220)
+    preflush_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_conversation_id = preflush_start.get("conversation_id")
+    scenario["preflush_start"] = {
+        "conversation_id": preflush_conversation_id,
+        "tooling_state": preflush_start.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "g3_preflush_has_conversation_id",
+        isinstance(preflush_conversation_id, str) and bool(preflush_conversation_id),
+        str(preflush_conversation_id),
+    )
+
+    preflush_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            conversation_id=preflush_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_repeat_state = preflush_repeat.get("tooling_state") or {}
+    scenario["preflush_repeat"] = {
+        "tooling_state": preflush_repeat_state,
+    }
+    _assert(
+        summary,
+        "g3_preflush_duplicate_guard_status",
+        preflush_repeat_state.get("pre_compaction_flush_status") == "duplicate_guard",
+        str(preflush_repeat_state),
+    )
+    _assert(
+        summary,
+        "g3_preflush_duplicate_guard_history_seen",
+        preflush_repeat_state.get("pre_compaction_flush_duplicate_guard") == "history_seen",
+        str(preflush_repeat_state),
+    )
+
+    return scenario
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process G.1/G.2/G.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="qwen3-8b-new-server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-g123")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.5)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument(
+        "--reset-from-template",
+        action="store_true",
+        default=True,
+        help="Reset user scope from template before running probes (default: true).",
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        action="store_false",
+        dest="reset_from_template",
+        help="Skip scope reset.",
+    )
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def _summary_to_json(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap
+
+        summary.scenarios["g1"] = _run_g1(summary, config, token, user_id)
+        summary.scenarios["g2"] = _run_g2(summary, config, token, user_id)
+        summary.scenarios["g3"] = _run_g3(summary, config, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness surface
+        summary.error = str(exc)
+        summary.success = False
+
+    summary_path = run_dir / "summary.json"
+    summary_path.write_text(json.dumps(_summary_to_json(summary), indent=2), encoding="utf-8")
+    print(str(summary_path))
+    print(f"success={summary.success}")
+    if summary.error:
+        print(f"error={summary.error}")
+
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_h1_h2_h3.py
+++ b/scripts/e2e_process_h1_h2_h3.py
@@ -1,0 +1,880 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process H.1, H.2, and H.3.
+
+H.1: VS-11 expansion + VS-8 focused-page parity checks.
+H.2: VS-5/VS-6 integrated edit/approval matrix checks.
+H.3: VS-12/TR-4 delivery-channel digest + duplicate-guard checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+APPROVAL_REQUIRED_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _http_post(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                if not body.strip():
+                    return {}
+                return json.loads(body)
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    response = _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+    page_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    if page_id:
+        payload["page_id"] = page_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _run_h1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    project_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Create a new project page for side business.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/finance",
+            mcp_project_name="Finance",
+        ),
+    )
+    project_request = project_start.get("approval_request") or {}
+    project_args = project_request.get("arguments") or {}
+    project_files = project_args.get("files") or []
+    project_paths = {
+        entry.get("path") for entry in project_files if isinstance(entry, dict)
+    }
+    scenario["new_page_project"] = {
+        "approval_required": project_start.get("approval_required"),
+        "approval_request": project_request,
+        "tooling_state": project_start.get("tooling_state"),
+    }
+    _assert(summary, "h1_project_approval_required", project_start.get("approval_required") is True, str(project_start))
+    _assert(summary, "h1_project_tool_create_project", project_request.get("tool") == "create_project", str(project_request))
+    _assert(
+        summary,
+        "h1_project_reason_seeded",
+        project_request.get("synthetic_reason") == "new_page_engine_scaffold",
+        str(project_request),
+    )
+    _assert(summary, "h1_project_path", project_args.get("path") == "projects/active/side-business", str(project_args))
+    _assert(
+        summary,
+        "h1_project_richer_seed_pack",
+        {
+            "AGENT.md",
+            "interview.md",
+            "interview-followup.md",
+            "spec.md",
+            "build-plan.md",
+            "decisions.md",
+            "ideas.md",
+            "status.md",
+            "_meta/interview-state.md",
+        }.issubset(project_paths),
+        str(sorted(project_paths)),
+    )
+
+    project_followup = next(
+        (entry for entry in project_files if entry.get("path") == "interview-followup.md"),
+        None,
+    )
+    _assert(summary, "h1_project_followup_file_present", isinstance(project_followup, dict), str(project_files))
+    _assert(
+        summary,
+        "h1_project_followup_has_target_date",
+        "Target Follow-up Date (UTC Date):" in str((project_followup or {}).get("content") or ""),
+        str(project_followup),
+    )
+    project_meta = next(
+        (entry for entry in project_files if entry.get("path") == "_meta/interview-state.md"),
+        None,
+    )
+    parsed_project_meta = json.loads(str((project_meta or {}).get("content") or "{}"))
+    _assert(summary, "h1_project_meta_has_followup_due", bool(parsed_project_meta.get("first_followup_due_utc")), str(parsed_project_meta))
+
+    life_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Create a new life page for debt reset sprint.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+        ),
+    )
+    life_request = life_start.get("approval_request") or {}
+    life_args = life_request.get("arguments") or {}
+    life_files = life_args.get("files") or []
+    life_paths = {entry.get("path") for entry in life_files if isinstance(entry, dict)}
+    scenario["new_page_life"] = {
+        "approval_required": life_start.get("approval_required"),
+        "approval_request": life_request,
+        "tooling_state": life_start.get("tooling_state"),
+    }
+    _assert(summary, "h1_life_approval_required", life_start.get("approval_required") is True, str(life_start))
+    _assert(summary, "h1_life_tool_create_project", life_request.get("tool") == "create_project", str(life_request))
+    _assert(summary, "h1_life_path", life_args.get("path") == "life/debt-reset-sprint", str(life_args))
+    _assert(
+        summary,
+        "h1_life_richer_seed_pack",
+        {
+            "AGENT.md",
+            "interview.md",
+            "interview-followup.md",
+            "spec.md",
+            "build-plan.md",
+            "goals.md",
+            "action-plan.md",
+            "context.md",
+            "checkins.md",
+            "_meta/interview-state.md",
+        }.issubset(life_paths),
+        str(sorted(life_paths)),
+    )
+
+    focused_checks: List[Dict[str, Any]] = []
+    for conversation_type, expected_slug in (
+        ("life-whyfinder", "whyfinder"),
+        ("life-career", "career"),
+        ("life-finances", "finances"),
+        ("life-fitness", "fitness"),
+        ("life-relationships", "relationships"),
+    ):
+        focused_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message="Status check.",
+                conversation_type=conversation_type,
+                mcp_scope_mode="none",
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_sync_on_request": False,
+                },
+            ),
+        )
+        state = focused_response.get("tooling_state") or {}
+        focused_checks.append(
+            {
+                "conversation_type": conversation_type,
+                "mcp_scope_mode": state.get("mcp_scope_mode"),
+                "mcp_project_slug": state.get("mcp_project_slug"),
+                "mcp_scope_source": state.get("mcp_scope_source"),
+            }
+        )
+        _assert(
+            summary,
+            f"h1_focused_scope_{expected_slug}",
+            state.get("mcp_scope_mode") == "project"
+            and state.get("mcp_project_slug") == expected_slug
+            and state.get("mcp_scope_source") == "conversation_type",
+            str(state),
+        )
+    scenario["focused_page_scope_matrix"] = focused_checks
+
+    return scenario
+
+
+def _run_h2(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {"attempts": []}
+    marker = f"H2 marker {summary.run_id}"
+    prompts = [
+        (
+            "primary",
+            "Return ONLY a tool call to edit_markdown. "
+            "Path: projects/active/side-business/spec.md. "
+            f"Operation: append line '- {marker}'. No prose.",
+        ),
+        (
+            "multi_op",
+            "Return ONLY a tool call to edit_markdown. "
+            "Path: projects/active/side-business/spec.md. "
+            f"Append two lines in one operation: '- {marker} A' and '- {marker} B'. No prose.",
+        ),
+    ]
+
+    selected_response: Optional[Dict[str, Any]] = None
+    selected_prompt: Optional[str] = None
+    for label, prompt in prompts:
+        response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=prompt,
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="projects/active/side-business",
+                mcp_project_name="Side Business",
+                params_extra={"mcp_native_tool_calling": True},
+            ),
+        )
+        approval = response.get("approval_request") or {}
+        preview = approval.get("preview") if isinstance(approval, dict) else None
+        attempt = {
+            "label": label,
+            "prompt": prompt,
+            "approval_required": response.get("approval_required"),
+            "assistant_text": ((response.get("choices") or [{}])[0].get("message") or {}).get("content"),
+            "approval_request": approval,
+        }
+        scenario["attempts"].append(attempt)
+        if (
+            response.get("approval_required") is True
+            and isinstance(approval, dict)
+            and str(approval.get("tool") or "").strip() in {"edit_markdown", "write_markdown"}
+            and isinstance(preview, dict)
+        ):
+            selected_response = response
+            selected_prompt = prompt
+            break
+
+    _assert(summary, "h2_preview_approval_found", selected_response is not None, json.dumps(scenario["attempts"], indent=2))
+    assert selected_response is not None
+    first_approval = selected_response.get("approval_request") or {}
+    first_preview = first_approval.get("preview") or {}
+    first_text = str((((selected_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+    _assert(summary, "h2_approval_copy_locked", first_text == APPROVAL_REQUIRED_TEXT, first_text)
+    _assert(
+        summary,
+        "h2_preview_has_diff_or_summary",
+        bool(str(first_preview.get("diff") or "").strip()) or bool(str(first_preview.get("summary") or "").strip()),
+        str(first_preview),
+    )
+    _assert(summary, "h2_preview_marker", first_preview.get("previewTool") == "preview_markdown_change", str(first_preview))
+
+    conversation_id = selected_response.get("conversation_id")
+    request_id = first_approval.get("request_id")
+    _assert(summary, "h2_has_conversation_id", isinstance(conversation_id, str) and bool(conversation_id), str(conversation_id))
+    _assert(summary, "h2_has_request_id", isinstance(request_id, str) and bool(request_id), str(request_id))
+
+    reject_response = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="reject",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/side-business",
+            mcp_project_name="Side Business",
+            conversation_id=conversation_id,
+            params_extra={
+                "mcp_approval": {
+                    "action": "reject",
+                    "request_id": request_id,
+                }
+            },
+        ),
+    )
+    reject_resolution = reject_response.get("approval_resolution") or {}
+    _assert(summary, "h2_reject_resolution", reject_resolution.get("status") == "rejected", str(reject_resolution))
+
+    correction_prompt = (
+        "Return ONLY a tool call to edit_markdown. "
+        "Path: projects/active/side-business/spec.md. "
+        f"Operation: append line '- {marker} corrected'. No prose."
+    )
+    corrected_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=correction_prompt,
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/side-business",
+            mcp_project_name="Side Business",
+            conversation_id=conversation_id,
+            params_extra={"mcp_native_tool_calling": True},
+        ),
+    )
+    corrected_request = corrected_start.get("approval_request") or {}
+    corrected_text = str((((corrected_start.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+    scenario["correction_flow"] = {
+        "selected_prompt": selected_prompt,
+        "first_request": first_approval,
+        "reject_resolution": reject_resolution,
+        "corrected_start": {
+            "approval_required": corrected_start.get("approval_required"),
+            "assistant_text": corrected_text,
+            "approval_request": corrected_request,
+        },
+    }
+    _assert(summary, "h2_corrected_approval_required", corrected_start.get("approval_required") is True, str(corrected_start))
+    _assert(summary, "h2_corrected_copy_locked", corrected_text == APPROVAL_REQUIRED_TEXT, corrected_text)
+    corrected_preview = corrected_request.get("preview") or {}
+    _assert(summary, "h2_corrected_preview_marker", corrected_preview.get("previewTool") == "preview_markdown_change", str(corrected_preview))
+
+    corrected_approve = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/side-business",
+            mcp_project_name="Side Business",
+            conversation_id=conversation_id,
+            params_extra={
+                "mcp_approval": {
+                    "action": "approve",
+                    "request_id": corrected_request.get("request_id"),
+                }
+            },
+        ),
+    )
+    approve_resolution = corrected_approve.get("approval_resolution") or {}
+    approve_state = corrected_approve.get("tooling_state") or {}
+    final_text = str((((corrected_approve.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+    scenario["correction_flow"]["corrected_approve"] = {
+        "approval_resolution": approve_resolution,
+        "tooling_state": approve_state,
+        "assistant_text": final_text,
+    }
+    _assert(summary, "h2_corrected_approved", approve_resolution.get("status") == "approved", str(approve_resolution))
+    _assert(
+        summary,
+        "h2_corrected_execution_recorded",
+        int(approve_state.get("tool_calls_executed_count") or 0) >= 1 and bool(approve_state.get("approval_resolved")),
+        str(approve_state),
+    )
+    _assert(summary, "h2_corrected_response_text_non_empty", bool(final_text.strip()), final_text)
+
+    return scenario
+
+
+def _run_h3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    digest_event_id = f"h3-digest-email-{summary.run_id}"
+    digest_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest delivery now.",
+            conversation_type="digest-email",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_tool_profile": "read_only",
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+                "mcp_digest_sections": ["top_priorities", "needs_attention"],
+            },
+        ),
+    )
+    digest_conversation_id = digest_start.get("conversation_id")
+    digest_state = digest_start.get("tooling_state") or {}
+    scenario["digest_email_start"] = {
+        "conversation_id": digest_conversation_id,
+        "tooling_state": digest_state,
+        "approval_required": digest_start.get("approval_required"),
+    }
+    _assert(summary, "h3_digest_email_conversation_id", isinstance(digest_conversation_id, str) and bool(digest_conversation_id), str(digest_conversation_id))
+    _assert(
+        summary,
+        "h3_digest_email_channel_metadata",
+        digest_state.get("digest_delivery_channel") == "email"
+        and digest_state.get("mcp_project_slug") == "digest"
+        and digest_state.get("conversation_orchestration") == "digest_heartbeat"
+        and digest_state.get("tool_profile") in {"digest", "read_only"},
+        str(digest_state),
+    )
+
+    digest_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest delivery now.",
+            conversation_type="digest-email",
+            mcp_scope_mode="none",
+            conversation_id=digest_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_tool_profile": "read_only",
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+                "mcp_digest_sections": ["top_priorities", "needs_attention"],
+            },
+        ),
+    )
+    digest_repeat_state = digest_repeat.get("tooling_state") or {}
+    scenario["digest_email_repeat"] = {
+        "tooling_state": digest_repeat_state,
+    }
+    _assert(
+        summary,
+        "h3_digest_duplicate_guard_status",
+        digest_repeat_state.get("digest_schedule_status") == "duplicate_guard",
+        str(digest_repeat_state),
+    )
+    _assert(
+        summary,
+        "h3_digest_duplicate_guard_history_seen",
+        digest_repeat_state.get("digest_schedule_duplicate_guard") == "history_seen",
+        str(digest_repeat_state),
+    )
+
+    preflush_event_id = f"h3-preflush-{summary.run_id}"
+    long_message = " ".join(["context-window-pressure"] * 220)
+    preflush_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_conversation_id = preflush_start.get("conversation_id")
+    scenario["preflush_start"] = {
+        "conversation_id": preflush_conversation_id,
+        "tooling_state": preflush_start.get("tooling_state"),
+    }
+    _assert(summary, "h3_preflush_conversation_id", isinstance(preflush_conversation_id, str) and bool(preflush_conversation_id), str(preflush_conversation_id))
+
+    preflush_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            conversation_id=preflush_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_repeat_state = preflush_repeat.get("tooling_state") or {}
+    scenario["preflush_repeat"] = {
+        "tooling_state": preflush_repeat_state,
+    }
+    _assert(
+        summary,
+        "h3_preflush_duplicate_guard_status",
+        preflush_repeat_state.get("pre_compaction_flush_status") == "duplicate_guard",
+        str(preflush_repeat_state),
+    )
+    _assert(
+        summary,
+        "h3_preflush_duplicate_guard_history_seen",
+        preflush_repeat_state.get("pre_compaction_flush_duplicate_guard") == "history_seen",
+        str(preflush_repeat_state),
+    )
+
+    sustained_checks: List[Dict[str, Any]] = []
+    sustained_conversation_id = digest_conversation_id
+    for index in range(3):
+        event_id = f"h3-digest-email-sustain-{summary.run_id}-{index + 1}"
+        sustained = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=f"Run digest delivery pass {index + 1}.",
+                conversation_type="digest-email",
+                mcp_scope_mode="none",
+                conversation_id=sustained_conversation_id,
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_tool_profile": "read_only",
+                    "mcp_digest_schedule_enabled": True,
+                    "mcp_digest_force_run": True,
+                    "mcp_digest_schedule_event_id": event_id,
+                },
+            ),
+        )
+        sustained_state = sustained.get("tooling_state") or {}
+        sustained_checks.append(
+            {
+                "event_id": event_id,
+                "status": sustained_state.get("digest_schedule_status"),
+                "channel": sustained_state.get("digest_delivery_channel"),
+            }
+        )
+        _assert(
+            summary,
+            f"h3_sustained_status_{index + 1}",
+            sustained_state.get("digest_schedule_status")
+            in {"triggered", "awaiting_approval", "completed_tool_calls", "completed_noop", "duplicate_guard"},
+            str(sustained_state),
+        )
+    scenario["digest_email_sustained"] = sustained_checks
+
+    return scenario
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process H.1/H.2/H.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="qwen3-8b-new-server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-h123")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.6)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument(
+        "--reset-from-template",
+        action="store_true",
+        default=True,
+        help="Reset user scope from template before running probes (default: true).",
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        action="store_false",
+        dest="reset_from_template",
+        help="Skip scope reset.",
+    )
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def _summary_to_json(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap_meta = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap_meta
+
+        summary.scenarios["process_h1"] = _run_h1(summary, config, token, user_id)
+        summary.scenarios["process_h2"] = _run_h2(summary, config, token, user_id)
+        summary.scenarios["process_h3"] = _run_h3(summary, config, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness
+        summary.error = str(exc)
+        summary.success = False
+    finally:
+        output = _summary_to_json(summary)
+        summary_path = run_dir / "summary.json"
+        summary_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"summary_path": str(summary_path.resolve()), "success": summary.success}, indent=2))
+
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_i1_i2_i3.py
+++ b/scripts/e2e_process_i1_i2_i3.py
@@ -1,0 +1,1084 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process I.1, I.2, and I.3.
+
+I.1: VS-11/TR-1 multi-turn evolution interview (scaffold -> interview -> scoped updates).
+I.2: VS-5/VS-6 compound edit follow-through and approval UX closure checks.
+I.3: VS-12/TR-4 delivery hand-off contract + duplicate-guard soak checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+APPROVAL_REQUIRED_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _http_post(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                if not body.strip():
+                    return {}
+                return json.loads(body)
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    response = _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+    page_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    if page_id:
+        payload["page_id"] = page_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _run_i1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    project_conversation_type = "project-side-business"
+
+    scaffold_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Create a new project page for side business.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/finance",
+            mcp_project_name="Finance",
+        ),
+    )
+    scaffold_request = scaffold_start.get("approval_request") or {}
+    scaffold_args = scaffold_request.get("arguments") or {}
+    scaffold_files = scaffold_args.get("files") or []
+    scaffold_paths = {
+        entry.get("path")
+        for entry in scaffold_files
+        if isinstance(entry, dict) and isinstance(entry.get("path"), str)
+    }
+    created_scope_path = str(scaffold_args.get("path") or "").strip()
+    scenario["scaffold_start"] = {
+        "approval_required": scaffold_start.get("approval_required"),
+        "approval_request": scaffold_request,
+        "tooling_state": scaffold_start.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "i1_scaffold_approval_required",
+        scaffold_start.get("approval_required") is True,
+        str(scaffold_start),
+    )
+    _assert(
+        summary,
+        "i1_scaffold_tool_create_project",
+        scaffold_request.get("tool") == "create_project",
+        str(scaffold_request),
+    )
+    _assert(
+        summary,
+        "i1_scaffold_reason_seeded",
+        scaffold_request.get("synthetic_reason") == "new_page_engine_scaffold",
+        str(scaffold_request),
+    )
+    _assert(
+        summary,
+        "i1_scaffold_scope_path",
+        isinstance(created_scope_path, str)
+        and created_scope_path.startswith("projects/active/")
+        and len(created_scope_path) > len("projects/active/"),
+        str(scaffold_args),
+    )
+    _assert(
+        summary,
+        "i1_scaffold_seed_pack_contains_interview_state",
+        {
+            "interview.md",
+            "interview-followup.md",
+            "spec.md",
+            "build-plan.md",
+            "status.md",
+            "_meta/interview-state.md",
+        }.issubset(scaffold_paths),
+        str(sorted(scaffold_paths)),
+    )
+
+    project_meta = next(
+        (entry for entry in scaffold_files if entry.get("path") == "_meta/interview-state.md"),
+        None,
+    )
+    parsed_project_meta = json.loads(str((project_meta or {}).get("content") or "{}"))
+    _assert(
+        summary,
+        "i1_scaffold_meta_followup_due",
+        bool(parsed_project_meta.get("first_followup_due_utc")),
+        str(parsed_project_meta),
+    )
+
+    scaffold_conversation_id = scaffold_start.get("conversation_id")
+    scaffold_request_id = scaffold_request.get("request_id")
+    _assert(
+        summary,
+        "i1_scaffold_has_conversation_id",
+        isinstance(scaffold_conversation_id, str) and bool(scaffold_conversation_id),
+        str(scaffold_conversation_id),
+    )
+    _assert(
+        summary,
+        "i1_scaffold_has_request_id",
+        isinstance(scaffold_request_id, str) and bool(scaffold_request_id),
+        str(scaffold_request_id),
+    )
+
+    scaffold_approve = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/finance",
+            mcp_project_name="Finance",
+            conversation_id=scaffold_conversation_id,
+            params_extra={
+                "mcp_approval": {
+                    "action": "approve",
+                    "request_id": scaffold_request_id,
+                }
+            },
+        ),
+    )
+    scaffold_approve_resolution = scaffold_approve.get("approval_resolution") or {}
+    scenario["scaffold_approve"] = {
+        "approval_resolution": scaffold_approve_resolution,
+        "tooling_state": scaffold_approve.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "i1_scaffold_approved",
+        scaffold_approve_resolution.get("status") == "approved",
+        str(scaffold_approve_resolution),
+    )
+
+    created_scope_name = str(created_scope_path.split("/")[-1] or "New Page").replace("-", " ").title()
+
+    interview_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Start page interview for this scope.",
+            conversation_type=project_conversation_type,
+            mcp_scope_mode="project",
+            mcp_project_slug=created_scope_path,
+            mcp_project_name=created_scope_name,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_sync_on_request": False,
+            },
+        ),
+    )
+    interview_conversation_id = interview_start.get("conversation_id")
+    interview_start_text = str(
+        (((interview_start.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    interview_start_state = interview_start.get("tooling_state") or {}
+    scenario["interview_start"] = {
+        "conversation_id": interview_conversation_id,
+        "assistant_text": interview_start_text,
+        "tooling_state": interview_start_state,
+    }
+    _assert(
+        summary,
+        "i1_interview_started",
+        "question 1 of" in interview_start_text.lower(),
+        interview_start_text,
+    )
+    _assert(
+        summary,
+        "i1_interview_orchestration_mode",
+        interview_start_state.get("conversation_orchestration") == "new_page_interview_deterministic",
+        str(interview_start_state),
+    )
+
+    interview_answer = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=(
+                "Success means a repeatable weekly pipeline and a signed first customer by 2026-03-15."
+            ),
+            conversation_type=project_conversation_type,
+            mcp_scope_mode="project",
+            mcp_project_slug=created_scope_path,
+            mcp_project_name=created_scope_name,
+            conversation_id=interview_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_sync_on_request": False,
+            },
+        ),
+    )
+    interview_answer_text = str(
+        (((interview_answer.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    scenario["interview_answer"] = {
+        "assistant_text": interview_answer_text,
+        "tooling_state": interview_answer.get("tooling_state"),
+    }
+    lowered_answer_text = interview_answer_text.lower()
+    _assert(
+        summary,
+        "i1_interview_prepared_scoped_updates",
+        "prepared scoped updates" in lowered_answer_text and "reply `approve`" in lowered_answer_text,
+        interview_answer_text,
+    )
+    _assert(
+        summary,
+        "i1_interview_preview_paths_present",
+        "spec.md" in lowered_answer_text
+        and "build-plan.md" in lowered_answer_text
+        and "status.md" in lowered_answer_text,
+        interview_answer_text,
+    )
+
+    interview_approve = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type=project_conversation_type,
+            mcp_scope_mode="project",
+            mcp_project_slug=created_scope_path,
+            mcp_project_name=created_scope_name,
+            conversation_id=interview_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_sync_on_request": False,
+            },
+        ),
+    )
+    interview_approve_text = str(
+        (((interview_approve.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    interview_approve_state = interview_approve.get("tooling_state") or {}
+
+    if "could not apply all scoped updates yet" in interview_approve_text.lower():
+        interview_approve_retry = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message="approve",
+                conversation_type=project_conversation_type,
+                mcp_scope_mode="project",
+                mcp_project_slug=created_scope_path,
+                mcp_project_name=created_scope_name,
+                conversation_id=interview_conversation_id,
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_sync_on_request": False,
+                },
+            ),
+        )
+        interview_approve = interview_approve_retry
+        interview_approve_text = str(
+            (((interview_approve.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+            or ""
+        )
+        interview_approve_state = interview_approve.get("tooling_state") or {}
+        scenario["interview_approve_retry"] = {
+            "assistant_text": interview_approve_text,
+            "tooling_state": interview_approve_state,
+        }
+
+    scenario["interview_approve"] = {
+        "assistant_text": interview_approve_text,
+        "tooling_state": interview_approve_state,
+    }
+    _assert(
+        summary,
+        "i1_interview_saved_updates",
+        "saved scoped updates" in interview_approve_text.lower(),
+        interview_approve_text,
+    )
+    _assert(
+        summary,
+        "i1_interview_execution_count",
+        int(interview_approve_state.get("tool_calls_executed_count") or 0) >= 3,
+        str(interview_approve_state),
+    )
+    _assert(
+        summary,
+        "i1_interview_deterministic_stop_reason",
+        interview_approve_state.get("tool_loop_stop_reason") == "deterministic_new_page_interview_turn",
+        str(interview_approve_state),
+    )
+
+    scenario["created_scope"] = {
+        "path": created_scope_path,
+        "name": created_scope_name,
+    }
+    return scenario
+
+
+def _run_i2(
+    summary: ProbeSummary,
+    config: Config,
+    token: str,
+    user_id: str,
+    *,
+    scope_path: str,
+    scope_name: str,
+) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {"attempts": []}
+    project_conversation_type = "project-side-business"
+    marker = f"I2 marker {summary.run_id}"
+    prompts = [
+        (
+            "compound_two_files",
+            (
+                'Edit spec.md and build-plan.md. Add "Define launch criteria." and '
+                '"Track weekly execution cadence."'
+            ),
+        ),
+        (
+            "compound_three_files",
+            (
+                f'Edit spec.md, build-plan.md, and status.md. Add "{marker} spec", '
+                f'"{marker} plan", and "{marker} status".'
+            ),
+        ),
+    ]
+
+    selected_response: Optional[Dict[str, Any]] = None
+    selected_prompt: Optional[str] = None
+    for label, prompt in prompts:
+        response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=prompt,
+                conversation_type=project_conversation_type,
+                mcp_scope_mode="project",
+                mcp_project_slug=scope_path,
+                mcp_project_name=scope_name,
+                params_extra={"mcp_native_tool_calling": True},
+            ),
+        )
+        approval = response.get("approval_request") or {}
+        preview = approval.get("preview") if isinstance(approval, dict) else None
+        assistant_text = str(
+            (((response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+            or ""
+        )
+        attempt = {
+            "label": label,
+            "prompt": prompt,
+            "approval_required": response.get("approval_required"),
+            "assistant_text": assistant_text,
+            "approval_request": approval,
+            "tooling_state": response.get("tooling_state"),
+        }
+        scenario["attempts"].append(attempt)
+        if (
+            response.get("approval_required") is True
+            and isinstance(approval, dict)
+            and str(approval.get("tool") or "").strip() == "edit_markdown"
+            and str(approval.get("synthetic_reason") or "").strip()
+            == "compound_edit_followthrough"
+            and isinstance(preview, dict)
+        ):
+            selected_response = response
+            selected_prompt = prompt
+            break
+
+    _assert(
+        summary,
+        "i2_compound_approval_found",
+        selected_response is not None,
+        json.dumps(scenario["attempts"], indent=2),
+    )
+    assert selected_response is not None
+    first_approval = selected_response.get("approval_request") or {}
+    first_preview = first_approval.get("preview") or {}
+    first_text = str(
+        (((selected_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    _assert(summary, "i2_approval_copy_locked", first_text == APPROVAL_REQUIRED_TEXT, first_text)
+    _assert(
+        summary,
+        "i2_preview_has_diff_or_summary",
+        bool(str(first_preview.get("diff") or "").strip())
+        or bool(str(first_preview.get("summary") or "").strip()),
+        str(first_preview),
+    )
+    _assert(
+        summary,
+        "i2_preview_marker",
+        first_preview.get("previewTool") == "preview_markdown_change",
+        str(first_preview),
+    )
+
+    if first_preview.get("diffTruncated") is True:
+        _assert(
+            summary,
+            "i2_preview_truncation_notice",
+            first_preview.get("previewNotice") == "Diff truncated for approval preview.",
+            str(first_preview),
+        )
+
+    conversation_id = selected_response.get("conversation_id")
+    request_id = first_approval.get("request_id")
+    _assert(
+        summary,
+        "i2_has_conversation_id",
+        isinstance(conversation_id, str) and bool(conversation_id),
+        str(conversation_id),
+    )
+    _assert(
+        summary,
+        "i2_has_request_id",
+        isinstance(request_id, str) and bool(request_id),
+        str(request_id),
+    )
+
+    approve_response = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type=project_conversation_type,
+            mcp_scope_mode="project",
+            mcp_project_slug=scope_path,
+            mcp_project_name=scope_name,
+            conversation_id=conversation_id,
+            params_extra={
+                "mcp_native_tool_calling": True,
+                "mcp_approval": {
+                    "action": "approve",
+                    "request_id": request_id,
+                }
+            },
+        ),
+    )
+    approve_resolution = approve_response.get("approval_resolution") or {}
+    approve_state = approve_response.get("tooling_state") or {}
+    final_text = str(
+        (((approve_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    scenario["approval_resume"] = {
+        "selected_prompt": selected_prompt,
+        "approval_resolution": approve_resolution,
+        "tooling_state": approve_state,
+        "assistant_text": final_text,
+    }
+    _assert(
+        summary,
+        "i2_approval_resolved",
+        approve_resolution.get("status") == "approved",
+        str(approve_resolution),
+    )
+    _assert(
+        summary,
+        "i2_compound_execution_count",
+        int(approve_state.get("tool_calls_executed_count") or 0) >= 2,
+        str(approve_state),
+    )
+    _assert(
+        summary,
+        "i2_confirmation_copy_multi_op",
+        (
+            "approved and executed `edit_markdown` successfully" in final_text.lower()
+            or "edits have been successfully applied" in final_text.lower()
+            or "successfully applied" in final_text.lower()
+        ),
+        final_text,
+    )
+    _assert(summary, "i2_confirmation_text_non_empty", bool(final_text.strip()), final_text)
+
+    return scenario
+
+
+def _run_i3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    digest_event_id = f"i3-digest-email-{summary.run_id}"
+    digest_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest delivery now.",
+            conversation_type="digest-email",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_tool_profile": "read_only",
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+                "mcp_digest_sections": ["top_priorities", "needs_attention"],
+            },
+        ),
+    )
+    digest_conversation_id = digest_start.get("conversation_id")
+    digest_state = digest_start.get("tooling_state") or {}
+    digest_handoff = digest_start.get("delivery_handoff") or {}
+    scenario["digest_email_start"] = {
+        "conversation_id": digest_conversation_id,
+        "tooling_state": digest_state,
+        "delivery_handoff": digest_handoff,
+        "approval_required": digest_start.get("approval_required"),
+    }
+    _assert(
+        summary,
+        "i3_digest_email_conversation_id",
+        isinstance(digest_conversation_id, str) and bool(digest_conversation_id),
+        str(digest_conversation_id),
+    )
+    _assert(
+        summary,
+        "i3_digest_email_channel_metadata",
+        digest_state.get("digest_delivery_channel") == "email"
+        and digest_state.get("mcp_project_slug") == "digest"
+        and digest_state.get("conversation_orchestration") == "digest_heartbeat"
+        and digest_state.get("tool_profile") in {"digest", "read_only"},
+        str(digest_state),
+    )
+    _assert(
+        summary,
+        "i3_digest_email_handoff_contract",
+        digest_handoff.get("channel") == "email"
+        and digest_handoff.get("conversation_type") == "digest-email"
+        and digest_handoff.get("format") == "markdown"
+        and isinstance(digest_handoff.get("body"), str)
+        and bool(str(digest_handoff.get("body") or "").strip()),
+        str(digest_handoff),
+    )
+    tooling_handoff = digest_state.get("digest_delivery_handoff") or {}
+    _assert(
+        summary,
+        "i3_digest_email_handoff_metadata",
+        tooling_handoff.get("channel") == "email",
+        str(tooling_handoff),
+    )
+
+    digest_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest delivery now.",
+            conversation_type="digest-email",
+            mcp_scope_mode="none",
+            conversation_id=digest_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_tool_profile": "read_only",
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+                "mcp_digest_sections": ["top_priorities", "needs_attention"],
+            },
+        ),
+    )
+    digest_repeat_state = digest_repeat.get("tooling_state") or {}
+    scenario["digest_email_repeat"] = {
+        "tooling_state": digest_repeat_state,
+        "delivery_handoff": digest_repeat.get("delivery_handoff"),
+    }
+    _assert(
+        summary,
+        "i3_digest_duplicate_guard_status",
+        digest_repeat_state.get("digest_schedule_status") == "duplicate_guard",
+        str(digest_repeat_state),
+    )
+    _assert(
+        summary,
+        "i3_digest_duplicate_guard_history_seen",
+        digest_repeat_state.get("digest_schedule_duplicate_guard") == "history_seen",
+        str(digest_repeat_state),
+    )
+
+    preflush_event_id = f"i3-preflush-{summary.run_id}"
+    long_message = " ".join(["context-window-pressure"] * 220)
+    preflush_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_conversation_id = preflush_start.get("conversation_id")
+    scenario["preflush_start"] = {
+        "conversation_id": preflush_conversation_id,
+        "tooling_state": preflush_start.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "i3_preflush_conversation_id",
+        isinstance(preflush_conversation_id, str) and bool(preflush_conversation_id),
+        str(preflush_conversation_id),
+    )
+
+    preflush_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            conversation_id=preflush_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_repeat_state = preflush_repeat.get("tooling_state") or {}
+    scenario["preflush_repeat"] = {
+        "tooling_state": preflush_repeat_state,
+    }
+    _assert(
+        summary,
+        "i3_preflush_duplicate_guard_status",
+        preflush_repeat_state.get("pre_compaction_flush_status") == "duplicate_guard",
+        str(preflush_repeat_state),
+    )
+    _assert(
+        summary,
+        "i3_preflush_duplicate_guard_history_seen",
+        preflush_repeat_state.get("pre_compaction_flush_duplicate_guard") == "history_seen",
+        str(preflush_repeat_state),
+    )
+
+    sustained_checks: List[Dict[str, Any]] = []
+    for index in range(5):
+        event_id = f"i3-digest-email-sustain-{summary.run_id}-{index + 1}"
+        sustained = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=f"Run digest delivery pass {index + 1}.",
+                conversation_type="digest-email",
+                mcp_scope_mode="none",
+                conversation_id=digest_conversation_id,
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_tool_profile": "read_only",
+                    "mcp_digest_schedule_enabled": True,
+                    "mcp_digest_force_run": True,
+                    "mcp_digest_schedule_event_id": event_id,
+                },
+            ),
+        )
+        sustained_state = sustained.get("tooling_state") or {}
+        sustained_handoff = sustained.get("delivery_handoff") or {}
+        sustained_checks.append(
+            {
+                "event_id": event_id,
+                "status": sustained_state.get("digest_schedule_status"),
+                "channel": sustained_state.get("digest_delivery_channel"),
+                "handoff_channel": sustained_handoff.get("channel"),
+            }
+        )
+        _assert(
+            summary,
+            f"i3_sustained_status_{index + 1}",
+            sustained_state.get("digest_schedule_status")
+            in {"triggered", "awaiting_approval", "completed_tool_calls", "completed_noop", "duplicate_guard"},
+            str(sustained_state),
+        )
+        _assert(
+            summary,
+            f"i3_sustained_handoff_{index + 1}",
+            sustained_handoff.get("channel") == "email"
+            and sustained_handoff.get("conversation_type") == "digest-email",
+            str(sustained_handoff),
+        )
+    scenario["digest_email_sustained"] = sustained_checks
+
+    return scenario
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process I.1/I.2/I.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="qwen3-8b-new-server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-i123")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.6)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument(
+        "--reset-from-template",
+        action="store_true",
+        default=True,
+        help="Reset user scope from template before running probes (default: true).",
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        action="store_false",
+        dest="reset_from_template",
+        help="Skip scope reset.",
+    )
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def _summary_to_json(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap_meta = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap_meta
+
+        process_i1 = _run_i1(summary, config, token, user_id)
+        summary.scenarios["process_i1"] = process_i1
+        created_scope = process_i1.get("created_scope") if isinstance(process_i1, dict) else {}
+        created_scope_path = str((created_scope or {}).get("path") or "").strip()
+        created_scope_name = str((created_scope or {}).get("name") or "New Page").strip()
+        if not created_scope_path:
+            raise RuntimeError("Process I.1 did not return created scope path")
+
+        summary.scenarios["process_i2"] = _run_i2(
+            summary,
+            config,
+            token,
+            user_id,
+            scope_path=created_scope_path,
+            scope_name=created_scope_name,
+        )
+        summary.scenarios["process_i3"] = _run_i3(summary, config, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness
+        summary.error = str(exc)
+        summary.success = False
+    finally:
+        output = _summary_to_json(summary)
+        summary_path = run_dir / "summary.json"
+        summary_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"summary_path": str(summary_path.resolve()), "success": summary.success}, indent=2))
+
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_j1_j2_j3.py
+++ b/scripts/e2e_process_j1_j2_j3.py
@@ -1,0 +1,1001 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process J.1, J.2, and J.3.
+
+J.1: VS-10/TR-3/TR-1 multi-target cross-pollination chain + project-scope compat policy.
+J.2: VS-1/VS-2/VS-6 capture multi-folder fanout sequencing + task payload quality.
+J.3: VS-12/TR-4 delivery integration closure with persisted outbox handoff + soak checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import time
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+APPROVAL_REQUIRED_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _http_post(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                if not body.strip():
+                    return {}
+                return json.loads(body)
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    response = _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _seed_finances_onboarding_complete(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    onboarding_path = (
+        config.library_root
+        / "users"
+        / normalized_user_id
+        / ".braindrive"
+        / "onboarding_state.json"
+    )
+    if not onboarding_path.is_file():
+        return {"updated": False, "path": str(onboarding_path), "reason": "missing"}
+
+    try:
+        state = json.loads(onboarding_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {
+            "updated": False,
+            "path": str(onboarding_path),
+            "reason": f"read_error:{exc}",
+        }
+    if not isinstance(state, dict):
+        return {"updated": False, "path": str(onboarding_path), "reason": "invalid_json_root"}
+
+    now_iso = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+
+    starter_topics = state.setdefault("starter_topics", {})
+    if isinstance(starter_topics, dict):
+        starter_topics["finances"] = "complete"
+
+    completed_at = state.setdefault("completed_at", {})
+    if isinstance(completed_at, dict):
+        completed_at["finances"] = now_iso
+
+    topic_progress = state.setdefault("topic_progress", {})
+    if isinstance(topic_progress, dict):
+        finances_progress = topic_progress.setdefault("finances", {})
+        if isinstance(finances_progress, dict):
+            finances_progress["status"] = "complete"
+            finances_progress["phase"] = "complete"
+            finances_progress["completed_at_utc"] = now_iso
+            finances_progress["last_updated_at_utc"] = now_iso
+            if not finances_progress.get("started_at_utc"):
+                finances_progress["started_at_utc"] = now_iso
+
+    state["active_topic"] = None
+    state["recommended_next_topic"] = "fitness"
+    state["updated_at_utc"] = now_iso
+
+    onboarding_path.write_text(
+        json.dumps(state, ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    return {"updated": True, "path": str(onboarding_path), "updated_at_utc": now_iso}
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+    page_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    if page_id:
+        payload["page_id"] = page_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _run_j1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    scenario["onboarding_seed"] = _seed_finances_onboarding_complete(config, user_id)
+
+    project_policy_probe = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Create a task to lock release checklist by next week.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/finance",
+            mcp_project_name="Finance",
+            params_extra={"mcp_max_tool_iterations": 5},
+        ),
+    )
+    project_policy_state = project_policy_probe.get("tooling_state") or {}
+    scenario["project_policy_probe"] = {
+        "tooling_state": project_policy_state,
+        "approval_required": project_policy_probe.get("approval_required"),
+        "approval_request": project_policy_probe.get("approval_request"),
+    }
+    _assert(
+        summary,
+        "j1_project_policy_mode",
+        project_policy_state.get("tool_policy_mode") == "dual_path_project_scope_compat",
+        str(project_policy_state),
+    )
+    _assert(
+        summary,
+        "j1_project_policy_profile",
+        project_policy_state.get("tool_profile") == "full"
+        and project_policy_state.get("tool_profile_source") == "routing_scope_policy",
+        str(project_policy_state),
+    )
+
+    cross_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="I need a family budget plan and workout routine for my kids.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+            params_extra={
+                "mcp_max_tool_iterations": 6,
+            },
+        ),
+    )
+    first_request = cross_start.get("approval_request") or {}
+    first_tool = str(first_request.get("tool") or "").strip()
+    first_reason = str(first_request.get("synthetic_reason") or "")
+    first_is_cross_pollination = first_reason.startswith("cross_pollination_finances_to_")
+    conversation_id = cross_start.get("conversation_id")
+    scenario["cross_pollination_start"] = {
+        "approval_required": cross_start.get("approval_required"),
+        "approval_request": first_request,
+        "reason_mode": (
+            "synthetic_cross_pollination"
+            if first_is_cross_pollination
+            else "provider_or_other_variance"
+        ),
+        "tooling_state": cross_start.get("tooling_state"),
+        "conversation_id": conversation_id,
+    }
+    _assert(
+        summary,
+        "j1_cross_start_approval_required",
+        cross_start.get("approval_required") is True,
+        str(cross_start),
+    )
+    _assert(
+        summary,
+        "j1_cross_first_tool_mutating_approval",
+        bool(first_tool)
+        and str(first_request.get("safety_class") or "").strip().lower() == "mutating",
+        str(first_request),
+    )
+    _assert(
+        summary,
+        "j1_cross_first_reason_or_provider_variance",
+        first_is_cross_pollination
+        or not first_reason,
+        str(first_request),
+    )
+    _assert(
+        summary,
+        "j1_cross_has_conversation_and_request",
+        isinstance(conversation_id, str)
+        and bool(conversation_id)
+        and isinstance(first_request.get("request_id"), str)
+        and bool(str(first_request.get("request_id"))),
+        str({"conversation_id": conversation_id, "request": first_request}),
+    )
+
+    cross_resume = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+            conversation_id=conversation_id,
+            params_extra={
+                "mcp_max_tool_iterations": 6,
+                "mcp_approval": {
+                    "action": "approve",
+                    "request_id": first_request.get("request_id"),
+                },
+            },
+        ),
+    )
+    second_request = cross_resume.get("approval_request") or {}
+    second_reason = str(second_request.get("synthetic_reason") or "")
+    second_requires_approval = cross_resume.get("approval_required") is True
+    second_is_cross_pollination = second_reason.startswith("cross_pollination_finances_to_")
+    resume_state = cross_resume.get("tooling_state") or {}
+    scenario["cross_pollination_resume"] = {
+        "approval_required": cross_resume.get("approval_required"),
+        "approval_resolution": cross_resume.get("approval_resolution"),
+        "approval_request": second_request,
+        "reason_mode": (
+            "synthetic_cross_pollination"
+            if second_is_cross_pollination
+            else "provider_or_other_variance"
+        ),
+        "tooling_state": resume_state,
+    }
+    _assert(
+        summary,
+        "j1_cross_resume_resolution",
+        (cross_resume.get("approval_resolution") or {}).get("status") == "approved",
+        str(cross_resume.get("approval_resolution")),
+    )
+    _assert(
+        summary,
+        "j1_cross_resume_progress",
+        second_requires_approval
+        or resume_state.get("tool_loop_stop_reason") == "provider_final_response",
+        str(cross_resume),
+    )
+    if second_requires_approval:
+        second_tool = str(second_request.get("tool") or "").strip()
+        if first_is_cross_pollination:
+            _assert(
+                summary,
+                "j1_cross_second_tool_create_markdown",
+                second_tool == "create_markdown",
+                str(second_request),
+            )
+            _assert(
+                summary,
+                "j1_cross_second_reason_different_target",
+                second_is_cross_pollination and second_reason != first_reason,
+                str({"first": first_reason, "second": second_reason}),
+            )
+        else:
+            _assert(
+                summary,
+                "j1_cross_second_tool_provider_variance",
+                bool(second_tool)
+                and str(second_request.get("safety_class") or "").strip().lower() == "mutating",
+                str(second_request),
+            )
+    else:
+        _assert(
+            summary,
+            "j1_cross_resume_provider_variance_path",
+            not second_request,
+            str(second_request),
+        )
+    _assert(
+        summary,
+        "j1_cross_stop_reason",
+        resume_state.get("tool_loop_stop_reason") in {"approval_required", "provider_final_response"},
+        str(resume_state),
+    )
+
+    return scenario
+
+
+def _run_j2(
+    summary: ProbeSummary,
+    config: Config,
+    token: str,
+    user_id: str,
+) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    base_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="",
+        conversation_type="capture",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+
+    prompts = [
+        "Capture this in finances and relationships and add a task to review budget for Dave J by next week.",
+        "Capture this note to life/finances and life/relationships, then add a task for Dave J to review budget by next week.",
+        "Save this in finances and relationships capture notes and create a task: Dave J reviews budget next week.",
+    ]
+
+    selected_attempt: Optional[Dict[str, Any]] = None
+    for attempt_idx, prompt in enumerate(prompts, start=1):
+        attempt_data: Dict[str, Any] = {"prompt": prompt}
+        start_payload = deepcopy(base_payload)
+        start_payload["messages"] = [{"role": "user", "content": prompt}]
+        start = _chat(config, token, start_payload)
+        first_request = start.get("approval_request") or {}
+        conversation_id = start.get("conversation_id")
+        attempt_data["start"] = {
+            "approval_required": start.get("approval_required"),
+            "approval_request": first_request,
+            "conversation_id": conversation_id,
+            "tooling_state": start.get("tooling_state"),
+        }
+        first_path = str((first_request.get("arguments") or {}).get("path") or "")
+        inbox_ok = (
+            start.get("approval_required") is True
+            and first_request.get("tool") == "create_markdown"
+            and "/capture/inbox/" in f"/{first_path.strip('/')}"
+        )
+        attempt_data["inbox_ok"] = inbox_ok
+        if not inbox_ok:
+            scenario[f"fanout_attempt_{attempt_idx}"] = attempt_data
+            continue
+
+        approval_chain: List[Dict[str, Any]] = [first_request]
+        current_request: Dict[str, Any] = first_request
+        create_task_request: Optional[Dict[str, Any]] = None
+        all_steps_approved = True
+
+        for step_idx in range(1, 6):
+            request_id = str(current_request.get("request_id") or "").strip()
+            if not request_id:
+                break
+            next_payload = deepcopy(base_payload)
+            next_payload["conversation_id"] = conversation_id
+            next_payload["messages"] = [{"role": "user", "content": "approve"}]
+            next_payload["params"]["mcp_approval"] = {
+                "action": "approve",
+                "request_id": request_id,
+            }
+            step_response = _chat(config, token, next_payload)
+            step_request = step_response.get("approval_request") or {}
+            attempt_data[f"step_{step_idx}"] = {
+                "approval_required": step_response.get("approval_required"),
+                "approval_resolution": step_response.get("approval_resolution"),
+                "approval_request": step_request,
+                "tooling_state": step_response.get("tooling_state"),
+            }
+            if (step_response.get("approval_resolution") or {}).get("status") != "approved":
+                all_steps_approved = False
+                break
+            if step_response.get("approval_required") is not True:
+                break
+            approval_chain.append(step_request)
+            current_request = step_request
+            if step_request.get("tool") == "create_task":
+                create_task_request = step_request
+                break
+
+        fanout_seen = False
+        for request_item in approval_chain:
+            if request_item.get("tool") != "create_markdown":
+                continue
+            reason_value = str(request_item.get("synthetic_reason") or "")
+            request_path = str((request_item.get("arguments") or {}).get("path") or "")
+            if reason_value.startswith("capture_scope_fanout_"):
+                fanout_seen = True
+                break
+            if request_path.startswith("life/") and "/capture/" in request_path:
+                fanout_seen = True
+                break
+
+        create_task_args = (create_task_request or {}).get("arguments") or {}
+        payload_quality_ok = (
+            bool(str(create_task_args.get("owner") or "").strip())
+            and bool(str(create_task_args.get("due") or "").strip())
+            and str(create_task_args.get("scope") or "").strip() == "life/finances"
+        )
+
+        attempt_data["approval_chain"] = approval_chain
+        attempt_data["all_steps_approved"] = all_steps_approved
+        attempt_data["fanout_seen"] = fanout_seen
+        attempt_data["create_task_request"] = create_task_request
+        attempt_data["create_task_payload_quality_ok"] = payload_quality_ok
+        scenario[f"fanout_attempt_{attempt_idx}"] = attempt_data
+
+        if all_steps_approved and fanout_seen and isinstance(create_task_request, dict) and payload_quality_ok:
+            selected_attempt = attempt_data
+            break
+
+    _assert(
+        summary,
+        "j2_first_approval_inbox",
+        isinstance(selected_attempt, dict)
+        and bool(selected_attempt.get("inbox_ok")),
+        str(scenario),
+    )
+    _assert(
+        summary,
+        "j2_scope_fanout_seen",
+        isinstance(selected_attempt, dict)
+        and bool(selected_attempt.get("fanout_seen")),
+        str(scenario),
+    )
+    _assert(
+        summary,
+        "j2_create_task_approval_seen",
+        isinstance(selected_attempt, dict)
+        and isinstance(selected_attempt.get("create_task_request"), dict),
+        str(scenario),
+    )
+    _assert(
+        summary,
+        "j2_create_task_payload_quality",
+        isinstance(selected_attempt, dict)
+        and bool(selected_attempt.get("create_task_payload_quality_ok")),
+        str(scenario),
+    )
+    scenario["selected_attempt"] = selected_attempt
+
+    return scenario
+
+
+def _run_j3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    digest_event_id = f"j3-digest-email-{summary.run_id}"
+    digest_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest delivery now.",
+            conversation_type="digest-email",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_tool_profile": "read_only",
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+                "mcp_digest_sections": ["top_priorities", "needs_attention"],
+            },
+        ),
+    )
+    digest_conversation_id = digest_start.get("conversation_id")
+    digest_state = digest_start.get("tooling_state") or {}
+    digest_handoff = digest_start.get("delivery_handoff") or {}
+    scenario["digest_email_start"] = {
+        "conversation_id": digest_conversation_id,
+        "tooling_state": digest_state,
+        "delivery_handoff": digest_handoff,
+        "approval_required": digest_start.get("approval_required"),
+    }
+    _assert(
+        summary,
+        "j3_digest_email_conversation_id",
+        isinstance(digest_conversation_id, str) and bool(digest_conversation_id),
+        str(digest_conversation_id),
+    )
+    _assert(
+        summary,
+        "j3_digest_email_channel_metadata",
+        digest_state.get("digest_delivery_channel") == "email"
+        and digest_state.get("mcp_project_slug") == "digest"
+        and digest_state.get("conversation_orchestration") == "digest_heartbeat"
+        and digest_state.get("tool_profile") in {"digest", "read_only"},
+        str(digest_state),
+    )
+    _assert(
+        summary,
+        "j3_digest_email_handoff_contract",
+        digest_handoff.get("channel") == "email"
+        and digest_handoff.get("conversation_type") == "digest-email"
+        and digest_handoff.get("format") == "markdown"
+        and isinstance(digest_handoff.get("body"), str)
+        and bool(str(digest_handoff.get("body") or "").strip())
+        and str(digest_handoff.get("delivery_record_status") or "").strip() == "persisted"
+        and bool(str(digest_handoff.get("delivery_record_path") or "").strip()),
+        str(digest_handoff),
+    )
+    tooling_handoff = digest_state.get("digest_delivery_handoff") or {}
+    _assert(
+        summary,
+        "j3_digest_email_handoff_metadata",
+        tooling_handoff.get("channel") == "email"
+        and tooling_handoff.get("delivery_record_status") == "persisted",
+        str(tooling_handoff),
+    )
+    handoff_path = Path(str(digest_handoff.get("delivery_record_path") or ""))
+    _assert(
+        summary,
+        "j3_digest_email_handoff_path_exists",
+        handoff_path.is_file(),
+        str(handoff_path),
+    )
+
+    digest_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Run scheduled digest delivery now.",
+            conversation_type="digest-email",
+            mcp_scope_mode="none",
+            conversation_id=digest_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_tool_profile": "read_only",
+                "mcp_digest_schedule_enabled": True,
+                "mcp_digest_force_run": True,
+                "mcp_digest_schedule_event_id": digest_event_id,
+                "mcp_digest_sections": ["top_priorities", "needs_attention"],
+            },
+        ),
+    )
+    digest_repeat_state = digest_repeat.get("tooling_state") or {}
+    scenario["digest_email_repeat"] = {
+        "tooling_state": digest_repeat_state,
+        "delivery_handoff": digest_repeat.get("delivery_handoff"),
+    }
+    _assert(
+        summary,
+        "j3_digest_duplicate_guard_status",
+        digest_repeat_state.get("digest_schedule_status") == "duplicate_guard",
+        str(digest_repeat_state),
+    )
+    _assert(
+        summary,
+        "j3_digest_duplicate_guard_history_seen",
+        digest_repeat_state.get("digest_schedule_duplicate_guard") == "history_seen",
+        str(digest_repeat_state),
+    )
+
+    preflush_event_id = f"j3-preflush-{summary.run_id}"
+    long_message = " ".join(["context-window-pressure"] * 220)
+    preflush_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_conversation_id = preflush_start.get("conversation_id")
+    scenario["preflush_start"] = {
+        "conversation_id": preflush_conversation_id,
+        "tooling_state": preflush_start.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "j3_preflush_conversation_id",
+        isinstance(preflush_conversation_id, str) and bool(preflush_conversation_id),
+        str(preflush_conversation_id),
+    )
+
+    preflush_repeat = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=long_message,
+            conversation_type="chat",
+            mcp_scope_mode="none",
+            conversation_id=preflush_conversation_id,
+            params_extra={
+                "mcp_tools_enabled": False,
+                "mcp_pre_compaction_flush_enabled": True,
+                "mcp_context_window_tokens": 64,
+                "mcp_pre_compaction_flush_threshold": 0.5,
+                "mcp_pre_compaction_event_id": preflush_event_id,
+            },
+        ),
+    )
+    preflush_repeat_state = preflush_repeat.get("tooling_state") or {}
+    scenario["preflush_repeat"] = {
+        "tooling_state": preflush_repeat_state,
+    }
+    _assert(
+        summary,
+        "j3_preflush_duplicate_guard_status",
+        preflush_repeat_state.get("pre_compaction_flush_status") == "duplicate_guard",
+        str(preflush_repeat_state),
+    )
+    _assert(
+        summary,
+        "j3_preflush_duplicate_guard_history_seen",
+        preflush_repeat_state.get("pre_compaction_flush_duplicate_guard") == "history_seen",
+        str(preflush_repeat_state),
+    )
+
+    sustained_checks: List[Dict[str, Any]] = []
+    for index in range(8):
+        event_id = f"j3-digest-email-sustain-{summary.run_id}-{index + 1}"
+        sustained = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=f"Run digest delivery pass {index + 1}.",
+                conversation_type="digest-email",
+                mcp_scope_mode="none",
+                conversation_id=digest_conversation_id,
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_tool_profile": "read_only",
+                    "mcp_digest_schedule_enabled": True,
+                    "mcp_digest_force_run": True,
+                    "mcp_digest_schedule_event_id": event_id,
+                },
+            ),
+        )
+        sustained_state = sustained.get("tooling_state") or {}
+        sustained_handoff = sustained.get("delivery_handoff") or {}
+        sustained_path = Path(str(sustained_handoff.get("delivery_record_path") or ""))
+        sustained_checks.append(
+            {
+                "event_id": event_id,
+                "status": sustained_state.get("digest_schedule_status"),
+                "channel": sustained_state.get("digest_delivery_channel"),
+                "handoff_channel": sustained_handoff.get("channel"),
+                "record_status": sustained_handoff.get("delivery_record_status"),
+                "record_path": str(sustained_handoff.get("delivery_record_path") or ""),
+            }
+        )
+        _assert(
+            summary,
+            f"j3_sustained_status_{index + 1}",
+            sustained_state.get("digest_schedule_status")
+            in {"triggered", "awaiting_approval", "completed_tool_calls", "completed_noop", "duplicate_guard"},
+            str(sustained_state),
+        )
+        _assert(
+            summary,
+            f"j3_sustained_handoff_{index + 1}",
+            sustained_handoff.get("channel") == "email"
+            and sustained_handoff.get("conversation_type") == "digest-email"
+            and sustained_handoff.get("delivery_record_status") == "persisted",
+            str(sustained_handoff),
+        )
+        _assert(
+            summary,
+            f"j3_sustained_handoff_path_{index + 1}",
+            sustained_path.is_file(),
+            str(sustained_path),
+        )
+    scenario["digest_email_sustained"] = sustained_checks
+
+    return scenario
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process J.1/J.2/J.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="qwen3-8b-new-server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-j123")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.6)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument(
+        "--reset-from-template",
+        action="store_true",
+        default=True,
+        help="Reset user scope from template before running probes (default: true).",
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        action="store_false",
+        dest="reset_from_template",
+        help="Skip scope reset.",
+    )
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def _summary_to_json(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap_meta = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap_meta
+
+        summary.scenarios["process_j1"] = _run_j1(summary, config, token, user_id)
+        summary.scenarios["process_j2"] = _run_j2(summary, config, token, user_id)
+        summary.scenarios["process_j3"] = _run_j3(summary, config, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness
+        summary.error = str(exc)
+        summary.success = False
+    finally:
+        output = _summary_to_json(summary)
+        summary_path = run_dir / "summary.json"
+        summary_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"summary_path": str(summary_path.resolve()), "success": summary.success}, indent=2))
+
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_k1_k2_k3.py
+++ b/scripts/e2e_process_k1_k2_k3.py
@@ -1,0 +1,1120 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process K.1, K.2, and K.3.
+
+K.1: VS-12/TR-4 outbound delivery sender wiring + ack/failure paths + soak.
+K.2: VS-9/VS-17 deterministic non-finance onboarding + profile update/error loops.
+K.3: VS-4/TR-3/TR-5 citation acceptance + routing capability matrix expansion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import os
+import random
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+APPROVAL_REQUIRED_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+@dataclass
+class LocalWebhookServer:
+    server: ThreadingHTTPServer
+    thread: threading.Thread
+    records: List[Dict[str, Any]]
+    base_url: str
+
+    def shutdown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _http_post(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                if not body.strip():
+                    return {}
+                return json.loads(body)
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    response = _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _seed_finances_onboarding_complete(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    onboarding_path = (
+        config.library_root
+        / "users"
+        / normalized_user_id
+        / ".braindrive"
+        / "onboarding_state.json"
+    )
+    if not onboarding_path.is_file():
+        return {"updated": False, "path": str(onboarding_path), "reason": "missing"}
+
+    try:
+        state = json.loads(onboarding_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {
+            "updated": False,
+            "path": str(onboarding_path),
+            "reason": f"read_error:{exc}",
+        }
+    if not isinstance(state, dict):
+        return {"updated": False, "path": str(onboarding_path), "reason": "invalid_json_root"}
+
+    now_iso = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+    starter_topics = state.setdefault("starter_topics", {})
+    if isinstance(starter_topics, dict):
+        starter_topics["finances"] = "complete"
+    completed_at = state.setdefault("completed_at", {})
+    if isinstance(completed_at, dict):
+        completed_at["finances"] = now_iso
+    topic_progress = state.setdefault("topic_progress", {})
+    if isinstance(topic_progress, dict):
+        finances_progress = topic_progress.setdefault("finances", {})
+        if isinstance(finances_progress, dict):
+            finances_progress["status"] = "complete"
+            finances_progress["phase"] = "complete"
+            finances_progress["completed_at_utc"] = now_iso
+            finances_progress["last_updated_at_utc"] = now_iso
+            if not finances_progress.get("started_at_utc"):
+                finances_progress["started_at_utc"] = now_iso
+    state["active_topic"] = None
+    state["updated_at_utc"] = now_iso
+    onboarding_path.write_text(json.dumps(state, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    return {"updated": True, "path": str(onboarding_path), "updated_at_utc": now_iso}
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+    page_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    if page_id:
+        payload["page_id"] = page_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _start_local_webhook_server() -> LocalWebhookServer:
+    records: List[Dict[str, Any]] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802 - stdlib hook name
+            content_length = int(self.headers.get("Content-Length", "0") or 0)
+            raw = self.rfile.read(content_length).decode("utf-8", errors="replace")
+            payload: Any
+            try:
+                payload = json.loads(raw) if raw.strip() else {}
+            except Exception:
+                payload = {"_raw": raw}
+
+            record = {
+                "path": self.path,
+                "headers": {k: v for k, v in self.headers.items()},
+                "payload": payload,
+            }
+            records.append(record)
+
+            if self.path.startswith("/fail"):
+                body = {"error": "simulated_unavailable"}
+                encoded = json.dumps(body).encode("utf-8")
+                self.send_response(503)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+                return
+
+            ack_id = f"ack-{len(records)}"
+            body = {"ack_id": ack_id, "status": "accepted"}
+            encoded = json.dumps(body).encode("utf-8")
+            self.send_response(202)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, format, *args):  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    base_url = f"http://{host}:{port}"
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return LocalWebhookServer(
+        server=server,
+        thread=thread,
+        records=records,
+        base_url=base_url,
+    )
+
+
+def _run_k1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    webhook = _start_local_webhook_server()
+    scenario["webhook_base_url"] = webhook.base_url
+
+    try:
+        success_event_id = f"k1-success-{summary.run_id}"
+        success = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message="Run scheduled digest delivery now.",
+                conversation_type="digest-email",
+                mcp_scope_mode="none",
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_tool_profile": "read_only",
+                    "mcp_digest_schedule_enabled": True,
+                    "mcp_digest_force_run": True,
+                    "mcp_digest_schedule_event_id": success_event_id,
+                    "mcp_digest_delivery_send_enabled": True,
+                    "mcp_digest_delivery_endpoint": f"{webhook.base_url}/ok",
+                },
+            ),
+        )
+        success_handoff = success.get("delivery_handoff") or {}
+        success_state = success.get("tooling_state") or {}
+        success_conversation_id = success.get("conversation_id")
+        scenario["digest_delivery_success"] = {
+            "delivery_handoff": success_handoff,
+            "tooling_state": success_state,
+            "conversation_id": success_conversation_id,
+        }
+        _assert(
+            summary,
+            "k1_send_success_handoff_status",
+            success_handoff.get("delivery_send_status") == "sent"
+            and success_handoff.get("delivery_send_http_status") == 202
+            and bool(str(success_handoff.get("delivery_send_ack_id") or "")),
+            str(success_handoff),
+        )
+        _assert(
+            summary,
+            "k1_send_success_persisted",
+            success_handoff.get("delivery_record_status") == "persisted"
+            and bool(str(success_handoff.get("delivery_record_path") or "")),
+            str(success_handoff),
+        )
+        _assert(
+            summary,
+            "k1_send_success_tooling_metadata",
+            success_state.get("digest_delivery_send_status") == "sent"
+            and success_state.get("digest_delivery_send_http_status") == 202,
+            str(success_state),
+        )
+
+        failure_event_id = f"k1-failure-{summary.run_id}"
+        failure = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message="Run scheduled digest delivery now.",
+                conversation_type="digest-email",
+                mcp_scope_mode="none",
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_tool_profile": "read_only",
+                    "mcp_digest_schedule_enabled": True,
+                    "mcp_digest_force_run": True,
+                    "mcp_digest_schedule_event_id": failure_event_id,
+                    "mcp_digest_delivery_send_enabled": True,
+                    "mcp_digest_delivery_endpoint": f"{webhook.base_url}/fail",
+                },
+            ),
+        )
+        failure_handoff = failure.get("delivery_handoff") or {}
+        failure_state = failure.get("tooling_state") or {}
+        scenario["digest_delivery_failure"] = {
+            "delivery_handoff": failure_handoff,
+            "tooling_state": failure_state,
+        }
+        _assert(
+            summary,
+            "k1_send_failure_handoff_status",
+            failure_handoff.get("delivery_send_status") == "http_error"
+            and int(failure_handoff.get("delivery_send_http_status") or 0) == 503,
+            str(failure_handoff),
+        )
+        _assert(
+            summary,
+            "k1_send_failure_metadata",
+            failure_state.get("digest_delivery_send_status") == "http_error"
+            and int(failure_state.get("digest_delivery_send_http_status") or 0) == 503,
+            str(failure_state),
+        )
+
+        soak_checks: List[Dict[str, Any]] = []
+        for index in range(12):
+            event_id = f"k1-soak-{summary.run_id}-{index + 1}"
+            soak = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    config=config,
+                    user_id=user_id,
+                    message=f"Run digest delivery soak pass {index + 1}.",
+                    conversation_type="digest-email",
+                    mcp_scope_mode="none",
+                    conversation_id=success_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_tool_profile": "read_only",
+                        "mcp_digest_schedule_enabled": True,
+                        "mcp_digest_force_run": True,
+                        "mcp_digest_schedule_event_id": event_id,
+                        "mcp_digest_delivery_send_enabled": True,
+                        "mcp_digest_delivery_endpoint": f"{webhook.base_url}/ok",
+                    },
+                ),
+            )
+            soak_handoff = soak.get("delivery_handoff") or {}
+            soak_state = soak.get("tooling_state") or {}
+            soak_checks.append(
+                {
+                    "event_id": event_id,
+                    "send_status": soak_handoff.get("delivery_send_status"),
+                    "record_status": soak_handoff.get("delivery_record_status"),
+                    "digest_status": soak_state.get("digest_schedule_status"),
+                }
+            )
+            _assert(
+                summary,
+                f"k1_soak_send_status_{index + 1}",
+                soak_handoff.get("delivery_send_status") == "sent",
+                str(soak_handoff),
+            )
+            _assert(
+                summary,
+                f"k1_soak_record_status_{index + 1}",
+                soak_handoff.get("delivery_record_status") == "persisted",
+                str(soak_handoff),
+            )
+        scenario["digest_delivery_soak"] = soak_checks
+        _assert(
+            summary,
+            "k1_webhook_records_seen",
+            len(webhook.records) >= 14,
+            f"records={len(webhook.records)}",
+        )
+
+        preflush_event_id = f"k1-preflush-{summary.run_id}"
+        long_message = " ".join(["context-pressure"] * 220)
+        preflush_start = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=long_message,
+                conversation_type="chat",
+                mcp_scope_mode="none",
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_pre_compaction_flush_enabled": True,
+                    "mcp_context_window_tokens": 64,
+                    "mcp_pre_compaction_flush_threshold": 0.5,
+                    "mcp_pre_compaction_event_id": preflush_event_id,
+                },
+            ),
+        )
+        preflush_conversation_id = preflush_start.get("conversation_id")
+        preflush_repeat = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=long_message,
+                conversation_type="chat",
+                mcp_scope_mode="none",
+                conversation_id=preflush_conversation_id,
+                params_extra={
+                    "mcp_tools_enabled": False,
+                    "mcp_pre_compaction_flush_enabled": True,
+                    "mcp_context_window_tokens": 64,
+                    "mcp_pre_compaction_flush_threshold": 0.5,
+                    "mcp_pre_compaction_event_id": preflush_event_id,
+                },
+            ),
+        )
+        preflush_state = preflush_repeat.get("tooling_state") or {}
+        scenario["pre_compaction_duplicate_guard"] = preflush_state
+        _assert(
+            summary,
+            "k1_preflush_duplicate_guard",
+            preflush_state.get("pre_compaction_flush_status") == "duplicate_guard"
+            and preflush_state.get("pre_compaction_flush_duplicate_guard") == "history_seen",
+            str(preflush_state),
+        )
+
+        return scenario
+    finally:
+        webhook.shutdown()
+
+
+def _approve_pending_request(
+    *,
+    config: Config,
+    token: str,
+    base_payload: Dict[str, Any],
+    conversation_id: str,
+    request_id: str,
+) -> Dict[str, Any]:
+    payload = dict(base_payload)
+    payload["conversation_id"] = conversation_id
+    payload["messages"] = [{"role": "user", "content": "approve"}]
+    params = dict(payload.get("params") or {})
+    params["mcp_approval"] = {"action": "approve", "request_id": request_id}
+    payload["params"] = params
+    return _chat(config, token, payload)
+
+
+def _run_k2(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    fitness_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Start my fitness onboarding interview.",
+            conversation_type="life-fitness",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/fitness",
+            mcp_project_name="Fitness",
+            params_extra={"mcp_max_tool_iterations": 6},
+        ),
+    )
+    fitness_text = str(((fitness_start.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+    fitness_state = fitness_start.get("tooling_state") or {}
+    scenario["fitness_onboarding_start"] = {
+        "conversation_id": fitness_start.get("conversation_id"),
+        "text": fitness_text,
+        "tooling_state": fitness_state,
+    }
+    _assert(
+        summary,
+        "k2_fitness_onboarding_question",
+        "question 1 of" in fitness_text.lower() and "fitness" in fitness_text.lower(),
+        fitness_text,
+    )
+    _assert(
+        summary,
+        "k2_fitness_onboarding_state",
+        fitness_state.get("conversation_orchestration") == "life_onboarding_deterministic"
+        and fitness_state.get("mcp_project_slug") in {"fitness", "life/fitness"},
+        str(fitness_state),
+    )
+
+    profile_base_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Update my profile with I prefer concise check-ins and 7am deep work.",
+        conversation_type="capture",
+        mcp_scope_mode="none",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    profile_start = _chat(config, token, profile_base_payload)
+    profile_request = profile_start.get("approval_request") or {}
+    profile_conversation_id = str(profile_start.get("conversation_id") or "")
+    scenario["profile_update_start"] = {
+        "approval_required": profile_start.get("approval_required"),
+        "approval_request": profile_request,
+        "conversation_id": profile_conversation_id,
+    }
+    _assert(
+        summary,
+        "k2_profile_update_first_approval",
+        profile_start.get("approval_required") is True
+        and profile_request.get("tool") in {"write_markdown", "create_markdown"}
+        and str((profile_request.get("arguments") or {}).get("path") or "").strip() == "me/profile.md",
+        str(profile_start),
+    )
+    first_request_id = str(profile_request.get("request_id") or "")
+    _assert(summary, "k2_profile_update_request_id", bool(first_request_id), str(profile_request))
+    profile_resume = _approve_pending_request(
+        config=config,
+        token=token,
+        base_payload=profile_base_payload,
+        conversation_id=profile_conversation_id,
+        request_id=first_request_id,
+    )
+    scenario["profile_update_resume"] = {
+        "approval_resolution": profile_resume.get("approval_resolution"),
+        "approval_required": profile_resume.get("approval_required"),
+        "approval_request": profile_resume.get("approval_request"),
+    }
+    _assert(
+        summary,
+        "k2_profile_update_resolution",
+        (profile_resume.get("approval_resolution") or {}).get("status") == "approved",
+        str(profile_resume.get("approval_resolution")),
+    )
+
+    normalized_user_id = _normalize_user_id(user_id)
+    profile_path = config.library_root / "users" / normalized_user_id / "me" / "profile.md"
+    if profile_path.exists():
+        profile_path.unlink()
+    scenario["profile_file_deleted_for_error_path"] = str(profile_path)
+
+    missing_base_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Update my profile with I do weekly planning every Sunday.",
+        conversation_type="capture",
+        mcp_scope_mode="none",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    missing_start = _chat(config, token, missing_base_payload)
+    missing_first_request = missing_start.get("approval_request") or {}
+    missing_conversation_id = str(missing_start.get("conversation_id") or "")
+    _assert(
+        summary,
+        "k2_profile_missing_first_approval",
+        missing_start.get("approval_required") is True
+        and str(missing_first_request.get("tool") or "").strip() in {"write_markdown", "create_markdown"}
+        and str((missing_first_request.get("arguments") or {}).get("path") or "").strip()
+        == "me/profile.md",
+        str(missing_start),
+    )
+
+    missing_first_resume = _approve_pending_request(
+        config=config,
+        token=token,
+        base_payload=missing_base_payload,
+        conversation_id=missing_conversation_id,
+        request_id=str(missing_first_request.get("request_id") or ""),
+    )
+    missing_second_request = missing_first_resume.get("approval_request") or {}
+    scenario["profile_missing_resume_1"] = {
+        "approval_resolution": missing_first_resume.get("approval_resolution"),
+        "approval_required": missing_first_resume.get("approval_required"),
+        "approval_request": missing_second_request,
+    }
+    _assert(
+        summary,
+        "k2_profile_missing_write_resolution",
+        (missing_first_resume.get("approval_resolution") or {}).get("status") == "approved",
+        str(missing_first_resume.get("approval_resolution")),
+    )
+    if missing_first_resume.get("approval_required") is True:
+        followup_chain: List[Dict[str, Any]] = []
+        saw_create_followup = False
+        pending_response = missing_first_resume
+        guard = 0
+        while pending_response.get("approval_required") is True and guard < 6:
+            pending_request = pending_response.get("approval_request") or {}
+            pending_tool = str(pending_request.get("tool") or "").strip()
+            pending_request_id = str(pending_request.get("request_id") or "").strip()
+            pending_args = pending_request.get("arguments") or {}
+
+            if pending_tool == "create_markdown":
+                saw_create_followup = True
+                _assert(
+                    summary,
+                    "k2_profile_missing_create_followup_path",
+                    str((pending_args.get("path") or "")).strip() == "me/profile.md",
+                    str(pending_request),
+                )
+
+            _assert(
+                summary,
+                f"k2_profile_missing_followup_request_id_{guard + 1}",
+                bool(pending_request_id),
+                str(pending_request),
+            )
+
+            next_response = _approve_pending_request(
+                config=config,
+                token=token,
+                base_payload=missing_base_payload,
+                conversation_id=missing_conversation_id,
+                request_id=pending_request_id,
+            )
+            followup_chain.append(
+                {
+                    "step": guard + 1,
+                    "request": pending_request,
+                    "approval_resolution": next_response.get("approval_resolution"),
+                    "approval_required_next": next_response.get("approval_required"),
+                }
+            )
+            _assert(
+                summary,
+                f"k2_profile_missing_followup_resolution_{guard + 1}",
+                (next_response.get("approval_resolution") or {}).get("status") == "approved",
+                str(next_response.get("approval_resolution")),
+            )
+            pending_response = next_response
+            guard += 1
+
+        scenario["profile_missing_followup_chain"] = followup_chain
+        _assert(
+            summary,
+            "k2_profile_missing_followup_progress",
+            saw_create_followup or profile_path.is_file(),
+            str(followup_chain),
+        )
+        settled_without_pending = pending_response.get("approval_required") is not True
+        settled_with_optional_followup = False
+        if not settled_without_pending:
+            pending_request = pending_response.get("approval_request") or {}
+            pending_tool = str(pending_request.get("tool") or "").strip()
+            pending_args = pending_request.get("arguments") or {}
+            pending_path = str((pending_args.get("path") or "")).strip()
+            pending_summary = str(pending_request.get("summary") or "").strip().lower()
+            if pending_tool in {"write_markdown", "create_markdown"} and (
+                pending_path == "me/profile.md" or "me/profile.md" in pending_summary
+            ):
+                settled_with_optional_followup = True
+                scenario["profile_missing_optional_followup_pending"] = pending_request
+
+        _assert(
+            summary,
+            "k2_profile_missing_followup_settled",
+            settled_without_pending or settled_with_optional_followup,
+            str(pending_response),
+        )
+    else:
+        _assert(
+            summary,
+            "k2_profile_missing_auto_recovered",
+            missing_first_resume.get("approval_required") is not True,
+            str(missing_first_resume),
+        )
+
+    _assert(
+        summary,
+        "k2_profile_file_recreated",
+        profile_path.is_file(),
+        str(profile_path),
+    )
+
+    return scenario
+
+
+def _attempt_citation_probe(
+    *,
+    summary: ProbeSummary,
+    config: Config,
+    token: str,
+    user_id: str,
+    scope_mode: str,
+    conversation_type: str,
+    project_slug: str,
+    project_name: str,
+    prompts: List[str],
+    params_extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    attempts: List[Dict[str, Any]] = []
+    for prompt in prompts:
+        response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=prompt,
+                conversation_type=conversation_type,
+                mcp_scope_mode=scope_mode,
+                mcp_project_slug=project_slug,
+                mcp_project_name=project_name,
+                params_extra=params_extra,
+            ),
+        )
+        tooling = response.get("tooling_state") or {}
+        citations = tooling.get("response_citations")
+        text = str(((response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        has_sources_block = "Sources:" in text
+        has_citation_meta = isinstance(citations, list) and len(citations) > 0
+        attempt = {
+            "prompt": prompt,
+            "tooling_state": tooling,
+            "has_sources_block": has_sources_block,
+            "has_citation_meta": has_citation_meta,
+            "citation_count": len(citations) if isinstance(citations, list) else 0,
+        }
+        attempts.append(attempt)
+        if has_sources_block or has_citation_meta:
+            return {
+                "accepted": True,
+                "attempts": attempts,
+            }
+    return {
+        "accepted": False,
+        "attempts": attempts,
+    }
+
+
+def _run_k3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    scenario["onboarding_seed"] = _seed_finances_onboarding_complete(config, user_id)
+
+    routing_default = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Create a task to review project budget next week.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/finance",
+            mcp_project_name="Finance",
+            params_extra={"mcp_max_tool_iterations": 5},
+        ),
+    )
+    routing_default_state = routing_default.get("tooling_state") or {}
+    scenario["routing_default_project_scope"] = routing_default_state
+    _assert(
+        summary,
+        "k3_routing_default_project_scope",
+        routing_default_state.get("tool_routing_mode") == "dual_path_fallback"
+        and routing_default_state.get("tool_profile") == "full"
+        and routing_default_state.get("tool_profile_source") == "routing_scope_policy"
+        and routing_default_state.get("tool_policy_mode") == "dual_path_project_scope_compat",
+        str(routing_default_state),
+    )
+
+    routing_native_override = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Create a task to review project budget next week.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="projects/active/finance",
+            mcp_project_name="Finance",
+            params_extra={
+                "mcp_max_tool_iterations": 5,
+                "mcp_native_tool_calling": True,
+            },
+        ),
+    )
+    routing_native_state = routing_native_override.get("tooling_state") or {}
+    scenario["routing_native_override"] = routing_native_state
+    _assert(
+        summary,
+        "k3_routing_native_override",
+        routing_native_state.get("tool_routing_mode") == "single_path_native"
+        and routing_native_state.get("tool_execution_mode") == "single_path_native"
+        and routing_native_state.get("routing_capability_source") == "request_override",
+        str(routing_native_state),
+    )
+
+    routing_life_scope = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="Create a task to review my fitness weekly plan.",
+            conversation_type="chat",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/fitness",
+            mcp_project_name="Fitness",
+            params_extra={"mcp_max_tool_iterations": 5},
+        ),
+    )
+    routing_life_state = routing_life_scope.get("tooling_state") or {}
+    scenario["routing_life_scope"] = routing_life_state
+    _assert(
+        summary,
+        "k3_routing_life_scope_policy",
+        routing_life_state.get("tool_policy_mode") == "dual_path_life_scope_compat"
+        and routing_life_state.get("tool_profile") == "full",
+        str(routing_life_state),
+    )
+
+    project_citation_probe = _attempt_citation_probe(
+        summary=summary,
+        config=config,
+        token=token,
+        user_id=user_id,
+        scope_mode="project",
+        conversation_type="chat",
+        project_slug="projects/active/finance",
+        project_name="Finance",
+        prompts=[
+            "What does my current budget say right now?",
+            "Use library files and tell me what the current budget page says.",
+            "Find the current budget details from the finance markdown files.",
+            "Read the project finance markdown files and answer with a short Sources: list.",
+            "Use read-only library tools and include Sources: with file paths.",
+        ],
+        params_extra={"mcp_max_tool_iterations": 6, "mcp_tool_profile": "read_only"},
+    )
+    life_citation_probe = _attempt_citation_probe(
+        summary=summary,
+        config=config,
+        token=token,
+        user_id=user_id,
+        scope_mode="project",
+        conversation_type="chat",
+        project_slug="life/finances",
+        project_name="Finances",
+        prompts=[
+            "What should I focus on in finances based on my library notes?",
+            "Use life finances markdown context and answer with the top focus areas.",
+            "Search my finances pages and summarize key focus areas.",
+            "Read life/finances markdown context and include a Sources: section.",
+            "Use read-only tools and answer with file-backed focus areas plus Sources.",
+        ],
+        params_extra={"mcp_max_tool_iterations": 6, "mcp_tool_profile": "read_only"},
+    )
+    scenario["citation_project_scope"] = project_citation_probe
+    scenario["citation_life_scope"] = life_citation_probe
+
+    _assert(
+        summary,
+        "k3_project_scope_citation_acceptance",
+        bool(project_citation_probe.get("accepted")),
+        str(project_citation_probe),
+    )
+    _assert(
+        summary,
+        "k3_life_scope_citation_acceptance",
+        bool(life_citation_probe.get("accepted")),
+        str(life_citation_probe),
+    )
+    return scenario
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process K.1/K.2/K.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="qwen3-8b-new-server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-k123")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.8)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument(
+        "--reset-from-template",
+        action="store_true",
+        default=True,
+        help="Reset user scope from template before running probes (default: true).",
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        action="store_false",
+        dest="reset_from_template",
+        help="Skip scope reset.",
+    )
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def _summary_to_json(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap_meta = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap_meta
+
+        summary.scenarios["process_k1"] = _run_k1(summary, config, token, user_id)
+        summary.scenarios["process_k2"] = _run_k2(summary, config, token, user_id)
+        summary.scenarios["process_k3"] = _run_k3(summary, config, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness
+        summary.error = str(exc)
+        summary.success = False
+    finally:
+        output = _summary_to_json(summary)
+        summary_path = run_dir / "summary.json"
+        summary_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"summary_path": str(summary_path.resolve()), "success": summary.success}, indent=2))
+
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_l1_l2_l3.py
+++ b/scripts/e2e_process_l1_l2_l3.py
@@ -1,0 +1,1338 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process L.1, L.2, and L.3.
+
+L.1: VS-5/VS-6/TR-1 final multi-op edit acceptance (compound + correction flows).
+L.2: VS-8/VS-11 focused page parity + new-page archetype expansion checks.
+L.3: TR-3/TR-5/VS-4 capability-policy + citation acceptance expansion checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Callable, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+APPROVAL_REQUIRED_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _decode_json_bytes(raw: bytes) -> Dict[str, Any]:
+    text = raw.decode("utf-8", errors="replace")
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+        return {"data": parsed}
+    except Exception:
+        return {"raw": text}
+
+
+def _http_post(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                return _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _http_post_with_status(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                return int(response.status), _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            return int(exc.code), _decode_json_bytes(exc.read())
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    response = _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _seed_finances_onboarding_complete(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    onboarding_path = (
+        config.library_root
+        / "users"
+        / normalized_user_id
+        / ".braindrive"
+        / "onboarding_state.json"
+    )
+    if not onboarding_path.is_file():
+        return {"updated": False, "path": str(onboarding_path), "reason": "missing"}
+
+    try:
+        state = json.loads(onboarding_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {
+            "updated": False,
+            "path": str(onboarding_path),
+            "reason": f"read_error:{exc}",
+        }
+    if not isinstance(state, dict):
+        return {"updated": False, "path": str(onboarding_path), "reason": "invalid_json_root"}
+
+    now_iso = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+    starter_topics = state.setdefault("starter_topics", {})
+    if isinstance(starter_topics, dict):
+        starter_topics["finances"] = "complete"
+    completed_at = state.setdefault("completed_at", {})
+    if isinstance(completed_at, dict):
+        completed_at["finances"] = now_iso
+    topic_progress = state.setdefault("topic_progress", {})
+    if isinstance(topic_progress, dict):
+        finances_progress = topic_progress.setdefault("finances", {})
+        if isinstance(finances_progress, dict):
+            finances_progress["status"] = "complete"
+            finances_progress["phase"] = "complete"
+            finances_progress["completed_at_utc"] = now_iso
+            finances_progress["last_updated_at_utc"] = now_iso
+            if not finances_progress.get("started_at_utc"):
+                finances_progress["started_at_utc"] = now_iso
+    state["active_topic"] = None
+    state["updated_at_utc"] = now_iso
+    onboarding_path.write_text(json.dumps(state, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    return {"updated": True, "path": str(onboarding_path), "updated_at_utc": now_iso}
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+    page_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    if page_id:
+        payload["page_id"] = page_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _chat_with_status(
+    config: Config,
+    token: str,
+    payload: Dict[str, Any],
+) -> Tuple[int, Dict[str, Any]]:
+    return _http_post_with_status(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _attempt_routing_probe(
+    *,
+    summary: ProbeSummary,
+    config: Config,
+    token: str,
+    user_id: str,
+    conversation_type: str,
+    scope_mode: str,
+    project_slug: Optional[str],
+    project_name: Optional[str],
+    prompts: List[str],
+    params_extra: Optional[Dict[str, Any]],
+    predicate: Callable[[Dict[str, Any]], bool],
+) -> Dict[str, Any]:
+    attempts: List[Dict[str, Any]] = []
+    for prompt in prompts:
+        response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=prompt,
+                conversation_type=conversation_type,
+                mcp_scope_mode=scope_mode,
+                mcp_project_slug=project_slug,
+                mcp_project_name=project_name,
+                params_extra=params_extra,
+            ),
+        )
+        tooling = response.get("tooling_state") or {}
+        attempts.append(
+            {
+                "prompt": prompt,
+                "tooling_state": tooling,
+                "approval_required": response.get("approval_required"),
+            }
+        )
+        if predicate(tooling):
+            return {"passed": True, "attempts": attempts, "accepted_state": tooling}
+    return {"passed": False, "attempts": attempts}
+
+
+def _attempt_citation_probe(
+    *,
+    config: Config,
+    token: str,
+    user_id: str,
+    scope_mode: str,
+    conversation_type: str,
+    project_slug: str,
+    project_name: str,
+    prompts: List[str],
+    params_extra: Optional[Dict[str, Any]] = None,
+) -> Dict[str, Any]:
+    attempts: List[Dict[str, Any]] = []
+    citation_path_pattern = re.compile(
+        r"(?:^|[\s(\\[])(?:life|projects|me|capture)/[A-Za-z0-9_./-]+\.md(?:$|[\s)\\]])"
+    )
+    for prompt in prompts:
+        response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=prompt,
+                conversation_type=conversation_type,
+                mcp_scope_mode=scope_mode,
+                mcp_project_slug=project_slug,
+                mcp_project_name=project_name,
+                params_extra=params_extra,
+            ),
+        )
+        tooling = response.get("tooling_state") or {}
+        citations = tooling.get("response_citations")
+        text = str(((response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        lower_text = text.lower()
+        has_sources_block = (
+            "sources:" in lower_text
+            or "\n## sources" in lower_text
+            or "\n### sources" in lower_text
+            or lower_text.startswith("sources\n")
+        )
+        has_citation_meta = isinstance(citations, list) and len(citations) > 0
+        has_path_citations = bool(citation_path_pattern.search(text))
+        attempt = {
+            "prompt": prompt,
+            "tooling_state": tooling,
+            "has_sources_block": has_sources_block,
+            "has_citation_meta": has_citation_meta,
+            "has_path_citations": has_path_citations,
+            "citation_count": len(citations) if isinstance(citations, list) else 0,
+            "assistant_text": text,
+        }
+        attempts.append(attempt)
+        if has_sources_block or has_citation_meta or has_path_citations:
+            return {"accepted": True, "attempts": attempts}
+    return {"accepted": False, "attempts": attempts}
+
+
+def _run_l1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    scope_path = "projects/active/side-business"
+    scope_name = "Side Business"
+    conversation_type = "project-side-business"
+    marker = f"L1 marker {summary.run_id}"
+
+    first_prompt = (
+        'Edit spec.md, build-plan.md, and status.md for side business. '
+        f'Add "{marker} spec", "{marker} plan", and "{marker} status".'
+    )
+
+    first_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=first_prompt,
+            conversation_type=conversation_type,
+            mcp_scope_mode="project",
+            mcp_project_slug=scope_path,
+            mcp_project_name=scope_name,
+            params_extra={"mcp_native_tool_calling": True},
+        ),
+    )
+    first_request = first_start.get("approval_request") or {}
+    first_preview = first_request.get("preview") or {}
+    first_text = str((((first_start.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+
+    conversation_id = first_start.get("conversation_id")
+    request_id = first_request.get("request_id")
+    scenario["first_compound_start"] = {
+        "approval_required": first_start.get("approval_required"),
+        "approval_request": first_request,
+        "tooling_state": first_start.get("tooling_state"),
+        "assistant_text": first_text,
+    }
+
+    _assert(summary, "l1_first_compound_approval_required", first_start.get("approval_required") is True, str(first_start))
+    _assert(summary, "l1_first_compound_tool", first_request.get("tool") == "edit_markdown", str(first_request))
+    _assert(
+        summary,
+        "l1_first_compound_reason",
+        str(first_request.get("synthetic_reason") or "").strip() == "compound_edit_followthrough",
+        str(first_request),
+    )
+    _assert(summary, "l1_first_copy_locked", first_text == APPROVAL_REQUIRED_TEXT, first_text)
+    _assert(summary, "l1_first_has_conversation_id", isinstance(conversation_id, str) and bool(conversation_id), str(conversation_id))
+    _assert(summary, "l1_first_has_request_id", isinstance(request_id, str) and bool(request_id), str(request_id))
+
+    reject_response = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="reject",
+            conversation_type=conversation_type,
+            mcp_scope_mode="project",
+            mcp_project_slug=scope_path,
+            mcp_project_name=scope_name,
+            conversation_id=conversation_id,
+            params_extra={
+                "mcp_native_tool_calling": True,
+                "mcp_approval": {
+                    "action": "reject",
+                    "request_id": request_id,
+                },
+            },
+        ),
+    )
+    reject_resolution = reject_response.get("approval_resolution") or {}
+    reject_text = str((((reject_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+    scenario["reject_resolution"] = {
+        "approval_resolution": reject_resolution,
+        "assistant_text": reject_text,
+        "tooling_state": reject_response.get("tooling_state"),
+    }
+    _assert(summary, "l1_reject_resolution_status", reject_resolution.get("status") == "rejected", str(reject_resolution))
+    _assert(summary, "l1_reject_text_non_empty", bool(reject_text.strip()), reject_text)
+
+    corrected_prompt = (
+        'Actually correct it: edit spec.md and status.md. '
+        f'Add "{marker} corrected spec" and "{marker} corrected status".'
+    )
+    corrected_start = _chat(
+        config,
+        token,
+        _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=corrected_prompt,
+            conversation_type=conversation_type,
+            mcp_scope_mode="project",
+            mcp_project_slug=scope_path,
+            mcp_project_name=scope_name,
+            conversation_id=conversation_id,
+            params_extra={"mcp_native_tool_calling": True},
+        ),
+    )
+    corrected_request = corrected_start.get("approval_request") or {}
+    corrected_preview = corrected_request.get("preview") or {}
+    corrected_text = str((((corrected_start.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+    scenario["corrected_start"] = {
+        "approval_required": corrected_start.get("approval_required"),
+        "approval_request": corrected_request,
+        "assistant_text": corrected_text,
+        "tooling_state": corrected_start.get("tooling_state"),
+    }
+
+    _assert(summary, "l1_corrected_approval_required", corrected_start.get("approval_required") is True, str(corrected_start))
+    _assert(summary, "l1_corrected_tool", corrected_request.get("tool") == "edit_markdown", str(corrected_request))
+    _assert(summary, "l1_corrected_copy_locked", corrected_text == APPROVAL_REQUIRED_TEXT, corrected_text)
+
+    corrected_chain: List[Dict[str, Any]] = []
+    corrected_total_execution_count = 0
+    corrected_request_id = corrected_request.get("request_id")
+    for step in range(4):
+        if not isinstance(corrected_request_id, str) or not corrected_request_id:
+            break
+        try:
+            corrected_approve = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    config=config,
+                    user_id=user_id,
+                    message="approve",
+                    conversation_type=conversation_type,
+                    mcp_scope_mode="project",
+                    mcp_project_slug=scope_path,
+                    mcp_project_name=scope_name,
+                    conversation_id=conversation_id,
+                    params_extra={
+                        "mcp_native_tool_calling": True,
+                        "mcp_approval": {
+                            "action": "approve",
+                            "request_id": corrected_request_id,
+                        },
+                    },
+                ),
+            )
+        except RuntimeError as exc:
+            if "No pending approval request found for this conversation" in str(exc):
+                corrected_chain.append(
+                    {
+                        "step": step + 1,
+                        "request_id": corrected_request_id,
+                        "error": "no_pending_approval",
+                    }
+                )
+                break
+            raise
+        corrected_state = corrected_approve.get("tooling_state") or {}
+        corrected_resolution = corrected_approve.get("approval_resolution") or {}
+        corrected_text_step = str((((corrected_approve.get("choices") or [{}])[0] or {}).get("message") or {}).get("content") or "")
+        corrected_total_execution_count += int(corrected_state.get("tool_calls_executed_count") or 0)
+        corrected_chain.append(
+            {
+                "step": step + 1,
+                "request_id": corrected_request_id,
+                "approval_required": corrected_approve.get("approval_required"),
+                "approval_request": corrected_approve.get("approval_request"),
+                "approval_resolution": corrected_resolution,
+                "tooling_state": corrected_state,
+                "assistant_text": corrected_text_step,
+            }
+        )
+        if corrected_approve.get("approval_required") is not True:
+            break
+        next_request = corrected_approve.get("approval_request") or {}
+        next_request_id = next_request.get("request_id")
+        if not isinstance(next_request_id, str) or not next_request_id or next_request_id == corrected_request_id:
+            break
+        corrected_request_id = next_request_id
+
+    corrected_final = corrected_chain[-1] if corrected_chain else {}
+    corrected_final_text = str(corrected_final.get("assistant_text") or "")
+    corrected_approved_any = any(
+        isinstance(item.get("approval_resolution"), dict)
+        and item["approval_resolution"].get("status") == "approved"
+        for item in corrected_chain
+    )
+    corrected_settled = bool(corrected_chain) and corrected_final.get("approval_required") is not True
+
+    scenario["corrected_approve_chain"] = corrected_chain
+    scenario["corrected_approve"] = {
+        "total_execution_count": corrected_total_execution_count,
+        "approved_any": corrected_approved_any,
+        "settled": corrected_settled,
+        "final_step": corrected_final,
+    }
+    _assert(summary, "l1_corrected_approved", corrected_approved_any, str(corrected_chain))
+    _assert(
+        summary,
+        "l1_corrected_execution_count",
+        corrected_total_execution_count >= 2,
+        str(corrected_chain),
+    )
+    _assert(summary, "l1_corrected_confirmation_text_non_empty", bool(corrected_final_text.strip()), corrected_final_text)
+
+    preview_checks: List[Dict[str, Any]] = [
+        {"stage": "first", "preview": first_preview},
+        {"stage": "corrected", "preview": corrected_preview},
+    ]
+    has_preview_marker = any(
+        isinstance(item.get("preview"), dict)
+        and item["preview"].get("previewTool") == "preview_markdown_change"
+        for item in preview_checks
+    )
+    has_preview_content = any(
+        isinstance(item.get("preview"), dict)
+        and (
+            bool(str(item["preview"].get("diff") or "").strip())
+            or bool(str(item["preview"].get("summary") or "").strip())
+        )
+        for item in preview_checks
+    )
+
+    if not (has_preview_marker and has_preview_content):
+        preview_probe_prompt = (
+            "Return ONLY a tool call to edit_markdown. "
+            f"Path: {scope_path}/spec.md. "
+            "Operation: append line '- preview probe'. No prose."
+        )
+        preview_probe = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=preview_probe_prompt,
+                conversation_type=conversation_type,
+                mcp_scope_mode="project",
+                mcp_project_slug=scope_path,
+                mcp_project_name=scope_name,
+                conversation_id=conversation_id,
+                params_extra={"mcp_native_tool_calling": True},
+            ),
+        )
+        preview_probe_request = preview_probe.get("approval_request") or {}
+        preview_probe_preview = preview_probe_request.get("preview") or {}
+        preview_checks.append({"stage": "preview_probe", "preview": preview_probe_preview})
+
+        has_preview_marker = has_preview_marker or (
+            isinstance(preview_probe_preview, dict)
+            and preview_probe_preview.get("previewTool") == "preview_markdown_change"
+        )
+        has_preview_content = has_preview_content or (
+            isinstance(preview_probe_preview, dict)
+            and (
+                bool(str(preview_probe_preview.get("diff") or "").strip())
+                or bool(str(preview_probe_preview.get("summary") or "").strip())
+            )
+        )
+
+        preview_probe_request_id = preview_probe_request.get("request_id")
+        if (
+            preview_probe.get("approval_required") is True
+            and isinstance(preview_probe_request_id, str)
+            and preview_probe_request_id
+        ):
+            preview_probe_reject = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    config=config,
+                    user_id=user_id,
+                    message="reject",
+                    conversation_type=conversation_type,
+                    mcp_scope_mode="project",
+                    mcp_project_slug=scope_path,
+                    mcp_project_name=scope_name,
+                    conversation_id=conversation_id,
+                    params_extra={
+                        "mcp_native_tool_calling": True,
+                        "mcp_approval": {
+                            "action": "reject",
+                            "request_id": preview_probe_request_id,
+                        },
+                    },
+                ),
+            )
+            scenario["preview_probe_reject"] = {
+                "approval_resolution": preview_probe_reject.get("approval_resolution"),
+                "tooling_state": preview_probe_reject.get("tooling_state"),
+            }
+        scenario["preview_probe"] = {
+            "approval_required": preview_probe.get("approval_required"),
+            "approval_request": preview_probe_request,
+            "tooling_state": preview_probe.get("tooling_state"),
+        }
+
+    scenario["preview_checks"] = preview_checks
+    summary_fallback_present = any(
+        bool(str(request.get("summary") or "").strip())
+        for request in (first_request, corrected_request)
+        if isinstance(request, dict)
+    )
+    scenario["preview_summary_fallback_present"] = summary_fallback_present
+    _assert(
+        summary,
+        "l1_preview_marker_or_summary_present",
+        has_preview_marker or summary_fallback_present,
+        str(
+            {
+                "preview_checks": preview_checks,
+                "summary_fallback_present": summary_fallback_present,
+            }
+        ),
+    )
+    _assert(
+        summary,
+        "l1_preview_content_or_summary_present",
+        has_preview_content or summary_fallback_present,
+        str(
+            {
+                "preview_checks": preview_checks,
+                "summary_fallback_present": summary_fallback_present,
+            }
+        ),
+    )
+
+    return scenario
+
+
+def _run_l2(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    scenario["onboarding_seed"] = _seed_finances_onboarding_complete(config, user_id)
+
+    page_matrix: List[Dict[str, Any]] = []
+    starter_pages = [
+        ("Library Capture", "capture", "capture", "Capture"),
+        ("New Page", "chat", None, None),
+        ("WhyFinder", "life-whyfinder", "whyfinder", "WhyFinder"),
+        ("Career", "life-career", "career", "Career"),
+        ("Finances", "life-finances", "finances", "Finances"),
+        ("Fitness", "life-fitness", "fitness", "Fitness"),
+        ("Relationships", "life-relationships", "relationships", "Relationships"),
+    ]
+    for index, (name, conversation_type, expected_slug, expected_name) in enumerate(starter_pages, start=1):
+        page_id = f"l2-starter-{index}-{name.lower().replace(' ', '-') }"
+        start = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=f"Starter page parity check for {name}.",
+                conversation_type=conversation_type,
+                mcp_scope_mode="none",
+                params_extra={"mcp_tools_enabled": False, "mcp_sync_on_request": False},
+                page_id=page_id,
+            ),
+        )
+        state = start.get("tooling_state") or {}
+        conversation_id = start.get("conversation_id")
+        _assert(
+            summary,
+            f"l2_{index}_start_conversation_id",
+            isinstance(conversation_id, str) and bool(conversation_id),
+            str(conversation_id),
+        )
+        if expected_slug is None:
+            _assert(
+                summary,
+                f"l2_{index}_chat_scope_unscoped",
+                state.get("mcp_scope_mode") in {None, "none"} and not state.get("mcp_project_slug"),
+                str(state),
+            )
+        else:
+            _assert(
+                summary,
+                f"l2_{index}_scope_defaults",
+                state.get("mcp_scope_mode") == "project"
+                and state.get("mcp_project_slug") == expected_slug
+                and state.get("mcp_project_name") == expected_name
+                and state.get("mcp_scope_source") == "conversation_type",
+                str(state),
+            )
+
+        same_page = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=f"Continue {name} parity conversation.",
+                conversation_type=conversation_type,
+                mcp_scope_mode="none",
+                conversation_id=conversation_id,
+                params_extra={"mcp_tools_enabled": False, "mcp_sync_on_request": False},
+                page_id=page_id,
+            ),
+        )
+        _assert(
+            summary,
+            f"l2_{index}_same_page_continue_ok",
+            str(same_page.get("conversation_id") or "") == str(conversation_id),
+            str(same_page),
+        )
+
+        mismatch_status, mismatch_body = _chat_with_status(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=f"Mismatch {name} parity conversation.",
+                conversation_type=conversation_type,
+                mcp_scope_mode="none",
+                conversation_id=conversation_id,
+                params_extra={"mcp_tools_enabled": False, "mcp_sync_on_request": False},
+                page_id=f"{page_id}-mismatch",
+            ),
+        )
+        mismatch_detail = str(mismatch_body.get("detail") or "")
+        _assert(summary, f"l2_{index}_mismatch_status_409", mismatch_status == 409, str(mismatch_body))
+        _assert(
+            summary,
+            f"l2_{index}_mismatch_detail",
+            "Conversation is bound to a different page" in mismatch_detail,
+            mismatch_detail,
+        )
+
+        page_matrix.append(
+            {
+                "name": name,
+                "conversation_type": conversation_type,
+                "page_id": page_id,
+                "tooling_state": state,
+                "mismatch_status": mismatch_status,
+                "mismatch_body": mismatch_body,
+            }
+        )
+
+    scenario["starter_page_parity_matrix"] = page_matrix
+
+    archetype_probes = [
+        {
+            "name": "project_research",
+            "message": "Create a new project page for competitor research vault.",
+            "conversation_type": "chat",
+            "scope_mode": "project",
+            "project_slug": "projects/active/finance",
+            "project_name": "Finance",
+            "expected_path": "projects/active/competitor-research-vault",
+            "expected_tools": ["create_project"],
+            "expected_archetype": "research",
+            "expected_file": "research.md",
+        },
+        {
+            "name": "project_operations",
+            "message": "Create a new project page for incident operations runbook.",
+            "conversation_type": "chat",
+            "scope_mode": "project",
+            "project_slug": "projects/active/finance",
+            "project_name": "Finance",
+            "expected_path": "projects/active/incident-operations-runbook",
+            "expected_tools": ["create_project"],
+            "expected_archetype": "operations",
+            "expected_file": "runbook.md",
+        },
+        {
+            "name": "life_habit",
+            "message": "Create a new life page for morning habit reset.",
+            "conversation_type": "chat",
+            "scope_mode": "project",
+            "project_slug": "life/finances",
+            "project_name": "Finances",
+            "expected_path": "life/morning-habit-reset",
+            "expected_tools": ["create_project", "create_markdown"],
+            "expected_archetype": "habit",
+            "expected_file": "habits.md",
+        },
+    ]
+
+    archetype_results: List[Dict[str, Any]] = []
+    for probe in archetype_probes:
+        response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                config=config,
+                user_id=user_id,
+                message=str(probe["message"]),
+                conversation_type=str(probe["conversation_type"]),
+                mcp_scope_mode=str(probe["scope_mode"]),
+                mcp_project_slug=str(probe["project_slug"]),
+                mcp_project_name=str(probe["project_name"]),
+                params_extra={"mcp_max_tool_iterations": 6},
+            ),
+        )
+        approval = response.get("approval_request") or {}
+        arguments = approval.get("arguments") or {}
+        files = arguments.get("files") or []
+        file_paths = {item.get("path") for item in files if isinstance(item, dict)}
+        tool_name = str(approval.get("tool") or "").strip()
+        expected_tools = {str(item).strip() for item in (probe.get("expected_tools") or [])}
+        if not expected_tools:
+            expected_tools = {"create_project"}
+
+        probe_name = str(probe["name"])
+        _assert(summary, f"l2_{probe_name}_approval_required", response.get("approval_required") is True, str(response))
+        _assert(summary, f"l2_{probe_name}_tool", tool_name in expected_tools, str(approval))
+
+        meta_payload: Dict[str, Any] = {}
+        if tool_name == "create_project":
+            _assert(
+                summary,
+                f"l2_{probe_name}_path",
+                arguments.get("path") == probe["expected_path"],
+                str(arguments),
+            )
+            meta_entry = next(
+                (item for item in files if isinstance(item, dict) and item.get("path") == "_meta/interview-state.md"),
+                None,
+            )
+            meta_payload = json.loads(str((meta_entry or {}).get("content") or "{}"))
+            _assert(
+                summary,
+                f"l2_{probe_name}_archetype_meta",
+                meta_payload.get("page_archetype") == probe["expected_archetype"],
+                str(meta_payload),
+            )
+            _assert(
+                summary,
+                f"l2_{probe_name}_archetype_file",
+                str(probe["expected_file"]) in file_paths,
+                str(sorted(file_paths)),
+            )
+            _assert(
+                summary,
+                f"l2_{probe_name}_seed_questions_present",
+                isinstance(meta_payload.get("seed_questions"), list)
+                and len(meta_payload.get("seed_questions") or []) >= 4,
+                str(meta_payload),
+            )
+        elif tool_name == "create_markdown":
+            expected_paths = {
+                str(probe["expected_path"]),
+                f"{probe['expected_path']}.md",
+            }
+            _assert(
+                summary,
+                f"l2_{probe_name}_markdown_path",
+                str(arguments.get("path") or "") in expected_paths,
+                str(arguments),
+            )
+            _assert(
+                summary,
+                f"l2_{probe_name}_markdown_content_non_empty",
+                bool(str(arguments.get("content") or "").strip()),
+                str(arguments),
+            )
+
+        archetype_results.append(
+            {
+                "name": probe_name,
+                "approval_required": response.get("approval_required"),
+                "approval_request": approval,
+                "meta_payload": meta_payload,
+                "file_paths": sorted(path for path in file_paths if isinstance(path, str)),
+            }
+        )
+
+    scenario["archetype_expansion"] = archetype_results
+    return scenario
+
+
+def _run_l3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    scenario["onboarding_seed"] = _seed_finances_onboarding_complete(config, user_id)
+
+    routing_default = _attempt_routing_probe(
+        summary=summary,
+        config=config,
+        token=token,
+        user_id=user_id,
+        conversation_type="chat",
+        scope_mode="project",
+        project_slug="projects/active/finance",
+        project_name="Finance",
+        prompts=[
+            "Create a task to review project budget next week.",
+            "Review this project and propose one concrete task.",
+        ],
+        params_extra={"mcp_max_tool_iterations": 5},
+        predicate=lambda s: s.get("tool_policy_mode") == "dual_path_project_scope_compat"
+        and s.get("tool_profile") == "full",
+    )
+    scenario["routing_default_project_scope"] = routing_default
+    _assert(
+        summary,
+        "l3_routing_default_project_scope",
+        bool(routing_default.get("passed")),
+        str(routing_default),
+    )
+
+    routing_native_override = _attempt_routing_probe(
+        summary=summary,
+        config=config,
+        token=token,
+        user_id=user_id,
+        conversation_type="chat",
+        scope_mode="project",
+        project_slug="projects/active/finance",
+        project_name="Finance",
+        prompts=["Create a task to review project budget next week."],
+        params_extra={"mcp_max_tool_iterations": 5, "mcp_native_tool_calling": True},
+        predicate=lambda s: s.get("tool_routing_mode") == "single_path_native"
+        and s.get("tool_execution_mode") == "single_path_native"
+        and s.get("routing_capability_source") == "request_override",
+    )
+    scenario["routing_native_override"] = routing_native_override
+    _assert(
+        summary,
+        "l3_routing_native_override",
+        bool(routing_native_override.get("passed")),
+        str(routing_native_override),
+    )
+
+    routing_life_scope = _attempt_routing_probe(
+        summary=summary,
+        config=config,
+        token=token,
+        user_id=user_id,
+        conversation_type="chat",
+        scope_mode="project",
+        project_slug="life/fitness",
+        project_name="Fitness",
+        prompts=[
+            "Create a task to review my fitness weekly plan.",
+            "What should I do this week in fitness?",
+        ],
+        params_extra={"mcp_max_tool_iterations": 5},
+        predicate=lambda s: s.get("tool_policy_mode") == "dual_path_life_scope_compat"
+        and s.get("tool_profile") == "full",
+    )
+    scenario["routing_life_scope"] = routing_life_scope
+    _assert(
+        summary,
+        "l3_routing_life_scope_policy",
+        bool(routing_life_scope.get("passed")),
+        str(routing_life_scope),
+    )
+
+    routing_new_page_intent = _attempt_routing_probe(
+        summary=summary,
+        config=config,
+        token=token,
+        user_id=user_id,
+        conversation_type="chat",
+        scope_mode="project",
+        project_slug="projects/active/finance",
+        project_name="Finance",
+        prompts=[
+            "Create a new project page for competitor research board.",
+            "Build a new project workspace for marketing launch prep.",
+        ],
+        params_extra={"mcp_max_tool_iterations": 5},
+        predicate=lambda s: str(s.get("tool_policy_mode") or "").strip()
+        in {"dual_path_new_page_compat", "dual_path_life_new_page_compat"},
+    )
+    scenario["routing_new_page_intent"] = routing_new_page_intent
+    _assert(
+        summary,
+        "l3_routing_new_page_policy",
+        bool(routing_new_page_intent.get("passed")),
+        str(routing_new_page_intent),
+    )
+
+    routing_owner_profile_intent = _attempt_routing_probe(
+        summary=summary,
+        config=config,
+        token=token,
+        user_id=user_id,
+        conversation_type="chat",
+        scope_mode="project",
+        project_slug="projects/active/finance",
+        project_name="Finance",
+        prompts=[
+            "Update my profile: I prefer short weekly check-ins and concise plans.",
+            "Write to me/profile.md that I prefer concise planning updates.",
+        ],
+        params_extra={"mcp_max_tool_iterations": 5},
+        predicate=lambda s: str(s.get("tool_policy_mode") or "").strip()
+        in {"dual_path_owner_profile_compat", "dual_path_project_scope_compat"}
+        and s.get("tool_profile") == "full",
+    )
+    scenario["routing_owner_profile_intent"] = routing_owner_profile_intent
+    _assert(
+        summary,
+        "l3_routing_owner_profile_policy_or_scope_fallback",
+        bool(routing_owner_profile_intent.get("passed")),
+        str(routing_owner_profile_intent),
+    )
+
+    project_citation_probe = _attempt_citation_probe(
+        config=config,
+        token=token,
+        user_id=user_id,
+        scope_mode="project",
+        conversation_type="chat",
+        project_slug="projects/active/finance",
+        project_name="Finance",
+        prompts=[
+            "What does my current budget say right now?",
+            "Use library files and tell me what the current budget page says.",
+            "Find the current budget details from the finance markdown files.",
+            "Read the project finance markdown files and answer with a short Sources: list.",
+            "Use read-only library tools and include Sources: with file paths.",
+        ],
+        params_extra={"mcp_max_tool_iterations": 6, "mcp_tool_profile": "read_only"},
+    )
+    life_citation_probe = _attempt_citation_probe(
+        config=config,
+        token=token,
+        user_id=user_id,
+        scope_mode="project",
+        conversation_type="chat",
+        project_slug="life/finances",
+        project_name="Finances",
+        prompts=[
+            "What should I focus on in finances based on my library notes?",
+            "Use life finances markdown context and answer with the top focus areas.",
+            "Search my finances pages and summarize key focus areas.",
+            "Read life/finances markdown context and include a Sources: section.",
+            "Use read-only tools and answer with file-backed focus areas plus Sources.",
+        ],
+        params_extra={"mcp_max_tool_iterations": 6, "mcp_tool_profile": "read_only"},
+    )
+    scenario["citation_project_scope"] = project_citation_probe
+    scenario["citation_life_scope"] = life_citation_probe
+
+    _assert(
+        summary,
+        "l3_project_scope_citation_acceptance",
+        bool(project_citation_probe.get("accepted")),
+        str(project_citation_probe),
+    )
+    _assert(
+        summary,
+        "l3_life_scope_citation_acceptance",
+        bool(life_citation_probe.get("accepted")),
+        str(life_citation_probe),
+    )
+
+    return scenario
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process L.1/L.2/L.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="qwen3-8b-new-server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-l123")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.8)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument(
+        "--reset-from-template",
+        action="store_true",
+        default=True,
+        help="Reset user scope from template before running probes (default: true).",
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        action="store_false",
+        dest="reset_from_template",
+        help="Skip scope reset.",
+    )
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def _summary_to_json(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap_meta = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap_meta
+
+        summary.scenarios["process_l1"] = _run_l1(summary, config, token, user_id)
+        summary.scenarios["process_l2"] = _run_l2(summary, config, token, user_id)
+        summary.scenarios["process_l3"] = _run_l3(summary, config, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness
+        summary.error = str(exc)
+        summary.success = False
+    finally:
+        output = _summary_to_json(summary)
+        summary_path = run_dir / "summary.json"
+        summary_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"summary_path": str(summary_path.resolve()), "success": summary.success}, indent=2))
+
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_m2_m3.py
+++ b/scripts/e2e_process_m2_m3.py
@@ -1,0 +1,748 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process M.2 and M.3.
+
+M.2: provider/model capability matrix with runtime evidence and skip reasons.
+M.3: longer mixed-traffic soak (chat + capture + digest + delivery) stability checks.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import parse as urllib_parse
+from urllib import request as urllib_request
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+    soak_iterations: int
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _decode_json_bytes(raw: bytes) -> Dict[str, Any]:
+    text = raw.decode("utf-8", errors="replace")
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+        if isinstance(parsed, dict):
+            return parsed
+        return {"data": parsed}
+    except Exception:
+        return {"raw": text}
+
+
+def _throttle(request_delay_seconds: float) -> None:
+    global _LAST_REQUEST_SENT_MONOTONIC
+    if request_delay_seconds <= 0:
+        return
+    now = time.monotonic()
+    if _LAST_REQUEST_SENT_MONOTONIC is not None:
+        elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+        if elapsed < request_delay_seconds:
+            time.sleep(request_delay_seconds - elapsed)
+    _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+
+def _http_json(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    data: Optional[bytes] = None
+    if payload is not None:
+        data = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=data, headers=headers, method=method.upper())
+        try:
+            _throttle(request_delay_seconds)
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                return int(response.status), _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            body = _decode_json_bytes(exc.read())
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            return int(exc.code), body
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    status, response = _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    if status != 200:
+        raise RuntimeError(f"Login failed: status={status} response={response}")
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    provider: str,
+    settings_id: str,
+    server_id: str,
+    model: str,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": provider,
+        "settings_id": settings_id,
+        "server_id": server_id,
+        "model": model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+    return _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _run_m2(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {"live_matrix": [], "skipped": []}
+    status, catalog = _http_json(
+        method="GET",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/catalog?user_id=current",
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+    _assert(summary, "m2_catalog_status_200", status == 200, str(catalog))
+    providers = catalog.get("providers") if isinstance(catalog, dict) else None
+    _assert(summary, "m2_catalog_has_providers", isinstance(providers, list) and len(providers) > 0, str(catalog))
+
+    configured = [
+        p for p in providers
+        if isinstance(p, dict) and bool(p.get("enabled")) and bool(p.get("configured"))
+    ]
+    _assert(summary, "m2_has_configured_provider", len(configured) > 0, str(providers))
+
+    for provider_entry in providers:
+        if not isinstance(provider_entry, dict):
+            continue
+        provider_id = str(provider_entry.get("id") or "").strip()
+        if not provider_id:
+            continue
+        if provider_entry not in configured:
+            scenario["skipped"].append(
+                {
+                    "provider": provider_id,
+                    "reason": "not_configured_or_disabled",
+                    "configured": bool(provider_entry.get("configured")),
+                    "enabled": bool(provider_entry.get("enabled")),
+                }
+            )
+            continue
+
+        matrix_entry: Dict[str, Any] = {"provider": provider_id, "models": []}
+        settings_id = str(provider_entry.get("settings_id") or "")
+        default_server_id = str(provider_entry.get("default_server_id") or "")
+        if provider_id == "ollama":
+            settings_id = config.settings_id
+            default_server_id = config.server_id
+
+        model_candidates: List[str] = [config.model]
+        if provider_id == "ollama":
+            model_candidates = [config.model, "hf.co/mradermacher/granite-4.0-micro-GGUF:Q8_0"]
+
+        seen_models: set[str] = set()
+        for model_name in model_candidates:
+            model_name = str(model_name or "").strip()
+            if not model_name or model_name in seen_models:
+                continue
+            seen_models.add(model_name)
+
+            route_status, route_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=provider_id,
+                    settings_id=settings_id,
+                    server_id=default_server_id,
+                    model=model_name,
+                    user_id=user_id,
+                    message="Create a task to review budget next week.",
+                    conversation_type="chat",
+                    mcp_scope_mode="project",
+                    mcp_project_slug="projects/active/finance",
+                    mcp_project_name="Finance",
+                    params_extra={"mcp_max_tool_iterations": 5},
+                ),
+            )
+            tooling = route_response.get("tooling_state") if isinstance(route_response, dict) else {}
+            route_ok = (
+                route_status == 200
+                and isinstance(tooling, dict)
+                and bool(str(tooling.get("tool_routing_mode") or "").strip())
+                and bool(str(tooling.get("tool_execution_mode") or "").strip())
+            )
+
+            citation_status, citation_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=provider_id,
+                    settings_id=settings_id,
+                    server_id=default_server_id,
+                    model=model_name,
+                    user_id=user_id,
+                    message="Read project finance markdown context and answer with Sources.",
+                    conversation_type="chat",
+                    mcp_scope_mode="project",
+                    mcp_project_slug="projects/active/finance",
+                    mcp_project_name="Finance",
+                    params_extra={"mcp_max_tool_iterations": 6, "mcp_tool_profile": "read_only"},
+                ),
+            )
+            citation_text = str(
+                ((citation_response.get("choices") or [{}])[0].get("message") or {}).get("content") or ""
+            ) if isinstance(citation_response, dict) else ""
+            citation_tooling = citation_response.get("tooling_state") if isinstance(citation_response, dict) else {}
+            citation_meta = citation_tooling.get("response_citations") if isinstance(citation_tooling, dict) else None
+            citation_ok = (
+                citation_status == 200
+                and (
+                    "sources:" in citation_text.lower()
+                    or (isinstance(citation_meta, list) and len(citation_meta) > 0)
+                    or ".md" in citation_text
+                )
+            )
+
+            matrix_entry["models"].append(
+                {
+                    "model": model_name,
+                    "routing_probe": {
+                        "status": route_status,
+                        "ok": route_ok,
+                        "tooling_state": tooling,
+                        "approval_required": bool(route_response.get("approval_required")) if isinstance(route_response, dict) else None,
+                    },
+                    "citation_probe": {
+                        "status": citation_status,
+                        "ok": citation_ok,
+                        "has_sources_block": "sources:" in citation_text.lower(),
+                        "citation_count": len(citation_meta) if isinstance(citation_meta, list) else 0,
+                    },
+                }
+            )
+
+        scenario["live_matrix"].append(matrix_entry)
+
+    matrix_has_pass = any(
+        any(
+            bool(model_entry.get("routing_probe", {}).get("ok"))
+            and bool(model_entry.get("citation_probe", {}).get("ok"))
+            for model_entry in provider_entry.get("models") or []
+        )
+        for provider_entry in scenario["live_matrix"]
+    )
+    _assert(summary, "m2_live_matrix_has_passing_entry", matrix_has_pass, str(scenario["live_matrix"]))
+
+    pytest_cmd = [
+        "/home/hacker/anaconda3/envs/BrainDriveDev/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_mcp_chat_gating.py",
+        "-k",
+        "other_native_providers_default_to_single_path or model_hint_promotes_unknown_provider_to_native_mode",
+    ]
+    completed = subprocess.run(
+        pytest_cmd,
+        cwd=str(Path(__file__).resolve().parents[1] / "backend"),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    scenario["policy_regression"] = {
+        "command": " ".join(pytest_cmd),
+        "returncode": completed.returncode,
+        "stdout_tail": completed.stdout[-2000:],
+        "stderr_tail": completed.stderr[-1200:],
+    }
+    _assert(summary, "m2_policy_regression_pass", completed.returncode == 0, completed.stdout[-1000:])
+    return scenario
+
+
+def _run_m3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {
+        "iterations": config.soak_iterations,
+        "digest_runs": [],
+        "pre_compaction_runs": [],
+        "capture_runs": [],
+    }
+
+    digest_conversation_id: Optional[str] = None
+    chat_conversation_id: Optional[str] = None
+    capture_conversation_id: Optional[str] = None
+
+    for i in range(config.soak_iterations):
+        digest_event_id = f"m3-digest-{i // 2}"
+        digest_status, digest_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=config.provider,
+                settings_id=config.settings_id,
+                server_id=config.server_id,
+                model=config.model,
+                user_id=user_id,
+                message=f"M3 digest check iteration {i + 1}.",
+                conversation_type="digest-email",
+                mcp_scope_mode="project",
+                mcp_project_slug="projects/active/finance",
+                mcp_project_name="Finance",
+                params_extra={
+                    "mcp_max_tool_iterations": 8,
+                    "mcp_digest_schedule_enabled": True,
+                    "mcp_digest_schedule_due_now": True,
+                    "mcp_digest_schedule_event_id": digest_event_id,
+                    "mcp_digest_reply_to_capture_enabled": True,
+                    "mcp_digest_delivery_send_enabled": True,
+                    "mcp_native_tool_calling": True,
+                },
+                conversation_id=digest_conversation_id,
+            ),
+        )
+        if isinstance(digest_response, dict) and isinstance(digest_response.get("conversation_id"), str):
+            digest_conversation_id = digest_response.get("conversation_id")
+        digest_tooling = digest_response.get("tooling_state") if isinstance(digest_response, dict) else {}
+        scenario["digest_runs"].append(
+            {
+                "iteration": i + 1,
+                "event_id": digest_event_id,
+                "status_code": digest_status,
+                "digest_schedule_status": (digest_tooling or {}).get("digest_schedule_status"),
+                "digest_schedule_duplicate_guard": (digest_tooling or {}).get("digest_schedule_duplicate_guard"),
+                "delivery_send_status": (digest_tooling or {}).get("delivery_send_status"),
+            }
+        )
+
+        pre_event_id = f"m3-pre-{i // 2}"
+        long_prompt = (
+            f"M3 pre-compaction iteration {i + 1}. "
+            + ("Budget risks and mitigation details. " * 80)
+        )
+        pre_status, pre_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=config.provider,
+                settings_id=config.settings_id,
+                server_id=config.server_id,
+                model=config.model,
+                user_id=user_id,
+                message=long_prompt,
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="projects/active/finance",
+                mcp_project_name="Finance",
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_pre_compaction_flush_enabled": True,
+                    "mcp_context_window_tokens": 128,
+                    "mcp_pre_compaction_flush_threshold": 0.0,
+                    "mcp_pre_compaction_event_id": pre_event_id,
+                },
+                conversation_id=chat_conversation_id,
+            ),
+        )
+        if isinstance(pre_response, dict) and isinstance(pre_response.get("conversation_id"), str):
+            chat_conversation_id = pre_response.get("conversation_id")
+        pre_tooling = pre_response.get("tooling_state") if isinstance(pre_response, dict) else {}
+        scenario["pre_compaction_runs"].append(
+            {
+                "iteration": i + 1,
+                "event_id": pre_event_id,
+                "status_code": pre_status,
+                "pre_compaction_flush_status": (pre_tooling or {}).get("pre_compaction_flush_status"),
+                "pre_compaction_flush_duplicate_guard": (pre_tooling or {}).get("pre_compaction_flush_duplicate_guard"),
+            }
+        )
+
+        capture_prompt = f"Capture M3 iteration {i + 1}: create a task to reconcile expenses by 2026-03-10."
+        cap_status, cap_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=config.provider,
+                settings_id=config.settings_id,
+                server_id=config.server_id,
+                model=config.model,
+                user_id=user_id,
+                message=capture_prompt,
+                conversation_type="capture",
+                mcp_scope_mode="project",
+                mcp_project_slug="projects/active/finance",
+                mcp_project_name="Finance",
+                params_extra={"mcp_max_tool_iterations": 8},
+                conversation_id=capture_conversation_id,
+            ),
+        )
+        if isinstance(cap_response, dict) and isinstance(cap_response.get("conversation_id"), str):
+            capture_conversation_id = cap_response.get("conversation_id")
+
+        approval_required = bool(cap_response.get("approval_required")) if isinstance(cap_response, dict) else False
+        cap_entry: Dict[str, Any] = {
+            "iteration": i + 1,
+            "status_code": cap_status,
+            "approval_required": approval_required,
+            "tooling_state": (cap_response.get("tooling_state") if isinstance(cap_response, dict) else {}),
+        }
+        if approval_required:
+            request_id = ((cap_response.get("approval_request") or {}).get("request_id") if isinstance(cap_response, dict) else None)
+            if isinstance(request_id, str) and request_id:
+                action = "approve" if i % 2 == 0 else "reject"
+                res_status, res_response = _chat(
+                    config,
+                    token,
+                    _build_chat_payload(
+                        provider=config.provider,
+                        settings_id=config.settings_id,
+                        server_id=config.server_id,
+                        model=config.model,
+                        user_id=user_id,
+                        message=action,
+                        conversation_type="capture",
+                        mcp_scope_mode="project",
+                        mcp_project_slug="projects/active/finance",
+                        mcp_project_name="Finance",
+                        params_extra={
+                            "mcp_max_tool_iterations": 8,
+                            "mcp_approval": {"action": action, "request_id": request_id},
+                        },
+                        conversation_id=capture_conversation_id,
+                    ),
+                )
+                cap_entry["approval_action"] = action
+                cap_entry["approval_resume_status_code"] = res_status
+                cap_entry["approval_resolution"] = res_response.get("approval_resolution") if isinstance(res_response, dict) else None
+        scenario["capture_runs"].append(cap_entry)
+
+    digest_duplicate_guard_count = sum(
+        1
+        for item in scenario["digest_runs"]
+        if str(item.get("digest_schedule_status") or "") == "duplicate_guard"
+    )
+    pre_duplicate_guard_count = sum(
+        1
+        for item in scenario["pre_compaction_runs"]
+        if str(item.get("pre_compaction_flush_status") or "") == "duplicate_guard"
+    )
+    capture_resolved = sum(
+        1
+        for item in scenario["capture_runs"]
+        if isinstance(item.get("approval_resolution"), dict)
+        and str(item["approval_resolution"].get("status") or "").strip() in {"approved", "rejected"}
+    )
+
+    scenario["aggregate"] = {
+        "digest_duplicate_guard_count": digest_duplicate_guard_count,
+        "pre_compaction_duplicate_guard_count": pre_duplicate_guard_count,
+        "capture_resolved_count": capture_resolved,
+    }
+    _assert(
+        summary,
+        "m3_digest_duplicate_guard_seen",
+        digest_duplicate_guard_count >= 1,
+        str(scenario["digest_runs"]),
+    )
+    _assert(
+        summary,
+        "m3_pre_compaction_duplicate_guard_seen",
+        pre_duplicate_guard_count >= 1,
+        str(scenario["pre_compaction_runs"]),
+    )
+    _assert(
+        summary,
+        "m3_capture_approval_resolved_seen",
+        capture_resolved >= 1,
+        str(scenario["capture_runs"]),
+    )
+    return scenario
+
+
+def _parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process M.2/M.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="qwen3-8b-new-server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-m123")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.8)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument("--soak-iterations", type=int, default=6)
+    parser.add_argument(
+        "--reset-from-template",
+        action="store_true",
+        default=True,
+        help="Reset user scope from template before running probes (default: true).",
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        action="store_false",
+        dest="reset_from_template",
+        help="Skip scope reset.",
+    )
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+        soak_iterations=max(2, int(args.soak_iterations)),
+    )
+
+
+def _summary_to_json(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+        if config.reset_from_template:
+            bootstrap_meta = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap_meta
+
+        summary.scenarios["process_m2"] = _run_m2(summary, config, token, user_id)
+        summary.scenarios["process_m3"] = _run_m3(summary, config, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness
+        summary.error = str(exc)
+        summary.success = False
+    finally:
+        output = _summary_to_json(summary)
+        summary_path = run_dir / "summary.json"
+        summary_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(
+            json.dumps(
+                {"summary_path": str(summary_path.resolve()), "success": summary.success},
+                indent=2,
+            )
+        )
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_matrix_a2_e3_f2.py
+++ b/scripts/e2e_process_matrix_a2_e3_f2.py
@@ -1,0 +1,558 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process A.2, E.3, and F.2.
+
+Runs against the real backend API and records a deterministic summary artifact.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _http_post(
+    *,
+    url: str,
+    payload: Dict[str, Any],
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+) -> Dict[str, Any]:
+    global _LAST_REQUEST_SENT_MONOTONIC
+
+    raw = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=raw, headers=headers, method="POST")
+        try:
+            if request_delay_seconds > 0:
+                now = time.monotonic()
+                if _LAST_REQUEST_SENT_MONOTONIC is not None:
+                    elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+                    if elapsed < request_delay_seconds:
+                        time.sleep(request_delay_seconds - elapsed)
+                _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                body = response.read().decode("utf-8")
+                if not body.strip():
+                    return {}
+                return json.loads(body)
+        except urllib_error.HTTPError as exc:
+            details = exc.read().decode("utf-8", errors="replace")
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 120.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"HTTP {exc.code} for {url}: {details}") from exc
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 120.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    payload = {"email": config.email, "password": config.password}
+    response = _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 5.0),
+    )
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _bootstrap_user_scope(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_project_slug: str,
+    mcp_project_name: str,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": "project",
+        "mcp_project_slug": mcp_project_slug,
+        "mcp_project_name": mcp_project_name,
+        "mcp_project_source": "ui",
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 4,
+        "mcp_provider_timeout_seconds": 30,
+    }
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Dict[str, Any]:
+    return _http_post(
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _run_a2(config: Config, summary: ProbeSummary, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    fanout_start_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Capture this: paid gym membership and add a task to review budget for Dave J by next week.",
+        conversation_type="capture",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+    )
+    fanout_start = _chat(config, token, fanout_start_payload)
+    first_request = fanout_start.get("approval_request") or {}
+    conversation_id = fanout_start.get("conversation_id")
+    scenario["fanout_start"] = {
+        "approval_required": fanout_start.get("approval_required"),
+        "approval_request": first_request,
+        "conversation_id": conversation_id,
+    }
+
+    _assert(summary, "a2_fanout_first_approval_required", fanout_start.get("approval_required") is True, str(fanout_start))
+    _assert(summary, "a2_fanout_first_tool_markdown", first_request.get("tool") == "create_markdown", str(first_request))
+    _assert(
+        summary,
+        "a2_fanout_first_reason_inbox_persist",
+        str(first_request.get("synthetic_reason") or "").strip() in {"", "capture_inbox_persist"},
+        str(first_request),
+    )
+    _assert(summary, "a2_fanout_has_conversation_id", isinstance(conversation_id, str) and bool(conversation_id), str(conversation_id))
+
+    fanout_resume_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="approve",
+        conversation_type="capture",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        conversation_id=conversation_id,
+        params_extra={
+            "mcp_approval": {
+                "action": "approve",
+                "request_id": first_request.get("request_id"),
+            }
+        },
+    )
+    fanout_resume = _chat(config, token, fanout_resume_payload)
+    second_request = fanout_resume.get("approval_request") or {}
+    second_args = second_request.get("arguments") or {}
+    scenario["fanout_resume"] = {
+        "approval_required": fanout_resume.get("approval_required"),
+        "approval_resolution": fanout_resume.get("approval_resolution"),
+        "approval_request": second_request,
+        "tooling_state": fanout_resume.get("tooling_state"),
+    }
+    _assert(summary, "a2_fanout_second_approval_required", fanout_resume.get("approval_required") is True, str(fanout_resume))
+    _assert(summary, "a2_fanout_second_tool_create_task", second_request.get("tool") == "create_task", str(second_request))
+    _assert(
+        summary,
+        "a2_fanout_second_reason_task_create",
+        str(second_request.get("synthetic_reason") or "").strip() in {"", "capture_new_task_create"},
+        str(second_request),
+    )
+    _assert(
+        summary,
+        "a2_fanout_second_has_owner_scope_project_due",
+        bool(second_args.get("owner"))
+        and second_args.get("scope") == "life/finances"
+        and second_args.get("project") == "finances"
+        and bool(second_args.get("due")),
+        str(second_args),
+    )
+
+    # Optional follow-on probes for visibility (no hard assertions due live-model variance).
+    fanout_finalize_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="approve",
+        conversation_type="capture",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        conversation_id=conversation_id,
+        params_extra={
+            "mcp_approval": {
+                "action": "approve",
+                "request_id": second_request.get("request_id"),
+            }
+        },
+    )
+    fanout_finalize = _chat(config, token, fanout_finalize_payload)
+    scenario["fanout_finalize_optional"] = {
+        "approval_required": fanout_finalize.get("approval_required"),
+        "approval_request": fanout_finalize.get("approval_request"),
+        "approval_resolution": fanout_finalize.get("approval_resolution"),
+        "tooling_state": fanout_finalize.get("tooling_state"),
+    }
+
+    edit_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message=(
+            "Update task 'Review budget for Dave J': owner: Sarah, "
+            "due next Friday, high priority."
+        ),
+        conversation_type="capture",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+    )
+    edit_response = _chat(config, token, edit_payload)
+    scenario["ambiguous_edit_optional"] = {
+        "approval_required": edit_response.get("approval_required"),
+        "approval_request": edit_response.get("approval_request"),
+        "tooling_state": edit_response.get("tooling_state"),
+    }
+    return scenario
+
+
+def _run_e3(config: Config, summary: ProbeSummary, token: str, user_id: str) -> Dict[str, Any]:
+    payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="My spouse and I keep arguing about debt and monthly budget stress.",
+        conversation_type="chat",
+        mcp_project_slug="life/relationships",
+        mcp_project_name="Relationships",
+    )
+    response = _chat(config, token, payload)
+    approval_request = response.get("approval_request") or {}
+    tooling_state = response.get("tooling_state") or {}
+    scenario = {
+        "approval_required": response.get("approval_required"),
+        "approval_request": approval_request,
+        "tooling_state": tooling_state,
+    }
+
+    _assert(summary, "e3_cross_pollination_approval_required", response.get("approval_required") is True, str(response))
+
+    tool_name = str(approval_request.get("tool") or "")
+    approval_args = approval_request.get("arguments") or {}
+    allow_cross_pollination_write = (
+        tool_name == "create_markdown"
+        and approval_request.get("synthetic_reason") == "cross_pollination_relationships_to_finances"
+    )
+    allow_onboarding_kickoff = (
+        tool_name == "start_topic_onboarding"
+        and str(approval_args.get("topic") or "").strip().lower() == "finances"
+    )
+    _assert(
+        summary,
+        "e3_cross_pollination_expected_action",
+        allow_cross_pollination_write or allow_onboarding_kickoff,
+        str(approval_request),
+    )
+    _assert(
+        summary,
+        "e3_dual_path_compat_routing_state",
+        tooling_state.get("tool_routing_mode") == "dual_path_fallback"
+        and tooling_state.get("tool_profile") == "full"
+        and tooling_state.get("tool_profile_source") == "routing_scope_policy",
+        str(tooling_state),
+    )
+    return scenario
+
+
+def _run_f2(config: Config, summary: ProbeSummary, token: str, user_id: str) -> Dict[str, Any]:
+    prompts = [
+        "Which files in life/finances contain '(to be populated during onboarding)'? Use library tools before answering.",
+        "What does my finances goals page currently say? Use library tools before answering.",
+        "What does my current budget file say right now? Please ground your answer in library reads.",
+        "What are the key points in my finances onboarding interview file?",
+    ]
+    attempts: List[Dict[str, Any]] = []
+    found_citation_acceptance = False
+    for prompt in prompts:
+        payload = _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=prompt,
+            conversation_type="chat",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+        )
+        response = _chat(config, token, payload)
+        content = (
+            response.get("choices", [{}])[0]
+            .get("message", {})
+            .get("content", "")
+        )
+        tooling_state = response.get("tooling_state") or {}
+        citations = tooling_state.get("response_citations") or []
+        appended = bool(tooling_state.get("response_citations_appended"))
+        has_sources_block = "Sources:" in str(content)
+        normalized_content = str(content).lower()
+        response_references_cited_path = any(
+            isinstance(path, str) and path.strip() and path.lower() in normalized_content
+            for path in citations
+        )
+        accepted = bool(citations) and (
+            appended or has_sources_block or response_references_cited_path
+        )
+        attempts.append(
+            {
+                "prompt": prompt,
+                "accepted": accepted,
+                "response_excerpt": str(content)[:500],
+                "response_has_sources_block": has_sources_block,
+                "response_references_cited_path": response_references_cited_path,
+                "response_citations": citations,
+                "response_citations_appended": appended,
+                "tooling_state": tooling_state,
+            }
+        )
+        if accepted:
+            found_citation_acceptance = True
+            break
+
+    _assert(
+        summary,
+        "f2_citation_acceptance_found",
+        found_citation_acceptance,
+        json.dumps(attempts, ensure_ascii=True),
+    )
+    return {"attempts": attempts}
+
+
+def _parse_args() -> Config:
+    repo_root = Path(__file__).resolve().parents[1]
+    parser = argparse.ArgumentParser(description="Live probe for Process A.2/E.3/F.2")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="ollama_default_server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-a2-e3-f2")
+    parser.add_argument("--timeout-seconds", type=int, default=60)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.25)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=2.0)
+    parser.add_argument("--reset-from-template", action="store_true")
+    parser.add_argument(
+        "--library-root",
+        default=str(repo_root / "backend" / "services_runtime" / "Library-Service" / "library"),
+    )
+    parser.add_argument(
+        "--template-root",
+        default=str(repo_root / "backend" / "library_templates" / "Base_Library"),
+    )
+    args = parser.parse_args()
+
+    return Config(
+        base_url=args.base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        output_dir=Path(args.output_dir),
+        timeout_seconds=args.timeout_seconds,
+        request_delay_seconds=args.request_delay_seconds,
+        http_max_retries=args.http_max_retries,
+        http_retry_base_seconds=args.http_retry_base_seconds,
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root),
+        template_root=Path(args.template_root),
+    )
+
+
+def main() -> int:
+    config = _parse_args()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("live-process-a2-e3-f2-%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / run_id
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=dt.datetime.now(dt.timezone.utc).isoformat(),
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        if config.reset_from_template:
+            bootstrap_meta = _bootstrap_user_scope(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap_meta
+
+        summary.scenarios["process_a2"] = _run_a2(config, summary, token, user_id)
+        summary.scenarios["process_e3"] = _run_e3(config, summary, token, user_id)
+        summary.scenarios["process_f2"] = _run_f2(config, summary, token, user_id)
+        summary.success = True
+    except Exception as exc:  # pragma: no cover - runtime harness
+        summary.error = str(exc)
+        summary.success = False
+    finally:
+        output = {
+            "run_id": summary.run_id,
+            "started_at": summary.started_at,
+            "base_url": summary.base_url,
+            "provider": summary.provider,
+            "model": summary.model,
+            "reset_applied": summary.reset_applied,
+            "success": summary.success,
+            "error": summary.error,
+            "assertions": [
+                {"name": item.name, "passed": item.passed, "detail": item.detail}
+                for item in summary.assertions
+            ],
+            "scenarios": summary.scenarios,
+        }
+        summary_path = run_dir / "summary.json"
+        summary_path.write_text(json.dumps(output, indent=2) + "\n", encoding="utf-8")
+        print(json.dumps({"summary_path": str(summary_path.resolve()), "success": summary.success}, indent=2))
+
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_n1_n2_n3.py
+++ b/scripts/e2e_process_n1_n2_n3.py
@@ -1,0 +1,1183 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process N.1, N.2, and N.3.
+
+N.1: VS-9/VS-17 deterministic onboarding parity for remaining life topics +
+      owner-profile edge-path approval flows (missing/oversized/corrupt).
+N.2: TR-3/TR-5/VS-4 configured non-ollama runtime matrix with routing/citation evidence.
+N.3: VS-12/TR-4 extended mixed-traffic soak with multi-channel delivery endpoints.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+APPROVAL_REQUIRED_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    alt_model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+    soak_iterations: int
+
+
+@dataclass
+class LocalWebhookServer:
+    server: ThreadingHTTPServer
+    thread: threading.Thread
+    records: List[Dict[str, Any]]
+    base_url: str
+
+    def shutdown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _decode_json_bytes(raw: bytes) -> Dict[str, Any]:
+    text = raw.decode("utf-8", errors="replace")
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return {"raw": text}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"data": parsed}
+
+
+def _throttle(request_delay_seconds: float) -> None:
+    global _LAST_REQUEST_SENT_MONOTONIC
+    if request_delay_seconds <= 0:
+        return
+    now = time.monotonic()
+    if _LAST_REQUEST_SENT_MONOTONIC is not None:
+        elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+        if elapsed < request_delay_seconds:
+            time.sleep(request_delay_seconds - elapsed)
+    _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+
+def _http_json(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    body: Optional[bytes] = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=body, headers=headers, method=method.upper())
+        try:
+            _throttle(request_delay_seconds)
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                return int(response.status), _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            parsed = _decode_json_bytes(exc.read())
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            return int(exc.code), parsed
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    status, response = _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    if status != 200:
+        raise RuntimeError(f"Login failed: status={status} response={response}")
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    provider: str,
+    settings_id: str,
+    server_id: str,
+    model: str,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": provider,
+        "settings_id": settings_id,
+        "server_id": server_id,
+        "model": model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+    return _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _approve_pending_request(
+    *,
+    config: Config,
+    token: str,
+    base_payload: Dict[str, Any],
+    conversation_id: str,
+    request_id: str,
+    action: str = "approve",
+) -> Tuple[int, Dict[str, Any]]:
+    payload = dict(base_payload)
+    payload["conversation_id"] = conversation_id
+    payload["messages"] = [{"role": "user", "content": action}]
+    params = dict(payload.get("params") or {})
+    params["mcp_approval"] = {"action": action, "request_id": request_id}
+    payload["params"] = params
+    return _chat(config, token, payload)
+
+
+def _start_local_webhook_server() -> LocalWebhookServer:
+    records: List[Dict[str, Any]] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            content_length = int(self.headers.get("Content-Length", "0") or 0)
+            raw = self.rfile.read(content_length).decode("utf-8", errors="replace")
+            try:
+                payload = json.loads(raw) if raw.strip() else {}
+            except Exception:
+                payload = {"_raw": raw}
+
+            record = {
+                "path": self.path,
+                "headers": {k: v for k, v in self.headers.items()},
+                "payload": payload,
+            }
+            records.append(record)
+
+            if self.path.startswith("/fail"):
+                response = {"error": "simulated_unavailable"}
+                encoded = json.dumps(response).encode("utf-8")
+                self.send_response(503)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Content-Length", str(len(encoded)))
+                self.end_headers()
+                self.wfile.write(encoded)
+                return
+
+            ack_id = f"ack-{len(records)}"
+            response = {"ack_id": ack_id, "status": "accepted"}
+            encoded = json.dumps(response).encode("utf-8")
+            self.send_response(202)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, format, *args):  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return LocalWebhookServer(
+        server=server,
+        thread=thread,
+        records=records,
+        base_url=f"http://{host}:{port}",
+    )
+
+
+def _upsert_setting_instance(
+    *,
+    config: Config,
+    token: str,
+    payload: Dict[str, Any],
+) -> Tuple[int, Dict[str, Any]]:
+    return _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/settings/instances",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _run_n1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    onboarding_topics: List[Tuple[str, str, str]] = [
+        ("relationships", "Relationships", "Start my relationships onboarding interview."),
+        ("career", "Career", "Start my career onboarding interview."),
+        ("whyfinder", "WhyFinder", "Start my whyfinder onboarding interview."),
+    ]
+    topic_results: List[Dict[str, Any]] = []
+
+    for topic_slug, topic_title, start_message in onboarding_topics:
+        start_payload = _build_chat_payload(
+            provider=config.provider,
+            settings_id=config.settings_id,
+            server_id=config.server_id,
+            model=config.model,
+            user_id=user_id,
+            message=start_message,
+            conversation_type=f"life-{topic_slug}",
+            mcp_scope_mode="project",
+            mcp_project_slug=f"life/{topic_slug}",
+            mcp_project_name=topic_title,
+            params_extra={"mcp_max_tool_iterations": 6},
+        )
+        start_status, start_response = _chat(config, token, start_payload)
+        start_text = str(((start_response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        start_state = start_response.get("tooling_state") or {}
+        conversation_id = str(start_response.get("conversation_id") or "")
+
+        _assert(
+            summary,
+            f"n1_{topic_slug}_kickoff_status",
+            start_status == 200,
+            str(start_response),
+        )
+        _assert(
+            summary,
+            f"n1_{topic_slug}_kickoff_question",
+            "question 1 of" in start_text.lower(),
+            start_text,
+        )
+        _assert(
+            summary,
+            f"n1_{topic_slug}_kickoff_scope",
+            start_state.get("conversation_orchestration") == "life_onboarding_deterministic"
+            and str(start_state.get("mcp_project_slug") or "").strip() in {topic_slug, f"life/{topic_slug}"},
+            str(start_state),
+        )
+        _assert(
+            summary,
+            f"n1_{topic_slug}_conversation_id",
+            bool(conversation_id),
+            str(start_response),
+        )
+
+        answer_payload = _build_chat_payload(
+            provider=config.provider,
+            settings_id=config.settings_id,
+            server_id=config.server_id,
+            model=config.model,
+            user_id=user_id,
+            message=f"My focus is improving {topic_slug} consistency this quarter.",
+            conversation_type=f"life-{topic_slug}",
+            mcp_scope_mode="project",
+            mcp_project_slug=f"life/{topic_slug}",
+            mcp_project_name=topic_title,
+            params_extra={"mcp_max_tool_iterations": 6},
+            conversation_id=conversation_id,
+        )
+        answer_status, answer_response = _chat(config, token, answer_payload)
+        answer_text = str(((answer_response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        _assert(
+            summary,
+            f"n1_{topic_slug}_answer_status",
+            answer_status == 200,
+            str(answer_response),
+        )
+        _assert(
+            summary,
+            f"n1_{topic_slug}_answer_pending_approval",
+            "approve" in answer_text.lower(),
+            answer_text,
+        )
+
+        approve_payload = _build_chat_payload(
+            provider=config.provider,
+            settings_id=config.settings_id,
+            server_id=config.server_id,
+            model=config.model,
+            user_id=user_id,
+            message="approve",
+            conversation_type=f"life-{topic_slug}",
+            mcp_scope_mode="project",
+            mcp_project_slug=f"life/{topic_slug}",
+            mcp_project_name=topic_title,
+            params_extra={"mcp_max_tool_iterations": 6},
+            conversation_id=conversation_id,
+        )
+        approve_status, approve_response = _chat(config, token, approve_payload)
+        approve_text = str(((approve_response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        _assert(
+            summary,
+            f"n1_{topic_slug}_approve_status",
+            approve_status == 200,
+            str(approve_response),
+        )
+        _assert(
+            summary,
+            f"n1_{topic_slug}_approve_progresses",
+            any(
+                token_text in approve_text.lower()
+                for token_text in ("question 2 of", "initial goals or tasks", "onboarding is complete")
+            ),
+            approve_text,
+        )
+
+        topic_results.append(
+            {
+                "topic": topic_slug,
+                "start_text": start_text,
+                "answer_text": answer_text,
+                "approve_text": approve_text,
+                "tooling_state": start_state,
+            }
+        )
+
+    scenario["onboarding_topics"] = topic_results
+
+    normalized_user_id = _normalize_user_id(user_id)
+    profile_path = config.library_root / "users" / normalized_user_id / "me" / "profile.md"
+    profile_path.parent.mkdir(parents=True, exist_ok=True)
+    scenario["profile_path"] = str(profile_path)
+
+    # Missing path recovery with approval chain.
+    if profile_path.exists():
+        profile_path.unlink()
+    missing_payload = _build_chat_payload(
+        provider=config.provider,
+        settings_id=config.settings_id,
+        server_id=config.server_id,
+        model=config.model,
+        user_id=user_id,
+        message="Update my profile with I do weekly planning every Sunday evening.",
+        conversation_type="capture",
+        mcp_scope_mode="none",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    missing_status, missing_start = _chat(config, token, missing_payload)
+    missing_request = missing_start.get("approval_request") or {}
+    missing_conversation_id = str(missing_start.get("conversation_id") or "")
+    _assert(summary, "n1_profile_missing_status", missing_status == 200, str(missing_start))
+    _assert(
+        summary,
+        "n1_profile_missing_first_approval",
+        missing_start.get("approval_required") is True
+        and str((missing_request.get("arguments") or {}).get("path") or "").strip() == "me/profile.md",
+        str(missing_start),
+    )
+    _assert(
+        summary,
+        "n1_profile_missing_request_id",
+        bool(str(missing_request.get("request_id") or "").strip()),
+        str(missing_request),
+    )
+
+    followups: List[Dict[str, Any]] = []
+    current = missing_start
+    guard = 0
+    while current.get("approval_required") is True and guard < 8:
+        request = current.get("approval_request") or {}
+        request_id = str(request.get("request_id") or "").strip()
+        _assert(
+            summary,
+            f"n1_profile_missing_followup_request_id_{guard + 1}",
+            bool(request_id),
+            str(request),
+        )
+        resume_status, current = _approve_pending_request(
+            config=config,
+            token=token,
+            base_payload=missing_payload,
+            conversation_id=missing_conversation_id,
+            request_id=request_id,
+            action="approve",
+        )
+        _assert(
+            summary,
+            f"n1_profile_missing_followup_status_{guard + 1}",
+            resume_status == 200,
+            str(current),
+        )
+        _assert(
+            summary,
+            f"n1_profile_missing_followup_resolution_{guard + 1}",
+            (current.get("approval_resolution") or {}).get("status") == "approved",
+            str(current.get("approval_resolution")),
+        )
+        followups.append(
+            {
+                "step": guard + 1,
+                "approval_request": request,
+                "approval_resolution": current.get("approval_resolution"),
+                "approval_required_next": current.get("approval_required"),
+            }
+        )
+        guard += 1
+
+    scenario["profile_missing_followup_chain"] = followups
+    _assert(
+        summary,
+        "n1_profile_missing_recreated",
+        profile_path.is_file(),
+        str(profile_path),
+    )
+
+    # Oversized context path should mark truncation and still surface approval.
+    profile_path.write_text("line\n" * 5000, encoding="utf-8")
+    oversized_payload = _build_chat_payload(
+        provider=config.provider,
+        settings_id=config.settings_id,
+        server_id=config.server_id,
+        model=config.model,
+        user_id=user_id,
+        message="Update my profile with I prefer concise planning notes and short check-ins.",
+        conversation_type="capture",
+        mcp_scope_mode="none",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    oversized_status, oversized_response = _chat(config, token, oversized_payload)
+    oversized_state = oversized_response.get("tooling_state") or {}
+    oversized_request = oversized_response.get("approval_request") or {}
+    scenario["profile_oversized"] = {
+        "tooling_state": oversized_state,
+        "approval_request": oversized_request,
+    }
+    _assert(summary, "n1_profile_oversized_status", oversized_status == 200, str(oversized_response))
+    _assert(
+        summary,
+        "n1_profile_oversized_metadata",
+        oversized_state.get("owner_profile_status") == "loaded"
+        and bool(oversized_state.get("owner_profile_truncated")),
+        str(oversized_state),
+    )
+    _assert(
+        summary,
+        "n1_profile_oversized_approval",
+        oversized_response.get("approval_required") is True
+        and str((oversized_request.get("arguments") or {}).get("path") or "").strip() == "me/profile.md",
+        str(oversized_response),
+    )
+
+    # Corrupt context path should show read_error but still allow approval flow.
+    profile_path.write_bytes(b"\xff\xfe\xfd")
+    corrupt_payload = _build_chat_payload(
+        provider=config.provider,
+        settings_id=config.settings_id,
+        server_id=config.server_id,
+        model=config.model,
+        user_id=user_id,
+        message="Update my profile with I do weekly planning on Sunday nights.",
+        conversation_type="capture",
+        mcp_scope_mode="none",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    corrupt_status, corrupt_start = _chat(config, token, corrupt_payload)
+    corrupt_state = corrupt_start.get("tooling_state") or {}
+    corrupt_request = corrupt_start.get("approval_request") or {}
+    scenario["profile_corrupt_start"] = {
+        "tooling_state": corrupt_state,
+        "approval_request": corrupt_request,
+    }
+    _assert(summary, "n1_profile_corrupt_status", corrupt_status == 200, str(corrupt_start))
+    _assert(
+        summary,
+        "n1_profile_corrupt_metadata",
+        corrupt_state.get("owner_profile_status") == "read_error",
+        str(corrupt_state),
+    )
+    _assert(
+        summary,
+        "n1_profile_corrupt_approval",
+        corrupt_start.get("approval_required") is True
+        and str((corrupt_request.get("arguments") or {}).get("path") or "").strip() == "me/profile.md",
+        str(corrupt_start),
+    )
+    corrupt_request_id = str(corrupt_request.get("request_id") or "").strip()
+    _assert(summary, "n1_profile_corrupt_request_id", bool(corrupt_request_id), str(corrupt_request))
+    corrupt_resume_status, corrupt_resume = _approve_pending_request(
+        config=config,
+        token=token,
+        base_payload=corrupt_payload,
+        conversation_id=str(corrupt_start.get("conversation_id") or ""),
+        request_id=corrupt_request_id,
+        action="approve",
+    )
+    scenario["profile_corrupt_resume"] = corrupt_resume
+    _assert(summary, "n1_profile_corrupt_resume_status", corrupt_resume_status == 200, str(corrupt_resume))
+    _assert(
+        summary,
+        "n1_profile_corrupt_resolution",
+        (corrupt_resume.get("approval_resolution") or {}).get("status") == "approved",
+        str(corrupt_resume.get("approval_resolution")),
+    )
+
+    return scenario
+
+
+def _run_n2(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    openai_settings_payload = {
+        "definition_id": "openai_api_keys_settings",
+        "name": "OpenAI API Keys",
+        "value": {
+            "api_key": "sk-local-test-key",
+            "base_url": "http://localhost:11434/v1",
+        },
+        "scope": "user",
+        "user_id": user_id,
+    }
+    settings_status, settings_response = _upsert_setting_instance(
+        config=config,
+        token=token,
+        payload=openai_settings_payload,
+    )
+    scenario["openai_settings_upsert"] = {
+        "status": settings_status,
+        "response": settings_response,
+    }
+    _assert(
+        summary,
+        "n2_openai_settings_upsert",
+        settings_status in {200, 201},
+        str(settings_response),
+    )
+
+    catalog_status, catalog = _http_json(
+        method="GET",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/catalog",
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+    providers = catalog.get("providers") if isinstance(catalog, dict) else []
+    scenario["provider_catalog"] = {"status": catalog_status, "providers": providers}
+    _assert(summary, "n2_catalog_status_200", catalog_status == 200, str(catalog))
+    openai_entry = None
+    for entry in providers if isinstance(providers, list) else []:
+        if str(entry.get("id") or "").strip() == "openai":
+            openai_entry = entry
+            break
+    _assert(summary, "n2_openai_in_catalog", isinstance(openai_entry, dict), str(providers))
+    _assert(
+        summary,
+        "n2_openai_marked_configured",
+        bool((openai_entry or {}).get("configured")),
+        str(openai_entry),
+    )
+
+    model_candidates = [config.model]
+    alt = str(config.alt_model or "").strip()
+    if alt and alt not in model_candidates:
+        model_candidates.append(alt)
+
+    matrix: List[Dict[str, Any]] = []
+    any_non_ollama_pass = False
+    any_citation_acceptance = False
+    n2_scope_slug = "life/finances"
+    n2_scope_name = "Finances"
+    for model in model_candidates:
+        routing_status, routing_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider="openai",
+                settings_id="openai_api_keys_settings",
+                server_id="openai_default_server",
+                model=model,
+                user_id=user_id,
+                message="List one markdown path in life/finances before answering.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug=n2_scope_slug,
+                mcp_project_name=n2_scope_name,
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                },
+            ),
+        )
+        routing_state = routing_response.get("tooling_state") if isinstance(routing_response, dict) else {}
+        routing_ok = (
+            routing_status == 200
+            and isinstance(routing_state, dict)
+            and str(routing_state.get("tool_routing_mode") or "").strip() in {"dual_path_fallback", "single_path_native"}
+            and str(routing_state.get("tool_execution_mode") or "").strip()
+            in {"single_path_compat", "single_path_native"}
+        )
+
+        citation_status, citation_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider="openai",
+                settings_id="openai_api_keys_settings",
+                server_id="openai_default_server",
+                model=model,
+                user_id=user_id,
+                message="Which markdown file in life/finances mentions '(to be populated during onboarding)'? cite the path.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug=n2_scope_slug,
+                mcp_project_name=n2_scope_name,
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                },
+            ),
+        )
+        citation_text = str(((citation_response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        citation_state = citation_response.get("tooling_state") if isinstance(citation_response, dict) else {}
+        citations = citation_state.get("response_citations") if isinstance(citation_state, dict) else None
+        citation_ok = (
+            citation_status == 200
+            and (
+                "sources:" in citation_text.lower()
+                or (isinstance(citations, list) and len(citations) > 0)
+                or ".md" in citation_text
+            )
+        )
+
+        model_result = {
+            "model": model,
+            "routing_probe": {
+                "status": routing_status,
+                "ok": routing_ok,
+                "tooling_state": routing_state,
+            },
+            "citation_probe": {
+                "status": citation_status,
+                "ok": citation_ok,
+                "response_citations": citations,
+                "has_sources_block": "sources:" in citation_text.lower(),
+                "text_excerpt": citation_text[:400],
+            },
+        }
+        matrix.append(model_result)
+        if routing_ok:
+            any_non_ollama_pass = True
+        if citation_ok:
+            any_citation_acceptance = True
+
+    scenario["openai_runtime_matrix"] = matrix
+    _assert(summary, "n2_openai_runtime_has_pass", any_non_ollama_pass, str(matrix))
+    _assert(summary, "n2_openai_citation_acceptance", any_citation_acceptance, str(matrix))
+    return scenario
+
+
+def _run_n3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {"iterations": config.soak_iterations}
+    webhook = _start_local_webhook_server()
+    scenario["webhook_base_url"] = webhook.base_url
+
+    digest_email_runs: List[Dict[str, Any]] = []
+    digest_slack_runs: List[Dict[str, Any]] = []
+    pre_compaction_runs: List[Dict[str, Any]] = []
+    capture_runs: List[Dict[str, Any]] = []
+
+    digest_email_conversation_id: Optional[str] = None
+    digest_slack_conversation_id: Optional[str] = None
+    pre_conversation_id: Optional[str] = None
+
+    try:
+        for index in range(config.soak_iterations):
+            pair_id = index // 2
+            email_event_id = f"n3-email-{pair_id}"
+            slack_event_id = f"n3-slack-{pair_id}"
+            pre_event_id = f"n3-pre-{pair_id}"
+
+            email_status, email_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message="Run scheduled digest delivery now.",
+                    conversation_type="digest-email",
+                    mcp_scope_mode="none",
+                    conversation_id=digest_email_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_tool_profile": "read_only",
+                        "mcp_digest_schedule_enabled": True,
+                        "mcp_digest_force_run": True,
+                        "mcp_digest_schedule_event_id": email_event_id,
+                        "mcp_digest_delivery_send_enabled": True,
+                        "mcp_digest_delivery_endpoint": f"{webhook.base_url}/email",
+                    },
+                ),
+            )
+            if digest_email_conversation_id is None:
+                digest_email_conversation_id = str(email_response.get("conversation_id") or "")
+            email_state = email_response.get("tooling_state") or {}
+            digest_email_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": email_event_id,
+                    "status_code": email_status,
+                    "digest_schedule_status": email_state.get("digest_schedule_status"),
+                    "digest_schedule_duplicate_guard": email_state.get("digest_schedule_duplicate_guard"),
+                    "delivery_send_status": email_state.get("digest_delivery_send_status"),
+                    "delivery_channel": email_state.get("digest_delivery_channel"),
+                }
+            )
+
+            slack_status, slack_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message="Run scheduled digest delivery now.",
+                    conversation_type="digest-slack",
+                    mcp_scope_mode="none",
+                    conversation_id=digest_slack_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_tool_profile": "read_only",
+                        "mcp_digest_schedule_enabled": True,
+                        "mcp_digest_force_run": True,
+                        "mcp_digest_schedule_event_id": slack_event_id,
+                        "mcp_digest_delivery_send_enabled": True,
+                        "mcp_digest_delivery_endpoint": f"{webhook.base_url}/slack",
+                    },
+                ),
+            )
+            if digest_slack_conversation_id is None:
+                digest_slack_conversation_id = str(slack_response.get("conversation_id") or "")
+            slack_state = slack_response.get("tooling_state") or {}
+            digest_slack_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": slack_event_id,
+                    "status_code": slack_status,
+                    "digest_schedule_status": slack_state.get("digest_schedule_status"),
+                    "digest_schedule_duplicate_guard": slack_state.get("digest_schedule_duplicate_guard"),
+                    "delivery_send_status": slack_state.get("digest_delivery_send_status"),
+                    "delivery_channel": slack_state.get("digest_delivery_channel"),
+                }
+            )
+
+            long_message = " ".join(["context-pressure"] * 240)
+            pre_status, pre_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=long_message,
+                    conversation_type="chat",
+                    mcp_scope_mode="none",
+                    conversation_id=pre_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_pre_compaction_flush_enabled": True,
+                        "mcp_context_window_tokens": 64,
+                        "mcp_pre_compaction_flush_threshold": 0.5,
+                        "mcp_pre_compaction_event_id": pre_event_id,
+                    },
+                ),
+            )
+            if pre_conversation_id is None:
+                pre_conversation_id = str(pre_response.get("conversation_id") or "")
+            pre_state = pre_response.get("tooling_state") or {}
+            pre_compaction_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": pre_event_id,
+                    "status_code": pre_status,
+                    "pre_compaction_flush_status": pre_state.get("pre_compaction_flush_status"),
+                    "pre_compaction_flush_duplicate_guard": pre_state.get("pre_compaction_flush_duplicate_guard"),
+                }
+            )
+
+            capture_status, capture_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=f"Create a task to reconcile finance notes for iteration {index + 1}.",
+                    conversation_type="capture",
+                    mcp_scope_mode="project",
+                    mcp_project_slug="projects/active/finance",
+                    mcp_project_name="Finance",
+                    params_extra={
+                        "mcp_max_tool_iterations": 6,
+                    },
+                ),
+            )
+            capture_entry: Dict[str, Any] = {
+                "iteration": index + 1,
+                "status_code": capture_status,
+                "approval_required": capture_response.get("approval_required"),
+                "tooling_state": capture_response.get("tooling_state"),
+            }
+            if capture_response.get("approval_required") is True:
+                approval_request = capture_response.get("approval_request") or {}
+                action = "approve" if index % 2 == 0 else "reject"
+                resume_status, resume_response = _approve_pending_request(
+                    config=config,
+                    token=token,
+                    base_payload=_build_chat_payload(
+                        provider=config.provider,
+                        settings_id=config.settings_id,
+                        server_id=config.server_id,
+                        model=config.model,
+                        user_id=user_id,
+                        message="approve",
+                        conversation_type="capture",
+                        mcp_scope_mode="project",
+                        mcp_project_slug="projects/active/finance",
+                        mcp_project_name="Finance",
+                        params_extra={"mcp_max_tool_iterations": 6},
+                    ),
+                    conversation_id=str(capture_response.get("conversation_id") or ""),
+                    request_id=str(approval_request.get("request_id") or ""),
+                    action=action,
+                )
+                capture_entry["approval_action"] = action
+                capture_entry["approval_resume_status_code"] = resume_status
+                capture_entry["approval_resolution"] = resume_response.get("approval_resolution")
+            capture_runs.append(capture_entry)
+
+        scenario["digest_email_runs"] = digest_email_runs
+        scenario["digest_slack_runs"] = digest_slack_runs
+        scenario["pre_compaction_runs"] = pre_compaction_runs
+        scenario["capture_runs"] = capture_runs
+
+        email_duplicate_guard_count = sum(
+            1 for item in digest_email_runs if str(item.get("digest_schedule_status") or "") == "duplicate_guard"
+        )
+        slack_duplicate_guard_count = sum(
+            1 for item in digest_slack_runs if str(item.get("digest_schedule_status") or "") == "duplicate_guard"
+        )
+        pre_duplicate_guard_count = sum(
+            1 for item in pre_compaction_runs if str(item.get("pre_compaction_flush_status") or "") == "duplicate_guard"
+        )
+        capture_resolved_count = sum(
+            1
+            for item in capture_runs
+            if str((item.get("approval_resolution") or {}).get("status") or "").strip() in {"approved", "rejected"}
+        )
+        email_send_count = sum(1 for item in digest_email_runs if str(item.get("delivery_send_status") or "") == "sent")
+        slack_send_count = sum(1 for item in digest_slack_runs if str(item.get("delivery_send_status") or "") == "sent")
+        email_webhook_hits = sum(1 for rec in webhook.records if str(rec.get("path") or "").startswith("/email"))
+        slack_webhook_hits = sum(1 for rec in webhook.records if str(rec.get("path") or "").startswith("/slack"))
+
+        scenario["aggregate"] = {
+            "email_duplicate_guard_count": email_duplicate_guard_count,
+            "slack_duplicate_guard_count": slack_duplicate_guard_count,
+            "pre_compaction_duplicate_guard_count": pre_duplicate_guard_count,
+            "capture_resolved_count": capture_resolved_count,
+            "email_send_count": email_send_count,
+            "slack_send_count": slack_send_count,
+            "email_webhook_hits": email_webhook_hits,
+            "slack_webhook_hits": slack_webhook_hits,
+        }
+
+        _assert(summary, "n3_email_duplicate_guard_seen", email_duplicate_guard_count >= 1, str(digest_email_runs))
+        _assert(summary, "n3_slack_duplicate_guard_seen", slack_duplicate_guard_count >= 1, str(digest_slack_runs))
+        _assert(summary, "n3_pre_compaction_duplicate_guard_seen", pre_duplicate_guard_count >= 1, str(pre_compaction_runs))
+        _assert(summary, "n3_capture_resolution_seen", capture_resolved_count >= 1, str(capture_runs))
+        _assert(summary, "n3_email_delivery_sent_seen", email_send_count >= 1, str(digest_email_runs))
+        _assert(summary, "n3_slack_delivery_sent_seen", slack_send_count >= 1, str(digest_slack_runs))
+        _assert(summary, "n3_email_webhook_hits_seen", email_webhook_hits >= 1, str(scenario["aggregate"]))
+        _assert(summary, "n3_slack_webhook_hits_seen", slack_webhook_hits >= 1, str(scenario["aggregate"]))
+
+        return scenario
+    finally:
+        webhook.shutdown()
+
+
+def _serialize_summary(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {
+                "name": assertion.name,
+                "passed": assertion.passed,
+                "detail": assertion.detail,
+            }
+            for assertion in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> Config:
+    parser = argparse.ArgumentParser(description="Live Process N.1/N.2/N.3 harness")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_servers_settings")
+    parser.add_argument("--server-id", default="ollama_default_server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--alt-model", default="hf.co/mradermacher/granite-4.0-micro-GGUF:Q8_0")
+    parser.add_argument("--output-dir", default="tmp/live-process-n123")
+    parser.add_argument("--timeout-seconds", type=int, default=90)
+    parser.add_argument("--request-delay-seconds", type=float, default=0.9)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=1.6)
+    parser.add_argument("--soak-iterations", type=int, default=10)
+    parser.add_argument("--reset-from-template", action="store_true")
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args(argv)
+    return Config(
+        base_url=str(args.base_url),
+        email=str(args.email),
+        password=str(args.password),
+        provider=str(args.provider),
+        settings_id=str(args.settings_id),
+        server_id=str(args.server_id),
+        model=str(args.model),
+        alt_model=str(args.alt_model),
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=max(10, int(args.timeout_seconds)),
+        request_delay_seconds=max(0.0, float(args.request_delay_seconds)),
+        http_max_retries=max(0, int(args.http_max_retries)),
+        http_retry_base_seconds=max(0.1, float(args.http_retry_base_seconds)),
+        soak_iterations=max(4, int(args.soak_iterations)),
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    config = _parse_args(argv)
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    started_at = dt.datetime.now(dt.timezone.utc).isoformat()
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=started_at,
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap
+
+        summary.scenarios["process_n1"] = _run_n1(summary, config, token, user_id)
+        summary.scenarios["process_n2"] = _run_n2(summary, config, token, user_id)
+        summary.scenarios["process_n3"] = _run_n3(summary, config, token, user_id)
+
+        summary.success = all(assertion.passed for assertion in summary.assertions)
+    except Exception as exc:
+        summary.success = False
+        summary.error = str(exc)
+
+    output_path = run_dir / "summary.json"
+    output_path.write_text(json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2))
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_o1_o3.py
+++ b/scripts/e2e_process_o1_o3.py
@@ -1,0 +1,952 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process O.1 and O.3.
+
+O.1: VS-12/TR-4/VS-6 long-window mixed-traffic soak closure.
+O.3: TR-3/TR-5/VS-4 external provider runtime matrix expansion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    openrouter_model: str
+    openai_model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+    soak_iterations: int
+    skip_o1: bool
+    skip_o3: bool
+
+
+@dataclass
+class LocalWebhookServer:
+    server: ThreadingHTTPServer
+    thread: threading.Thread
+    records: List[Dict[str, Any]]
+    base_url: str
+
+    def shutdown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _decode_json_bytes(raw: bytes) -> Dict[str, Any]:
+    text = raw.decode("utf-8", errors="replace")
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return {"raw": text}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"data": parsed}
+
+
+def _throttle(request_delay_seconds: float) -> None:
+    global _LAST_REQUEST_SENT_MONOTONIC
+    if request_delay_seconds <= 0:
+        return
+    now = time.monotonic()
+    if _LAST_REQUEST_SENT_MONOTONIC is not None:
+        elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+        if elapsed < request_delay_seconds:
+            time.sleep(request_delay_seconds - elapsed)
+    _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+
+def _http_json(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    body: Optional[bytes] = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=body, headers=headers, method=method.upper())
+        try:
+            _throttle(request_delay_seconds)
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                return int(response.status), _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            parsed = _decode_json_bytes(exc.read())
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            return int(exc.code), parsed
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    status, response = _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    if status != 200:
+        raise RuntimeError(f"Login failed: status={status} response={response}")
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    provider: str,
+    settings_id: str,
+    server_id: str,
+    model: str,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": provider,
+        "settings_id": settings_id,
+        "server_id": server_id,
+        "model": model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+    return _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _approve_pending_request(
+    *,
+    config: Config,
+    token: str,
+    base_payload: Dict[str, Any],
+    conversation_id: str,
+    request_id: str,
+    action: str,
+) -> Tuple[int, Dict[str, Any]]:
+    payload = dict(base_payload)
+    payload["conversation_id"] = conversation_id
+    payload["messages"] = [{"role": "user", "content": action}]
+    params = dict(payload.get("params") or {})
+    params["mcp_approval"] = {"action": action, "request_id": request_id}
+    payload["params"] = params
+    return _chat(config, token, payload)
+
+
+def _start_local_webhook_server() -> LocalWebhookServer:
+    records: List[Dict[str, Any]] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            content_length = int(self.headers.get("Content-Length", "0") or 0)
+            raw = self.rfile.read(content_length).decode("utf-8", errors="replace")
+            try:
+                payload = json.loads(raw) if raw.strip() else {}
+            except Exception:
+                payload = {"_raw": raw}
+
+            records.append(
+                {
+                    "path": self.path,
+                    "headers": {k: v for k, v in self.headers.items()},
+                    "payload": payload,
+                }
+            )
+
+            response = {"status": "accepted", "ack_id": f"ack-{len(records)}"}
+            encoded = json.dumps(response).encode("utf-8")
+            self.send_response(202)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, format, *args):  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return LocalWebhookServer(
+        server=server,
+        thread=thread,
+        records=records,
+        base_url=f"http://{host}:{port}",
+    )
+
+
+def _run_o1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {"iterations": config.soak_iterations}
+    webhook = _start_local_webhook_server()
+    scenario["webhook_base_url"] = webhook.base_url
+
+    digest_email_runs: List[Dict[str, Any]] = []
+    digest_slack_runs: List[Dict[str, Any]] = []
+    pre_compaction_runs: List[Dict[str, Any]] = []
+    capture_runs: List[Dict[str, Any]] = []
+
+    digest_email_conversation_id: Optional[str] = None
+    digest_slack_conversation_id: Optional[str] = None
+    chat_conversation_id: Optional[str] = None
+    capture_conversation_id: Optional[str] = None
+
+    started_mono = time.monotonic()
+
+    try:
+        for index in range(config.soak_iterations):
+            pair = index // 2
+            email_event_id = f"o1-email-{pair}"
+            slack_event_id = f"o1-slack-{pair}"
+            pre_event_id = f"o1-pre-{pair}"
+
+            email_status, email_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=f"Process O.1 digest email iteration {index + 1}.",
+                    conversation_type="digest-email",
+                    mcp_scope_mode="none",
+                    conversation_id=digest_email_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_tool_profile": "read_only",
+                        "mcp_digest_schedule_enabled": True,
+                        "mcp_digest_force_run": True,
+                        "mcp_digest_schedule_event_id": email_event_id,
+                        "mcp_digest_delivery_send_enabled": True,
+                        "mcp_digest_delivery_endpoint": f"{webhook.base_url}/email",
+                    },
+                ),
+            )
+            if digest_email_conversation_id is None:
+                digest_email_conversation_id = str(email_response.get("conversation_id") or "")
+            email_tooling = email_response.get("tooling_state") or {}
+            digest_email_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": email_event_id,
+                    "status_code": email_status,
+                    "digest_schedule_status": email_tooling.get("digest_schedule_status"),
+                    "digest_schedule_duplicate_guard": email_tooling.get("digest_schedule_duplicate_guard"),
+                    "delivery_send_status": email_tooling.get("digest_delivery_send_status"),
+                    "delivery_channel": email_tooling.get("digest_delivery_channel"),
+                }
+            )
+
+            slack_status, slack_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=f"Process O.1 digest slack iteration {index + 1}.",
+                    conversation_type="digest-slack",
+                    mcp_scope_mode="none",
+                    conversation_id=digest_slack_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_tool_profile": "read_only",
+                        "mcp_digest_schedule_enabled": True,
+                        "mcp_digest_force_run": True,
+                        "mcp_digest_schedule_event_id": slack_event_id,
+                        "mcp_digest_delivery_send_enabled": True,
+                        "mcp_digest_delivery_endpoint": f"{webhook.base_url}/slack",
+                    },
+                ),
+            )
+            if digest_slack_conversation_id is None:
+                digest_slack_conversation_id = str(slack_response.get("conversation_id") or "")
+            slack_tooling = slack_response.get("tooling_state") or {}
+            digest_slack_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": slack_event_id,
+                    "status_code": slack_status,
+                    "digest_schedule_status": slack_tooling.get("digest_schedule_status"),
+                    "digest_schedule_duplicate_guard": slack_tooling.get("digest_schedule_duplicate_guard"),
+                    "delivery_send_status": slack_tooling.get("digest_delivery_send_status"),
+                    "delivery_channel": slack_tooling.get("digest_delivery_channel"),
+                }
+            )
+
+            long_message = " ".join(["o1-context-pressure"] * 320)
+            pre_status, pre_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=long_message,
+                    conversation_type="chat",
+                    mcp_scope_mode="none",
+                    conversation_id=chat_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_pre_compaction_flush_enabled": True,
+                        "mcp_context_window_tokens": 64,
+                        "mcp_pre_compaction_flush_threshold": 0.5,
+                        "mcp_pre_compaction_event_id": pre_event_id,
+                    },
+                ),
+            )
+            if chat_conversation_id is None:
+                chat_conversation_id = str(pre_response.get("conversation_id") or "")
+            pre_tooling = pre_response.get("tooling_state") or {}
+            pre_compaction_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": pre_event_id,
+                    "status_code": pre_status,
+                    "pre_compaction_flush_status": pre_tooling.get("pre_compaction_flush_status"),
+                    "pre_compaction_flush_duplicate_guard": pre_tooling.get("pre_compaction_flush_duplicate_guard"),
+                }
+            )
+
+            capture_payload = _build_chat_payload(
+                provider=config.provider,
+                settings_id=config.settings_id,
+                server_id=config.server_id,
+                model=config.model,
+                user_id=user_id,
+                message=f"Create task O1 iteration {index + 1}: reconcile finance notes by 2026-03-20 for Dave J.",
+                conversation_type="capture",
+                mcp_scope_mode="project",
+                mcp_project_slug="projects/active/finance",
+                mcp_project_name="Finance",
+                conversation_id=capture_conversation_id,
+                params_extra={"mcp_max_tool_iterations": 7},
+            )
+            cap_status, cap_response = _chat(config, token, capture_payload)
+            if capture_conversation_id is None:
+                capture_conversation_id = str(cap_response.get("conversation_id") or "")
+            capture_entry: Dict[str, Any] = {
+                "iteration": index + 1,
+                "status_code": cap_status,
+                "approval_required": cap_response.get("approval_required"),
+                "tooling_state": cap_response.get("tooling_state"),
+            }
+            if cap_response.get("approval_required") is True:
+                request = cap_response.get("approval_request") or {}
+                request_id = str(request.get("request_id") or "").strip()
+                if request_id:
+                    action = "approve" if index % 2 == 0 else "reject"
+                    resume_status, resume_response = _approve_pending_request(
+                        config=config,
+                        token=token,
+                        base_payload=capture_payload,
+                        conversation_id=str(cap_response.get("conversation_id") or ""),
+                        request_id=request_id,
+                        action=action,
+                    )
+                    capture_entry["approval_action"] = action
+                    capture_entry["approval_resume_status_code"] = resume_status
+                    capture_entry["approval_resolution"] = resume_response.get("approval_resolution")
+            capture_runs.append(capture_entry)
+
+        elapsed_seconds = round(time.monotonic() - started_mono, 3)
+
+        email_dup = sum(1 for row in digest_email_runs if str(row.get("digest_schedule_status") or "") == "duplicate_guard")
+        slack_dup = sum(1 for row in digest_slack_runs if str(row.get("digest_schedule_status") or "") == "duplicate_guard")
+        pre_dup = sum(
+            1
+            for row in pre_compaction_runs
+            if str(row.get("pre_compaction_flush_status") or "") == "duplicate_guard"
+        )
+        capture_resolved = sum(
+            1
+            for row in capture_runs
+            if str((row.get("approval_resolution") or {}).get("status") or "") in {"approved", "rejected"}
+        )
+        email_sent = sum(1 for row in digest_email_runs if str(row.get("delivery_send_status") or "") == "sent")
+        slack_sent = sum(1 for row in digest_slack_runs if str(row.get("delivery_send_status") or "") == "sent")
+        email_hits = sum(1 for rec in webhook.records if str(rec.get("path") or "").startswith("/email"))
+        slack_hits = sum(1 for rec in webhook.records if str(rec.get("path") or "").startswith("/slack"))
+
+        scenario["digest_email_runs"] = digest_email_runs
+        scenario["digest_slack_runs"] = digest_slack_runs
+        scenario["pre_compaction_runs"] = pre_compaction_runs
+        scenario["capture_runs"] = capture_runs
+        scenario["aggregate"] = {
+            "elapsed_seconds": elapsed_seconds,
+            "email_duplicate_guard_count": email_dup,
+            "slack_duplicate_guard_count": slack_dup,
+            "pre_compaction_duplicate_guard_count": pre_dup,
+            "capture_resolved_count": capture_resolved,
+            "email_send_count": email_sent,
+            "slack_send_count": slack_sent,
+            "email_webhook_hits": email_hits,
+            "slack_webhook_hits": slack_hits,
+        }
+
+        min_dup_expected = max(2, config.soak_iterations // 6)
+        min_resolution_expected = max(4, config.soak_iterations // 3)
+        min_delivery_expected = max(4, config.soak_iterations // 3)
+
+        _assert(summary, "o1_email_duplicate_guard_seen", email_dup >= min_dup_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_slack_duplicate_guard_seen", slack_dup >= min_dup_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_pre_compaction_duplicate_guard_seen", pre_dup >= min_dup_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_capture_resolution_seen", capture_resolved >= min_resolution_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_email_delivery_seen", email_sent >= min_delivery_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_slack_delivery_seen", slack_sent >= min_delivery_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_email_webhook_hits_seen", email_hits >= min_delivery_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_slack_webhook_hits_seen", slack_hits >= min_delivery_expected, str(scenario["aggregate"]))
+
+        return scenario
+    finally:
+        webhook.shutdown()
+
+
+def _run_o3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {
+        "catalog": {},
+        "runtime_matrix": [],
+        "skipped": [],
+    }
+
+    cat_status, cat_response = _http_json(
+        method="GET",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/catalog?user_id=current",
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+    _assert(summary, "o3_catalog_status_200", cat_status == 200, str(cat_response))
+
+    providers = cat_response.get("providers") if isinstance(cat_response, dict) else []
+    _assert(summary, "o3_catalog_has_providers", isinstance(providers, list) and len(providers) >= 1, str(cat_response))
+
+    scenario["catalog"] = {
+        "status": cat_status,
+        "providers": providers,
+    }
+
+    provider_map: Dict[str, Dict[str, Any]] = {}
+    for entry in providers if isinstance(providers, list) else []:
+        if isinstance(entry, dict):
+            provider_map[str(entry.get("id") or "").strip()] = entry
+
+    openrouter_entry = provider_map.get("openrouter")
+    _assert(summary, "o3_openrouter_visible", isinstance(openrouter_entry, dict), str(providers))
+    _assert(
+        summary,
+        "o3_openrouter_configured",
+        bool((openrouter_entry or {}).get("configured")),
+        str(openrouter_entry),
+    )
+
+    candidates: List[Tuple[str, str, str]] = [
+        ("openrouter", "openrouter_api_keys_settings", config.openrouter_model),
+        ("openai", "openai_api_keys_settings", config.openai_model),
+    ]
+
+    for provider_id, settings_id, model in candidates:
+        entry = provider_map.get(provider_id)
+        if not isinstance(entry, dict) or not bool(entry.get("configured")):
+            scenario["skipped"].append(
+                {
+                    "provider": provider_id,
+                    "reason": "not_configured",
+                    "configured": bool(entry.get("configured")) if isinstance(entry, dict) else False,
+                }
+            )
+            continue
+
+        server_id = str(entry.get("default_server_id") or "").strip()
+        if not server_id:
+            if provider_id == "openrouter":
+                server_id = "openrouter_default_server"
+            elif provider_id == "openai":
+                server_id = "openai_default_server"
+
+        route_status, route_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=provider_id,
+                settings_id=settings_id,
+                server_id=server_id,
+                model=model,
+                user_id=user_id,
+                message="List one markdown path in life/finances before answering in one sentence.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="life/finances",
+                mcp_project_name="Finances",
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                },
+            ),
+        )
+        route_state = route_response.get("tooling_state") if isinstance(route_response, dict) else {}
+        route_ok = (
+            route_status == 200
+            and isinstance(route_state, dict)
+            and bool(str(route_state.get("tool_routing_mode") or "").strip())
+            and bool(str(route_state.get("tool_execution_mode") or "").strip())
+        )
+
+        citation_status, citation_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=provider_id,
+                settings_id=settings_id,
+                server_id=server_id,
+                model=model,
+                user_id=user_id,
+                message="Which markdown file in life/finances mentions '(to be populated during onboarding)'? include sources.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="life/finances",
+                mcp_project_name="Finances",
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                },
+            ),
+        )
+        citation_text = str(((citation_response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        citation_state = citation_response.get("tooling_state") if isinstance(citation_response, dict) else {}
+        citations = citation_state.get("response_citations") if isinstance(citation_state, dict) else None
+        citation_ok = (
+            citation_status == 200
+            and (
+                "sources:" in citation_text.lower()
+                or "sources\n" in citation_text.lower()
+                or (isinstance(citations, list) and len(citations) > 0)
+                or ".md" in citation_text.lower()
+            )
+        )
+
+        native_status, native_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=provider_id,
+                settings_id=settings_id,
+                server_id=server_id,
+                model=model,
+                user_id=user_id,
+                message="Read life/finances context and answer briefly.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="life/finances",
+                mcp_project_name="Finances",
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                    "mcp_native_tool_calling": True,
+                },
+            ),
+        )
+        native_state = native_response.get("tooling_state") if isinstance(native_response, dict) else {}
+        native_ok = (
+            native_status == 200
+            and isinstance(native_state, dict)
+            and bool(str(native_state.get("tool_routing_mode") or "").strip())
+            and bool(str(native_state.get("routing_capability_source") or "").strip())
+        )
+
+        scenario["runtime_matrix"].append(
+            {
+                "provider": provider_id,
+                "settings_id": settings_id,
+                "server_id": server_id,
+                "model": model,
+                "routing_probe": {
+                    "status": route_status,
+                    "ok": route_ok,
+                    "tooling_state": route_state,
+                },
+                "citation_probe": {
+                    "status": citation_status,
+                    "ok": citation_ok,
+                    "response_citations": citations,
+                    "has_sources_block": "sources:" in citation_text.lower() or "sources\n" in citation_text.lower(),
+                    "text_excerpt": citation_text[:400],
+                },
+                "native_override_probe": {
+                    "status": native_status,
+                    "ok": native_ok,
+                    "tooling_state": native_state,
+                },
+            }
+        )
+
+    openrouter_rows = [row for row in scenario["runtime_matrix"] if row.get("provider") == "openrouter"]
+    _assert(summary, "o3_openrouter_runtime_row_present", len(openrouter_rows) >= 1, str(scenario["runtime_matrix"]))
+
+    openrouter_pass = any(
+        bool(row.get("routing_probe", {}).get("ok"))
+        and bool(row.get("citation_probe", {}).get("ok"))
+        and bool(row.get("native_override_probe", {}).get("ok"))
+        for row in openrouter_rows
+    )
+    _assert(summary, "o3_openrouter_runtime_pass", openrouter_pass, str(openrouter_rows))
+
+    any_external_pass = any(
+        bool(row.get("routing_probe", {}).get("ok")) and bool(row.get("citation_probe", {}).get("ok"))
+        for row in scenario["runtime_matrix"]
+        if str(row.get("provider") or "") in {"openrouter", "openai"}
+    )
+    _assert(summary, "o3_external_runtime_matrix_has_pass", any_external_pass, str(scenario["runtime_matrix"]))
+
+    policy_cmd = [
+        "/home/hacker/anaconda3/envs/BrainDriveDev/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_mcp_chat_gating.py",
+        "-k",
+        "other_native_providers_default_to_single_path or model_hint_promotes_unknown_provider_to_native_mode",
+    ]
+    policy_completed = subprocess.run(
+        policy_cmd,
+        cwd=str(Path(__file__).resolve().parents[1] / "backend"),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    scenario["policy_regression"] = {
+        "command": " ".join(policy_cmd),
+        "returncode": policy_completed.returncode,
+        "stdout_tail": policy_completed.stdout[-2000:],
+        "stderr_tail": policy_completed.stderr[-1000:],
+    }
+    _assert(summary, "o3_policy_regression_pass", policy_completed.returncode == 0, policy_completed.stdout[-800:])
+
+    citation_cmd = [
+        "/home/hacker/anaconda3/envs/BrainDriveDev/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_mcp_tool_loop.py",
+        "tests/test_mcp_stream_tool_loop.py",
+        "-k",
+        "question_response_appends_grounded_sources",
+    ]
+    citation_completed = subprocess.run(
+        citation_cmd,
+        cwd=str(Path(__file__).resolve().parents[1] / "backend"),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    scenario["citation_regression"] = {
+        "command": " ".join(citation_cmd),
+        "returncode": citation_completed.returncode,
+        "stdout_tail": citation_completed.stdout[-2000:],
+        "stderr_tail": citation_completed.stderr[-1000:],
+    }
+    _assert(summary, "o3_citation_regression_pass", citation_completed.returncode == 0, citation_completed.stdout[-800:])
+
+    return scenario
+
+
+def _serialize_summary(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {
+                "name": assertion.name,
+                "passed": assertion.passed,
+                "detail": assertion.detail,
+            }
+            for assertion in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> Config:
+    parser = argparse.ArgumentParser(description="Live Process O.1/O.3 harness")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_servers_settings")
+    parser.add_argument("--server-id", default="ollama_default_server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--openrouter-model", default="openai/gpt-4o-mini")
+    parser.add_argument("--openai-model", default="qwen3:8b")
+    parser.add_argument("--output-dir", default="tmp/live-process-o13")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=0.8)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=1.5)
+    parser.add_argument("--soak-iterations", type=int, default=16)
+    parser.add_argument("--reset-from-template", action="store_true")
+    parser.add_argument("--skip-o1", action="store_true")
+    parser.add_argument("--skip-o3", action="store_true")
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args(argv)
+    return Config(
+        base_url=str(args.base_url),
+        email=str(args.email),
+        password=str(args.password),
+        provider=str(args.provider),
+        settings_id=str(args.settings_id),
+        server_id=str(args.server_id),
+        model=str(args.model),
+        openrouter_model=str(args.openrouter_model),
+        openai_model=str(args.openai_model),
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=max(10, int(args.timeout_seconds)),
+        request_delay_seconds=max(0.0, float(args.request_delay_seconds)),
+        http_max_retries=max(0, int(args.http_max_retries)),
+        http_retry_base_seconds=max(0.1, float(args.http_retry_base_seconds)),
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+        soak_iterations=max(12, int(args.soak_iterations)),
+        skip_o1=bool(args.skip_o1),
+        skip_o3=bool(args.skip_o3),
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    config = _parse_args(argv)
+    if config.skip_o1 and config.skip_o3:
+        raise SystemExit("At least one of O.1 or O.3 must run (remove one skip flag).")
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    started_at = dt.datetime.now(dt.timezone.utc).isoformat()
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=started_at,
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap
+
+        if config.skip_o1:
+            summary.scenarios["process_o1"] = {"skipped": True}
+        else:
+            summary.scenarios["process_o1"] = _run_o1(summary, config, token, user_id)
+
+        if config.skip_o3:
+            summary.scenarios["process_o3"] = {"skipped": True}
+        else:
+            summary.scenarios["process_o3"] = _run_o3(summary, config, token, user_id)
+
+        summary.success = all(assertion.passed for assertion in summary.assertions)
+    except Exception as exc:
+        summary.success = False
+        summary.error = str(exc)
+
+    output_path = run_dir / "summary.json"
+    output_path.write_text(
+        json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2))
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_o2_browser.ts
+++ b/scripts/e2e_process_o2_browser.ts
@@ -1,0 +1,418 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { connect, waitForPageLoad } from "/home/hacker/.codex/skills/dev-browser/src/client.ts";
+
+type Assertion = {
+  name: string;
+  passed: boolean;
+  detail?: unknown;
+};
+
+type Summary = {
+  process: "O2";
+  run_id: string;
+  started_at: string;
+  base_url: string;
+  assertions: Assertion[];
+  screenshots: string[];
+  success: boolean;
+  error?: string;
+};
+
+function argValue(name: string, fallback: string): string {
+  const idx = process.argv.indexOf(name);
+  if (idx >= 0 && idx + 1 < process.argv.length) {
+    return process.argv[idx + 1] ?? fallback;
+  }
+  return fallback;
+}
+
+function assertPush(summary: Summary, name: string, passed: boolean, detail?: unknown): void {
+  summary.assertions.push({ name, passed, detail });
+  if (!passed) {
+    throw new Error(`Assertion failed: ${name} :: ${JSON.stringify(detail ?? null)}`);
+  }
+}
+
+async function waitForVisible(
+  page: import("playwright").Page,
+  selectors: string[],
+  timeoutMs = 60000
+): Promise<boolean> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    for (const selector of selectors) {
+      const count = await page.locator(selector).count();
+      if (count > 0) {
+        const visible = await page.locator(selector).first().isVisible().catch(() => false);
+        if (visible) {
+          return true;
+        }
+      }
+    }
+    await page.waitForTimeout(250);
+  }
+  return false;
+}
+
+async function waitForPromptInput(page: import("playwright").Page, timeoutMs = 90000): Promise<boolean> {
+  const selectors = [
+    'textarea[placeholder="What would you like to know?"]',
+    'input[placeholder="What would you like to know?"]',
+  ];
+  return waitForVisible(page, selectors, timeoutMs);
+}
+
+async function navigateToPage(
+  page: import("playwright").Page,
+  baseUrl: string,
+  route: string,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await page.goto(`${baseUrl}${route}`);
+  await waitForPageLoad(page, { timeout: 45000 });
+  const inputReady = await waitForPromptInput(page, 120000);
+  assertPush(summary, `${prefix}_input_ready`, inputReady, { route, url: page.url() });
+  assertPush(summary, `${prefix}_route_ok`, page.url().includes(route), { route, url: page.url() });
+}
+
+async function ensureModelSelected(
+  page: import("playwright").Page,
+  summary: Summary,
+  modelHint: string
+): Promise<void> {
+  if (!modelHint.trim()) {
+    return;
+  }
+
+  const trigger = page.locator(".header-model-section .searchable-dropdown-trigger").first();
+  assertPush(summary, "o2_model_trigger_present", (await trigger.count()) > 0);
+
+  const currentText = ((await trigger.textContent()) ?? "").toLowerCase();
+  if (currentText.includes(modelHint.toLowerCase())) {
+    assertPush(summary, "o2_model_selected", true, { model_hint: modelHint, selected: currentText });
+    return;
+  }
+
+  await trigger.click();
+  const input = page.locator(".header-model-section .searchable-dropdown-input").first();
+  assertPush(summary, "o2_model_search_present", (await input.count()) > 0);
+  await input.fill(modelHint);
+  await input.press("Enter");
+  await page.waitForTimeout(2500);
+
+  const updatedText = ((await trigger.textContent()) ?? "").toLowerCase();
+  assertPush(summary, "o2_model_selected", updatedText.includes(modelHint.toLowerCase()), {
+    model_hint: modelHint,
+    selected: updatedText,
+  });
+}
+
+async function startFreshConversation(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const historyValue = page.locator(".header-history-section .searchable-dropdown-value").first();
+  assertPush(summary, `${prefix}_history_value_present`, (await historyValue.count()) > 0);
+
+  const button = page.locator('button[title="Start New Chat"]').first();
+  assertPush(summary, `${prefix}_new_chat_button_present`, (await button.count()) > 0);
+  await button.click();
+  await page.waitForTimeout(1200);
+
+  let historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  if (!/start new chat/i.test(historyLabel)) {
+    const historyTrigger = page.locator(".header-history-section .searchable-dropdown-trigger").first();
+    assertPush(summary, `${prefix}_history_trigger_present`, (await historyTrigger.count()) > 0);
+    await historyTrigger.click();
+    const startNewOption = page.locator(".searchable-dropdown-option:has-text('Start New Chat')").first();
+    assertPush(summary, `${prefix}_history_start_new_option_present`, (await startNewOption.count()) > 0);
+    await startNewOption.click();
+    await page.waitForTimeout(1200);
+    historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  }
+  assertPush(summary, `${prefix}_history_start_new_selected`, /start new chat/i.test(historyLabel), {
+    history_label: historyLabel,
+  });
+
+  const inputReady = await waitForPromptInput(page, 60000);
+  assertPush(summary, `${prefix}_new_chat_ready`, inputReady);
+}
+
+async function ensureLoginIfNeeded(
+  page: import("playwright").Page,
+  email: string,
+  password: string,
+  summary: Summary
+): Promise<void> {
+  const maxAttempts = 4;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const passwordInput = page.locator('input[type="password"]');
+    const needsLogin = page.url().includes("/login") || (await passwordInput.count()) > 0;
+    if (!needsLogin) {
+      return;
+    }
+
+    const emailInput = page.locator('input[type="email"], input[name="email"]');
+    assertPush(summary, `o2_login_email_input_present_attempt_${attempt}`, (await emailInput.count()) > 0);
+
+    await emailInput.first().fill(email);
+    await passwordInput.first().fill(password);
+
+    const submitCandidates = [
+      page.getByRole("button", { name: /sign in|login|log in/i }),
+      page.locator('button[type="submit"]'),
+    ];
+
+    let clicked = false;
+    for (const candidate of submitCandidates) {
+      const count = await candidate.count();
+      if (count > 0) {
+        await candidate.first().click();
+        clicked = true;
+        break;
+      }
+    }
+    assertPush(summary, `o2_login_submit_clicked_attempt_${attempt}`, clicked);
+
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2500 + attempt * 1000);
+    if (!page.url().includes("/login")) {
+      assertPush(summary, "o2_login_redirected", true, { url: page.url(), attempt });
+      return;
+    }
+  }
+
+  assertPush(summary, "o2_login_redirected", false, { url: page.url() });
+}
+
+async function sendPrompt(
+  page: import("playwright").Page,
+  prompt: string,
+  summary: Summary,
+  prefix: string
+): Promise<{ elapsedMs: number; pendingVisible: boolean }> {
+  const inputReady = await waitForPromptInput(page, 90000);
+  assertPush(summary, `${prefix}_input_present`, inputReady);
+
+  const input = page.locator(
+    'textarea[placeholder="What would you like to know?"], input[placeholder="What would you like to know?"]'
+  );
+  assertPush(summary, `${prefix}_input_locator_present`, (await input.count()) > 0);
+  await input.first().fill(prompt);
+
+  const pendingLocator = page.locator("text=PENDING");
+  const approvalCopyLocator = page.locator("text=Approval required to run mutating tool");
+  const pendingBaseline = await pendingLocator.count();
+  const approvalCopyBaseline = await approvalCopyLocator.count();
+
+  const sendCandidates = [
+    page.getByRole("button", { name: /send message/i }),
+    page.locator('button[aria-label="Send message"]'),
+  ];
+
+  let sent = false;
+  for (const candidate of sendCandidates) {
+    const count = await candidate.count();
+    if (count > 0) {
+      await candidate.first().click();
+      sent = true;
+      break;
+    }
+  }
+  assertPush(summary, `${prefix}_send_clicked`, sent);
+
+  const start = Date.now();
+  let pendingVisible = false;
+  const deadline = Date.now() + 65000;
+  while (Date.now() < deadline) {
+    const pendingCount = await pendingLocator.count();
+    const approvalCopyCount = await approvalCopyLocator.count();
+    if (pendingCount > pendingBaseline || approvalCopyCount > approvalCopyBaseline) {
+      pendingVisible = true;
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  const elapsed = Date.now() - start;
+  assertPush(summary, `${prefix}_pending_visible`, pendingVisible, {
+    elapsed_ms: elapsed,
+    pending_visible: pendingVisible,
+  });
+  if (pendingVisible) {
+    assertPush(summary, `${prefix}_approval_latency_under_60s`, elapsed <= 60000, { elapsed_ms: elapsed });
+  }
+
+  if (pendingVisible) {
+    const copyVisible = await waitForVisible(page, ["text=Approval required to run mutating tool"], 10000);
+    assertPush(summary, `${prefix}_approval_copy_visible`, copyVisible);
+  }
+
+  return { elapsedMs: elapsed, pendingVisible };
+}
+
+async function clickStrictApprovalButton(
+  page: import("playwright").Page,
+  buttonName: "Approve" | "Reject",
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const buttons = page.getByRole("button", { name: new RegExp(`^${buttonName}$`, "i") });
+  const deadline = Date.now() + 20000;
+  let visibleIndexes: number[] = [];
+
+  while (Date.now() < deadline) {
+    const count = await buttons.count();
+    visibleIndexes = [];
+    for (let idx = 0; idx < count; idx += 1) {
+      const visible = await buttons.nth(idx).isVisible().catch(() => false);
+      if (visible) {
+        visibleIndexes.push(idx);
+      }
+    }
+    if (visibleIndexes.length > 0) {
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_visible`, visibleIndexes.length > 0, {
+    visible_count: visibleIndexes.length,
+  });
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_unique`, visibleIndexes.length === 1, {
+    visible_count: visibleIndexes.length,
+  });
+
+  const targetIndex = visibleIndexes[visibleIndexes.length - 1] ?? 0;
+  await buttons.nth(targetIndex).click();
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_clicked`, true, { index: targetIndex });
+}
+
+async function resolveRejectSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Reject", summary, prefix);
+  const rejectOutcome = await waitForVisible(
+    page,
+    ["text=REJECTED", "text=did not run mutating tool", "text=Task creation was rejected"],
+    45000
+  );
+  assertPush(summary, `${prefix}_reject_semantics`, rejectOutcome);
+}
+
+async function resolveApproveSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Approve", summary, prefix);
+  const approveOutcome = await waitForVisible(
+    page,
+    ["text=APPROVED", "text=newly created task", "text=successfully saved", "text=Task ID"],
+    45000
+  );
+  assertPush(summary, `${prefix}_approve_semantics`, approveOutcome);
+}
+
+async function main(): Promise<void> {
+  const baseUrl = argValue("--base-url", "http://localhost:5173").replace(/\/$/, "");
+  const email = argValue("--email", "cccc@gmail.com");
+  const password = argValue("--password", "10012002");
+  const modelHint = argValue("--model-hint", "qwen3:8b");
+  const outputDir = argValue("--output-dir", "/home/hacker/BrainDriveDev/BrainDrive/tmp/live-process-o2-browser");
+
+  const runId = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+  const summary: Summary = {
+    process: "O2",
+    run_id: runId,
+    started_at: new Date().toISOString(),
+    base_url: baseUrl,
+    assertions: [],
+    screenshots: [],
+    success: false,
+  };
+
+  const artifactDir = path.resolve(outputDir);
+  await mkdir(artifactDir, { recursive: true });
+
+  const client = await connect();
+  const page = await client.page("process-o2", { viewport: { width: 1440, height: 1000 } });
+
+  try {
+    await page.goto(`${baseUrl}/dashboard`);
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2000);
+
+    await ensureLoginIfNeeded(page, email, password, summary);
+    assertPush(summary, "o2_session_ready", true, { url: page.url() });
+
+    await navigateToPage(page, baseUrl, "/pages/finances", summary, "o2_finances_preflight");
+    await ensureModelSelected(page, summary, modelHint);
+    await startFreshConversation(page, summary, "o2_finances_reject");
+
+    const rejectPrompt = `[LIBRARY SCOPE - Life / finances] Create a task O2 reject ${runId} due 2026-03-22 for Dave J.`;
+    await sendPrompt(page, rejectPrompt, summary, "o2_finances_reject");
+
+    await resolveRejectSemantics(page, summary, "o2_finances");
+
+    await startFreshConversation(page, summary, "o2_finances_approve");
+    const approvePrompt = `[LIBRARY SCOPE - Life / finances] Create a task O2 approve ${runId} due 2026-03-23 for Dave J.`;
+    await sendPrompt(page, approvePrompt, summary, "o2_finances_approve");
+
+    await resolveApproveSemantics(page, summary, "o2_finances");
+
+    await navigateToPage(page, baseUrl, "/pages/ai-chat", summary, "o2_ai_chat_preflight");
+    await ensureModelSelected(page, summary, modelHint);
+    await startFreshConversation(page, summary, "o2_ai_chat_reject");
+
+    const aiRejectPrompt = `[LIBRARY SCOPE - Life / finances] Create a task O2 ai-chat reject ${runId} due 2026-03-24 for Dave J.`;
+    await sendPrompt(page, aiRejectPrompt, summary, "o2_ai_chat_reject");
+    await resolveRejectSemantics(page, summary, "o2_ai_chat");
+
+    await startFreshConversation(page, summary, "o2_ai_chat_approve");
+    const aiApprovePrompt = `[LIBRARY SCOPE - Life / finances] Create a task O2 ai-chat approve ${runId} due 2026-03-25 for Dave J.`;
+    await sendPrompt(page, aiApprovePrompt, summary, "o2_ai_chat_approve");
+    await resolveApproveSemantics(page, summary, "o2_ai_chat");
+
+    await navigateToPage(page, baseUrl, "/pages/fitness", summary, "o2_fitness_preflight");
+    await ensureModelSelected(page, summary, modelHint);
+    await startFreshConversation(page, summary, "o2_fitness_reject");
+    const fitnessPrompt = `[LIBRARY SCOPE - Life / finances] Create a task O2 fitness reject ${runId} due 2026-03-26 for Dave J.`;
+    await sendPrompt(page, fitnessPrompt, summary, "o2_fitness_reject");
+    await resolveRejectSemantics(page, summary, "o2_fitness");
+
+    const screenshotPath = path.resolve(artifactDir, `o2-browser-${runId}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    summary.screenshots.push(screenshotPath);
+
+    summary.success = summary.assertions.every((a) => a.passed);
+  } catch (error) {
+    summary.success = false;
+    summary.error = error instanceof Error ? error.message : String(error);
+    const errorShot = path.resolve(artifactDir, `o2-browser-${runId}-error.png`);
+    try {
+      await page.screenshot({ path: errorShot, fullPage: true });
+      summary.screenshots.push(errorShot);
+    } catch {
+      // ignore
+    }
+  } finally {
+    const outPath = path.resolve(artifactDir, `o2-browser-${runId}.json`);
+    await writeFile(outPath, JSON.stringify(summary, null, 2) + "\n", "utf-8");
+    console.log(JSON.stringify(summary, null, 2));
+    await client.disconnect();
+  }
+
+  if (!summary.success) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/e2e_process_q1_q3.py
+++ b/scripts/e2e_process_q1_q3.py
@@ -1,0 +1,1222 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process Q.1 and Q.3.
+
+Q.1: VS-12/TR-4/VS-6 non-local delivery soak closure.
+Q.3: TR-3/TR-5/VS-4 external provider-family runtime expansion.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import shutil
+import subprocess
+import sys
+import threading
+import time
+from dataclasses import dataclass, field
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+from urllib.parse import urlparse
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    access_token: Optional[str]
+    user_id: Optional[str]
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    openrouter_model: str
+    openai_model: str
+    claude_model: str
+    groq_model: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+    soak_iterations: int
+    delivery_email_endpoint: Optional[str]
+    delivery_slack_endpoint: Optional[str]
+    require_non_local_delivery: bool
+    skip_o1: bool
+    skip_o3: bool
+
+
+@dataclass
+class LocalWebhookServer:
+    server: ThreadingHTTPServer
+    thread: threading.Thread
+    records: List[Dict[str, Any]]
+    base_url: str
+
+    def shutdown(self) -> None:
+        self.server.shutdown()
+        self.server.server_close()
+        self.thread.join(timeout=5)
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _decode_json_bytes(raw: bytes) -> Dict[str, Any]:
+    text = raw.decode("utf-8", errors="replace")
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return {"raw": text}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"data": parsed}
+
+
+def _is_local_endpoint(url: str) -> bool:
+    try:
+        parsed = urlparse(url)
+    except Exception:
+        return True
+    host = (parsed.hostname or "").strip().lower()
+    if not host:
+        return True
+    if host in {"localhost", "127.0.0.1", "::1"}:
+        return True
+    if host.startswith("127."):
+        return True
+    if host.endswith(".local"):
+        return True
+    return False
+
+
+def _provider_default_model(config: Config, provider_id: str) -> str:
+    defaults = {
+        "openrouter": config.openrouter_model,
+        "openai": config.openai_model,
+        "claude": config.claude_model,
+        "groq": config.groq_model,
+    }
+    return str(defaults.get(provider_id, "") or "").strip()
+
+
+def _throttle(request_delay_seconds: float) -> None:
+    global _LAST_REQUEST_SENT_MONOTONIC
+    if request_delay_seconds <= 0:
+        return
+    now = time.monotonic()
+    if _LAST_REQUEST_SENT_MONOTONIC is not None:
+        elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+        if elapsed < request_delay_seconds:
+            time.sleep(request_delay_seconds - elapsed)
+    _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+
+def _http_json(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    body: Optional[bytes] = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=body, headers=headers, method=method.upper())
+        try:
+            _throttle(request_delay_seconds)
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                return int(response.status), _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            parsed = _decode_json_bytes(exc.read())
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            return int(exc.code), parsed
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    status, response = _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    if status != 200:
+        raise RuntimeError(f"Login failed: status={status} response={response}")
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _build_chat_payload(
+    *,
+    provider: str,
+    settings_id: str,
+    server_id: str,
+    model: str,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 6,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": provider,
+        "settings_id": settings_id,
+        "server_id": server_id,
+        "model": model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+    return _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _approve_pending_request(
+    *,
+    config: Config,
+    token: str,
+    base_payload: Dict[str, Any],
+    conversation_id: str,
+    request_id: str,
+    action: str,
+) -> Tuple[int, Dict[str, Any]]:
+    payload = dict(base_payload)
+    payload["conversation_id"] = conversation_id
+    payload["messages"] = [{"role": "user", "content": action}]
+    params = dict(payload.get("params") or {})
+    params["mcp_approval"] = {"action": action, "request_id": request_id}
+    payload["params"] = params
+    return _chat(config, token, payload)
+
+
+def _start_local_webhook_server() -> LocalWebhookServer:
+    records: List[Dict[str, Any]] = []
+
+    class _Handler(BaseHTTPRequestHandler):
+        def do_POST(self):  # noqa: N802
+            content_length = int(self.headers.get("Content-Length", "0") or 0)
+            raw = self.rfile.read(content_length).decode("utf-8", errors="replace")
+            try:
+                payload = json.loads(raw) if raw.strip() else {}
+            except Exception:
+                payload = {"_raw": raw}
+
+            records.append(
+                {
+                    "path": self.path,
+                    "headers": {k: v for k, v in self.headers.items()},
+                    "payload": payload,
+                }
+            )
+
+            response = {"status": "accepted", "ack_id": f"ack-{len(records)}"}
+            encoded = json.dumps(response).encode("utf-8")
+            self.send_response(202)
+            self.send_header("Content-Type", "application/json")
+            self.send_header("Content-Length", str(len(encoded)))
+            self.end_headers()
+            self.wfile.write(encoded)
+
+        def log_message(self, format, *args):  # noqa: A003
+            return
+
+    server = ThreadingHTTPServer(("127.0.0.1", 0), _Handler)
+    host, port = server.server_address
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    return LocalWebhookServer(
+        server=server,
+        thread=thread,
+        records=records,
+        base_url=f"http://{host}:{port}",
+    )
+
+
+def _run_o1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {"iterations": config.soak_iterations}
+    webhook: Optional[LocalWebhookServer] = None
+
+    email_endpoint = str(config.delivery_email_endpoint or "").strip()
+    slack_endpoint = str(config.delivery_slack_endpoint or "").strip()
+    if email_endpoint and not slack_endpoint:
+        slack_endpoint = email_endpoint
+    if slack_endpoint and not email_endpoint:
+        email_endpoint = slack_endpoint
+
+    if not email_endpoint or not slack_endpoint:
+        webhook = _start_local_webhook_server()
+        email_endpoint = f"{webhook.base_url}/email"
+        slack_endpoint = f"{webhook.base_url}/slack"
+        scenario["delivery_mode"] = "local_webhook"
+        scenario["webhook_base_url"] = webhook.base_url
+    else:
+        scenario["delivery_mode"] = "non_local_configured"
+
+    scenario["delivery_endpoints"] = {
+        "email": email_endpoint,
+        "slack": slack_endpoint,
+        "email_is_local": _is_local_endpoint(email_endpoint),
+        "slack_is_local": _is_local_endpoint(slack_endpoint),
+    }
+
+    if config.require_non_local_delivery:
+        _assert(
+            summary,
+            "o1_email_endpoint_non_local",
+            not _is_local_endpoint(email_endpoint),
+            str(scenario["delivery_endpoints"]),
+        )
+        _assert(
+            summary,
+            "o1_slack_endpoint_non_local",
+            not _is_local_endpoint(slack_endpoint),
+            str(scenario["delivery_endpoints"]),
+        )
+
+    digest_email_runs: List[Dict[str, Any]] = []
+    digest_slack_runs: List[Dict[str, Any]] = []
+    pre_compaction_runs: List[Dict[str, Any]] = []
+    capture_runs: List[Dict[str, Any]] = []
+
+    digest_email_conversation_id: Optional[str] = None
+    digest_slack_conversation_id: Optional[str] = None
+    chat_conversation_id: Optional[str] = None
+    capture_conversation_id: Optional[str] = None
+
+    started_mono = time.monotonic()
+
+    try:
+        for index in range(config.soak_iterations):
+            pair = index // 2
+            email_event_id = f"o1-email-{pair}"
+            slack_event_id = f"o1-slack-{pair}"
+            pre_event_id = f"o1-pre-{pair}"
+
+            email_status, email_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=f"Process O.1 digest email iteration {index + 1}.",
+                    conversation_type="digest-email",
+                    mcp_scope_mode="none",
+                    conversation_id=digest_email_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_tool_profile": "read_only",
+                        "mcp_digest_schedule_enabled": True,
+                        "mcp_digest_force_run": True,
+                        "mcp_digest_schedule_event_id": email_event_id,
+                        "mcp_digest_delivery_send_enabled": True,
+                        "mcp_digest_delivery_endpoint": email_endpoint,
+                    },
+                ),
+            )
+            if digest_email_conversation_id is None:
+                digest_email_conversation_id = str(email_response.get("conversation_id") or "")
+            email_tooling = email_response.get("tooling_state") or {}
+            digest_email_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": email_event_id,
+                    "status_code": email_status,
+                    "digest_schedule_status": email_tooling.get("digest_schedule_status"),
+                    "digest_schedule_duplicate_guard": email_tooling.get("digest_schedule_duplicate_guard"),
+                    "delivery_send_status": email_tooling.get("digest_delivery_send_status"),
+                    "delivery_send_http_status": email_tooling.get("digest_delivery_send_http_status"),
+                    "delivery_channel": email_tooling.get("digest_delivery_channel"),
+                    "delivery_endpoint": email_endpoint,
+                }
+            )
+
+            slack_status, slack_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=f"Process O.1 digest slack iteration {index + 1}.",
+                    conversation_type="digest-slack",
+                    mcp_scope_mode="none",
+                    conversation_id=digest_slack_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_tool_profile": "read_only",
+                        "mcp_digest_schedule_enabled": True,
+                        "mcp_digest_force_run": True,
+                        "mcp_digest_schedule_event_id": slack_event_id,
+                        "mcp_digest_delivery_send_enabled": True,
+                        "mcp_digest_delivery_endpoint": slack_endpoint,
+                    },
+                ),
+            )
+            if digest_slack_conversation_id is None:
+                digest_slack_conversation_id = str(slack_response.get("conversation_id") or "")
+            slack_tooling = slack_response.get("tooling_state") or {}
+            digest_slack_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": slack_event_id,
+                    "status_code": slack_status,
+                    "digest_schedule_status": slack_tooling.get("digest_schedule_status"),
+                    "digest_schedule_duplicate_guard": slack_tooling.get("digest_schedule_duplicate_guard"),
+                    "delivery_send_status": slack_tooling.get("digest_delivery_send_status"),
+                    "delivery_send_http_status": slack_tooling.get("digest_delivery_send_http_status"),
+                    "delivery_channel": slack_tooling.get("digest_delivery_channel"),
+                    "delivery_endpoint": slack_endpoint,
+                }
+            )
+
+            long_message = " ".join(["o1-context-pressure"] * 320)
+            pre_status, pre_response = _chat(
+                config,
+                token,
+                _build_chat_payload(
+                    provider=config.provider,
+                    settings_id=config.settings_id,
+                    server_id=config.server_id,
+                    model=config.model,
+                    user_id=user_id,
+                    message=long_message,
+                    conversation_type="chat",
+                    mcp_scope_mode="none",
+                    conversation_id=chat_conversation_id,
+                    params_extra={
+                        "mcp_tools_enabled": False,
+                        "mcp_pre_compaction_flush_enabled": True,
+                        "mcp_context_window_tokens": 64,
+                        "mcp_pre_compaction_flush_threshold": 0.5,
+                        "mcp_pre_compaction_event_id": pre_event_id,
+                    },
+                ),
+            )
+            if chat_conversation_id is None:
+                chat_conversation_id = str(pre_response.get("conversation_id") or "")
+            pre_tooling = pre_response.get("tooling_state") or {}
+            pre_compaction_runs.append(
+                {
+                    "iteration": index + 1,
+                    "event_id": pre_event_id,
+                    "status_code": pre_status,
+                    "pre_compaction_flush_status": pre_tooling.get("pre_compaction_flush_status"),
+                    "pre_compaction_flush_duplicate_guard": pre_tooling.get("pre_compaction_flush_duplicate_guard"),
+                }
+            )
+
+            capture_payload = _build_chat_payload(
+                provider=config.provider,
+                settings_id=config.settings_id,
+                server_id=config.server_id,
+                model=config.model,
+                user_id=user_id,
+                message=f"Create task O1 iteration {index + 1}: reconcile finance notes by 2026-03-20 for Dave J.",
+                conversation_type="capture",
+                mcp_scope_mode="project",
+                mcp_project_slug="projects/active/finance",
+                mcp_project_name="Finance",
+                conversation_id=capture_conversation_id,
+                params_extra={"mcp_max_tool_iterations": 7},
+            )
+            cap_status, cap_response = _chat(config, token, capture_payload)
+            if capture_conversation_id is None:
+                capture_conversation_id = str(cap_response.get("conversation_id") or "")
+            capture_entry: Dict[str, Any] = {
+                "iteration": index + 1,
+                "status_code": cap_status,
+                "approval_required": cap_response.get("approval_required"),
+                "tooling_state": cap_response.get("tooling_state"),
+            }
+            if cap_response.get("approval_required") is True:
+                request = cap_response.get("approval_request") or {}
+                request_id = str(request.get("request_id") or "").strip()
+                if request_id:
+                    action = "approve" if index % 2 == 0 else "reject"
+                    resume_status, resume_response = _approve_pending_request(
+                        config=config,
+                        token=token,
+                        base_payload=capture_payload,
+                        conversation_id=str(cap_response.get("conversation_id") or ""),
+                        request_id=request_id,
+                        action=action,
+                    )
+                    capture_entry["approval_action"] = action
+                    capture_entry["approval_resume_status_code"] = resume_status
+                    capture_entry["approval_resolution"] = resume_response.get("approval_resolution")
+            capture_runs.append(capture_entry)
+
+        elapsed_seconds = round(time.monotonic() - started_mono, 3)
+
+        email_dup = sum(1 for row in digest_email_runs if str(row.get("digest_schedule_status") or "") == "duplicate_guard")
+        slack_dup = sum(1 for row in digest_slack_runs if str(row.get("digest_schedule_status") or "") == "duplicate_guard")
+        pre_dup = sum(
+            1
+            for row in pre_compaction_runs
+            if str(row.get("pre_compaction_flush_status") or "") == "duplicate_guard"
+        )
+        capture_resolved = sum(
+            1
+            for row in capture_runs
+            if str((row.get("approval_resolution") or {}).get("status") or "") in {"approved", "rejected"}
+        )
+        email_sent = sum(1 for row in digest_email_runs if str(row.get("delivery_send_status") or "") == "sent")
+        slack_sent = sum(1 for row in digest_slack_runs if str(row.get("delivery_send_status") or "") == "sent")
+        email_hits = (
+            sum(1 for rec in webhook.records if str(rec.get("path") or "").startswith("/email"))
+            if webhook
+            else None
+        )
+        slack_hits = (
+            sum(1 for rec in webhook.records if str(rec.get("path") or "").startswith("/slack"))
+            if webhook
+            else None
+        )
+
+        scenario["digest_email_runs"] = digest_email_runs
+        scenario["digest_slack_runs"] = digest_slack_runs
+        scenario["pre_compaction_runs"] = pre_compaction_runs
+        scenario["capture_runs"] = capture_runs
+        scenario["aggregate"] = {
+            "elapsed_seconds": elapsed_seconds,
+            "email_duplicate_guard_count": email_dup,
+            "slack_duplicate_guard_count": slack_dup,
+            "pre_compaction_duplicate_guard_count": pre_dup,
+            "capture_resolved_count": capture_resolved,
+            "email_send_count": email_sent,
+            "slack_send_count": slack_sent,
+            "email_webhook_hits": email_hits,
+            "slack_webhook_hits": slack_hits,
+        }
+
+        min_dup_expected = max(2, config.soak_iterations // 6)
+        min_resolution_expected = max(3, config.soak_iterations // 3)
+        min_delivery_expected = max(4, config.soak_iterations // 3)
+
+        _assert(summary, "o1_email_duplicate_guard_seen", email_dup >= min_dup_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_slack_duplicate_guard_seen", slack_dup >= min_dup_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_pre_compaction_duplicate_guard_seen", pre_dup >= min_dup_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_capture_resolution_seen", capture_resolved >= min_resolution_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_email_delivery_seen", email_sent >= min_delivery_expected, str(scenario["aggregate"]))
+        _assert(summary, "o1_slack_delivery_seen", slack_sent >= min_delivery_expected, str(scenario["aggregate"]))
+        if webhook:
+            _assert(
+                summary,
+                "o1_email_webhook_hits_seen",
+                int(email_hits or 0) >= min_delivery_expected,
+                str(scenario["aggregate"]),
+            )
+            _assert(
+                summary,
+                "o1_slack_webhook_hits_seen",
+                int(slack_hits or 0) >= min_delivery_expected,
+                str(scenario["aggregate"]),
+            )
+        else:
+            _assert(
+                summary,
+                "o1_non_local_delivery_mode",
+                str(scenario.get("delivery_mode")) == "non_local_configured",
+                str(scenario.get("delivery_mode")),
+            )
+
+        return scenario
+    finally:
+        if webhook:
+            webhook.shutdown()
+
+
+def _run_o3(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {
+        "catalog": {},
+        "runtime_matrix": [],
+        "skipped": [],
+        "provider_classification": {},
+    }
+
+    cat_status, cat_response = _http_json(
+        method="GET",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/catalog?user_id=current",
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+    _assert(summary, "o3_catalog_status_200", cat_status == 200, str(cat_response))
+
+    providers = cat_response.get("providers") if isinstance(cat_response, dict) else []
+    _assert(summary, "o3_catalog_has_providers", isinstance(providers, list) and len(providers) >= 1, str(cat_response))
+
+    scenario["catalog"] = {
+        "status": cat_status,
+        "providers": providers,
+    }
+
+    provider_map: Dict[str, Dict[str, Any]] = {}
+    for entry in providers if isinstance(providers, list) else []:
+        if isinstance(entry, dict):
+            provider_map[str(entry.get("id") or "").strip()] = entry
+
+    def _select_settings_value(rows: List[Dict[str, Any]]) -> Dict[str, Any]:
+        if not rows:
+            return {}
+        prioritized: List[Dict[str, Any]] = []
+        fallback: List[Dict[str, Any]] = []
+        for row in rows:
+            if not isinstance(row, dict):
+                continue
+            value = row.get("value")
+            if not isinstance(value, dict):
+                continue
+            keys = {str(k) for k in value.keys()}
+            if {"base_url", "baseUrl"} & keys:
+                prioritized.append(value)
+            else:
+                fallback.append(value)
+        if prioritized:
+            return prioritized[0]
+        if fallback:
+            return fallback[0]
+        return {}
+
+    def _load_provider_setting_value(settings_id: str) -> Dict[str, Any]:
+        if not settings_id:
+            return {}
+        query_variants = [
+            f"?definition_id={settings_id}&scope=user&user_id=current",
+            f"?definition_id={settings_id}&scope=USER&user_id=current",
+            f"?definition_id={settings_id}&user_id=current",
+        ]
+        for query in query_variants:
+            st, resp = _http_json(
+                method="GET",
+                url=f"{config.base_url.rstrip('/')}/api/v1/settings/instances{query}",
+                timeout_seconds=config.timeout_seconds,
+                request_delay_seconds=config.request_delay_seconds,
+                max_retries=config.http_max_retries,
+                retry_base_seconds=config.http_retry_base_seconds,
+                token=token,
+            )
+            if st != 200 or not isinstance(resp, list) or len(resp) == 0:
+                continue
+            rows = [row for row in resp if isinstance(row, dict)]
+            selected = _select_settings_value(rows)
+            if selected:
+                return selected
+        return {}
+
+    for provider_id in ["openrouter", "openai", "claude", "groq"]:
+        entry = provider_map.get(provider_id) or {}
+        configured = bool(entry.get("configured")) if isinstance(entry, dict) else False
+        settings_id = str(entry.get("settings_id") or "").strip() if isinstance(entry, dict) else ""
+        setting_value = _load_provider_setting_value(settings_id) if configured else {}
+        base_url = str(setting_value.get("base_url") or setting_value.get("baseUrl") or "").strip()
+        if provider_id == "openai":
+            is_external_family = bool(base_url) and not _is_local_endpoint(base_url)
+        elif provider_id in {"openrouter", "claude", "groq"}:
+            is_external_family = configured
+            if base_url:
+                is_external_family = not _is_local_endpoint(base_url)
+        else:
+            is_external_family = False
+        scenario["provider_classification"][provider_id] = {
+            "configured": configured,
+            "settings_id": settings_id,
+            "base_url": base_url or None,
+            "is_external_family": bool(is_external_family),
+        }
+
+    openrouter_entry = provider_map.get("openrouter")
+    _assert(summary, "o3_openrouter_visible", isinstance(openrouter_entry, dict), str(providers))
+    _assert(
+        summary,
+        "o3_openrouter_configured",
+        bool((openrouter_entry or {}).get("configured")),
+        str(openrouter_entry),
+    )
+
+    candidate_provider_ids = ["openrouter", "openai", "claude", "groq"]
+    candidates: List[Tuple[str, str, str]] = []
+    for provider_id in candidate_provider_ids:
+        entry = provider_map.get(provider_id)
+        settings_id = ""
+        if isinstance(entry, dict):
+            settings_id = str(entry.get("settings_id") or "").strip()
+        if not settings_id:
+            fallback_settings = {
+                "openrouter": "openrouter_api_keys_settings",
+                "openai": "openai_api_keys_settings",
+                "claude": "claude_api_keys_settings",
+                "groq": "groq_api_keys_settings",
+            }
+            settings_id = fallback_settings.get(provider_id, "")
+        model = _provider_default_model(config, provider_id)
+        candidates.append((provider_id, settings_id, model))
+
+    for provider_id, settings_id, model in candidates:
+        entry = provider_map.get(provider_id)
+        if not isinstance(entry, dict) or not bool(entry.get("configured")):
+            scenario["skipped"].append(
+                {
+                    "provider": provider_id,
+                    "reason": "not_configured",
+                    "configured": bool(entry.get("configured")) if isinstance(entry, dict) else False,
+                }
+            )
+            continue
+        if not model:
+            scenario["skipped"].append(
+                {
+                    "provider": provider_id,
+                    "reason": "missing_model",
+                    "configured": True,
+                }
+            )
+            continue
+
+        server_id = str(entry.get("default_server_id") or "").strip()
+        if not server_id:
+            if provider_id == "openrouter":
+                server_id = "openrouter_default_server"
+            elif provider_id == "openai":
+                server_id = "openai_default_server"
+            elif provider_id == "claude":
+                server_id = "claude_default_server"
+            elif provider_id == "groq":
+                server_id = "groq_default_server"
+
+        route_status, route_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=provider_id,
+                settings_id=settings_id,
+                server_id=server_id,
+                model=model,
+                user_id=user_id,
+                message="List one markdown path in life/finances before answering in one sentence.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="life/finances",
+                mcp_project_name="Finances",
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                },
+            ),
+        )
+        route_state = route_response.get("tooling_state") if isinstance(route_response, dict) else {}
+        route_ok = (
+            route_status == 200
+            and isinstance(route_state, dict)
+            and bool(str(route_state.get("tool_routing_mode") or "").strip())
+            and bool(str(route_state.get("tool_execution_mode") or "").strip())
+        )
+
+        citation_status, citation_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=provider_id,
+                settings_id=settings_id,
+                server_id=server_id,
+                model=model,
+                user_id=user_id,
+                message="Which markdown file in life/finances mentions '(to be populated during onboarding)'? include sources.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="life/finances",
+                mcp_project_name="Finances",
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                },
+            ),
+        )
+        citation_text = str(((citation_response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+        citation_state = citation_response.get("tooling_state") if isinstance(citation_response, dict) else {}
+        citations = citation_state.get("response_citations") if isinstance(citation_state, dict) else None
+        citation_ok = (
+            citation_status == 200
+            and (
+                "sources:" in citation_text.lower()
+                or "sources\n" in citation_text.lower()
+                or (isinstance(citations, list) and len(citations) > 0)
+                or ".md" in citation_text.lower()
+            )
+        )
+
+        native_status, native_response = _chat(
+            config,
+            token,
+            _build_chat_payload(
+                provider=provider_id,
+                settings_id=settings_id,
+                server_id=server_id,
+                model=model,
+                user_id=user_id,
+                message="Read life/finances context and answer briefly.",
+                conversation_type="chat",
+                mcp_scope_mode="project",
+                mcp_project_slug="life/finances",
+                mcp_project_name="Finances",
+                params_extra={
+                    "mcp_max_tool_iterations": 6,
+                    "mcp_tool_profile": "read_only",
+                    "mcp_native_tool_calling": True,
+                },
+            ),
+        )
+        native_state = native_response.get("tooling_state") if isinstance(native_response, dict) else {}
+        native_ok = (
+            native_status == 200
+            and isinstance(native_state, dict)
+            and bool(str(native_state.get("tool_routing_mode") or "").strip())
+            and bool(str(native_state.get("routing_capability_source") or "").strip())
+        )
+
+        usage = {}
+        metadata = route_response.get("metadata") if isinstance(route_response, dict) else {}
+        if isinstance(metadata, dict):
+            usage = metadata.get("usage") if isinstance(metadata.get("usage"), dict) else {}
+        cost_value = usage.get("cost")
+        runtime_external_hint = (
+            provider_id == "openai"
+            and isinstance(cost_value, (int, float))
+            and float(cost_value) > 0.0
+        )
+        is_external_family = bool(
+            (scenario["provider_classification"].get(provider_id) or {}).get("is_external_family")
+        ) or runtime_external_hint
+
+        scenario["runtime_matrix"].append(
+            {
+                "provider": provider_id,
+                "settings_id": settings_id,
+                "server_id": server_id,
+                "model": model,
+                "is_external_family": bool(is_external_family),
+                "runtime_external_hint": bool(runtime_external_hint),
+                "routing_probe": {
+                    "status": route_status,
+                    "ok": route_ok,
+                    "tooling_state": route_state,
+                },
+                "citation_probe": {
+                    "status": citation_status,
+                    "ok": citation_ok,
+                    "response_citations": citations,
+                    "has_sources_block": "sources:" in citation_text.lower() or "sources\n" in citation_text.lower(),
+                    "text_excerpt": citation_text[:400],
+                },
+                "native_override_probe": {
+                    "status": native_status,
+                    "ok": native_ok,
+                    "tooling_state": native_state,
+                },
+            }
+        )
+
+    openrouter_rows = [row for row in scenario["runtime_matrix"] if row.get("provider") == "openrouter"]
+    _assert(summary, "o3_openrouter_runtime_row_present", len(openrouter_rows) >= 1, str(scenario["runtime_matrix"]))
+
+    openrouter_pass = any(
+        bool(row.get("routing_probe", {}).get("ok"))
+        and bool(row.get("citation_probe", {}).get("ok"))
+        and bool(row.get("native_override_probe", {}).get("ok"))
+        for row in openrouter_rows
+    )
+    _assert(summary, "o3_openrouter_runtime_pass", openrouter_pass, str(openrouter_rows))
+
+    any_external_pass = any(
+        bool(row.get("routing_probe", {}).get("ok")) and bool(row.get("citation_probe", {}).get("ok"))
+        for row in scenario["runtime_matrix"]
+        if str(row.get("provider") or "") in {"openrouter", "openai"}
+    )
+    _assert(summary, "o3_external_runtime_matrix_has_pass", any_external_pass, str(scenario["runtime_matrix"]))
+
+    configured_external_families = sorted(
+        provider_id
+        for provider_id, meta in (scenario.get("provider_classification") or {}).items()
+        if bool((meta or {}).get("configured")) and bool((meta or {}).get("is_external_family"))
+    )
+    passing_external_families = sorted(
+        {
+            str(row.get("provider") or "")
+            for row in scenario["runtime_matrix"]
+            if bool(row.get("is_external_family"))
+            and bool(row.get("routing_probe", {}).get("ok"))
+            and bool(row.get("citation_probe", {}).get("ok"))
+            and bool(row.get("native_override_probe", {}).get("ok"))
+        }
+    )
+    scenario["external_family_summary"] = {
+        "configured_external_families": configured_external_families,
+        "passing_external_families": passing_external_families,
+    }
+    if len(configured_external_families) >= 2:
+        _assert(
+            summary,
+            "o3_external_family_expansion_pass",
+            len(passing_external_families) >= 2,
+            str(scenario["external_family_summary"]),
+        )
+    else:
+        _assert(
+            summary,
+            "o3_external_family_runtime_present",
+            len(passing_external_families) >= 1,
+            str(scenario["external_family_summary"]),
+        )
+        scenario["external_family_gap"] = (
+            "No second configured external provider family available; "
+            "additional expansion remains configuration-gated."
+        )
+
+    policy_cmd = [
+        "/home/hacker/anaconda3/envs/BrainDriveDev/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_mcp_chat_gating.py",
+        "-k",
+        "other_native_providers_default_to_single_path or model_hint_promotes_unknown_provider_to_native_mode",
+    ]
+    policy_completed = subprocess.run(
+        policy_cmd,
+        cwd=str(Path(__file__).resolve().parents[1] / "backend"),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    scenario["policy_regression"] = {
+        "command": " ".join(policy_cmd),
+        "returncode": policy_completed.returncode,
+        "stdout_tail": policy_completed.stdout[-2000:],
+        "stderr_tail": policy_completed.stderr[-1000:],
+    }
+    _assert(summary, "o3_policy_regression_pass", policy_completed.returncode == 0, policy_completed.stdout[-800:])
+
+    citation_cmd = [
+        "/home/hacker/anaconda3/envs/BrainDriveDev/bin/python",
+        "-m",
+        "pytest",
+        "-q",
+        "tests/test_mcp_tool_loop.py",
+        "tests/test_mcp_stream_tool_loop.py",
+        "-k",
+        "question_response_appends_grounded_sources",
+    ]
+    citation_completed = subprocess.run(
+        citation_cmd,
+        cwd=str(Path(__file__).resolve().parents[1] / "backend"),
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    scenario["citation_regression"] = {
+        "command": " ".join(citation_cmd),
+        "returncode": citation_completed.returncode,
+        "stdout_tail": citation_completed.stdout[-2000:],
+        "stderr_tail": citation_completed.stderr[-1000:],
+    }
+    _assert(summary, "o3_citation_regression_pass", citation_completed.returncode == 0, citation_completed.stdout[-800:])
+
+    return scenario
+
+
+def _serialize_summary(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {
+                "name": assertion.name,
+                "passed": assertion.passed,
+                "detail": assertion.detail,
+            }
+            for assertion in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> Config:
+    parser = argparse.ArgumentParser(description="Live Process Q.1/Q.3 harness")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--password", required=True)
+    parser.add_argument("--access-token", default="")
+    parser.add_argument("--user-id", default="")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_servers_settings")
+    parser.add_argument("--server-id", default="ollama_default_server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--openrouter-model", default="openai/gpt-4o-mini")
+    parser.add_argument("--openai-model", default="qwen3:8b")
+    parser.add_argument("--claude-model", default="claude-3-5-haiku-latest")
+    parser.add_argument("--groq-model", default="llama-3.1-8b-instant")
+    parser.add_argument("--output-dir", default="tmp/live-process-q13")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=0.8)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=1.5)
+    parser.add_argument("--soak-iterations", type=int, default=24)
+    parser.add_argument("--delivery-email-endpoint", default="https://httpbin.org/post?channel=email")
+    parser.add_argument("--delivery-slack-endpoint", default="https://httpbin.org/post?channel=slack")
+    parser.add_argument("--allow-local-delivery", action="store_true")
+    parser.add_argument("--reset-from-template", action="store_true")
+    parser.add_argument("--skip-o1", action="store_true")
+    parser.add_argument("--skip-o3", action="store_true")
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args(argv)
+    return Config(
+        base_url=str(args.base_url),
+        email=str(args.email),
+        password=str(args.password),
+        access_token=str(args.access_token or "").strip() or None,
+        user_id=str(args.user_id or "").strip() or None,
+        provider=str(args.provider),
+        settings_id=str(args.settings_id),
+        server_id=str(args.server_id),
+        model=str(args.model),
+        openrouter_model=str(args.openrouter_model),
+        openai_model=str(args.openai_model),
+        claude_model=str(args.claude_model),
+        groq_model=str(args.groq_model),
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=max(10, int(args.timeout_seconds)),
+        request_delay_seconds=max(0.0, float(args.request_delay_seconds)),
+        http_max_retries=max(0, int(args.http_max_retries)),
+        http_retry_base_seconds=max(0.1, float(args.http_retry_base_seconds)),
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+        soak_iterations=max(4, int(args.soak_iterations)),
+        delivery_email_endpoint=str(args.delivery_email_endpoint or "").strip() or None,
+        delivery_slack_endpoint=str(args.delivery_slack_endpoint or "").strip() or None,
+        require_non_local_delivery=not bool(args.allow_local_delivery),
+        skip_o1=bool(args.skip_o1),
+        skip_o3=bool(args.skip_o3),
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    config = _parse_args(argv)
+    if config.skip_o1 and config.skip_o3:
+        raise SystemExit("At least one of Q.1 or Q.3 must run (remove one skip flag).")
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    started_at = dt.datetime.now(dt.timezone.utc).isoformat()
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=started_at,
+        base_url=config.base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        if config.access_token and config.user_id:
+            token = str(config.access_token).strip()
+            user_id = str(config.user_id).strip()
+        else:
+            token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap
+
+        if config.skip_o1:
+            summary.scenarios["process_q1"] = {"skipped": True}
+        else:
+            summary.scenarios["process_q1"] = _run_o1(summary, config, token, user_id)
+
+        if config.skip_o3:
+            summary.scenarios["process_q3"] = {"skipped": True}
+        else:
+            summary.scenarios["process_q3"] = _run_o3(summary, config, token, user_id)
+
+        summary.success = all(assertion.passed for assertion in summary.assertions)
+    except Exception as exc:
+        summary.success = False
+        summary.error = str(exc)
+
+    output_path = run_dir / "summary.json"
+    output_path.write_text(
+        json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2))
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_q2_browser.ts
+++ b/scripts/e2e_process_q2_browser.ts
@@ -1,0 +1,441 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { connect, waitForPageLoad } from "/home/hacker/.codex/skills/dev-browser/src/client.ts";
+
+type Assertion = {
+  name: string;
+  passed: boolean;
+  detail?: unknown;
+};
+
+type Summary = {
+  process: "Q2";
+  run_id: string;
+  started_at: string;
+  base_url: string;
+  assertions: Assertion[];
+  screenshots: string[];
+  success: boolean;
+  error?: string;
+};
+
+function argValue(name: string, fallback: string): string {
+  const idx = process.argv.indexOf(name);
+  if (idx >= 0 && idx + 1 < process.argv.length) {
+    return process.argv[idx + 1] ?? fallback;
+  }
+  return fallback;
+}
+
+function assertPush(summary: Summary, name: string, passed: boolean, detail?: unknown): void {
+  summary.assertions.push({ name, passed, detail });
+  if (!passed) {
+    throw new Error(`Assertion failed: ${name} :: ${JSON.stringify(detail ?? null)}`);
+  }
+}
+
+async function waitForVisible(
+  page: import("playwright").Page,
+  selectors: string[],
+  timeoutMs = 60000
+): Promise<boolean> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    for (const selector of selectors) {
+      const count = await page.locator(selector).count();
+      if (count > 0) {
+        const visible = await page.locator(selector).first().isVisible().catch(() => false);
+        if (visible) {
+          return true;
+        }
+      }
+    }
+    await page.waitForTimeout(250);
+  }
+  return false;
+}
+
+async function waitForPromptInput(page: import("playwright").Page, timeoutMs = 90000): Promise<boolean> {
+  const selectors = [
+    'textarea[placeholder="What would you like to know?"]',
+    'input[placeholder="What would you like to know?"]',
+  ];
+  return waitForVisible(page, selectors, timeoutMs);
+}
+
+async function navigateToPage(
+  page: import("playwright").Page,
+  baseUrl: string,
+  route: string,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await page.goto(`${baseUrl}${route}`);
+  await waitForPageLoad(page, { timeout: 45000 });
+  const inputReady = await waitForPromptInput(page, 120000);
+  assertPush(summary, `${prefix}_input_ready`, inputReady, { route, url: page.url() });
+  assertPush(summary, `${prefix}_route_ok`, page.url().includes(route), { route, url: page.url() });
+}
+
+async function ensureModelSelected(
+  page: import("playwright").Page,
+  summary: Summary,
+  modelHint: string
+): Promise<void> {
+  if (!modelHint.trim()) {
+    return;
+  }
+
+  const trigger = page.locator(".header-model-section .searchable-dropdown-trigger").first();
+  assertPush(summary, "o2_model_trigger_present", (await trigger.count()) > 0);
+
+  const currentText = ((await trigger.textContent()) ?? "").toLowerCase();
+  if (currentText.includes(modelHint.toLowerCase())) {
+    assertPush(summary, "o2_model_selected", true, { model_hint: modelHint, selected: currentText });
+    return;
+  }
+
+  await trigger.click();
+  const input = page.locator(".header-model-section .searchable-dropdown-input").first();
+  assertPush(summary, "o2_model_search_present", (await input.count()) > 0);
+  await input.fill(modelHint);
+  await input.press("Enter");
+  await page.waitForTimeout(2500);
+
+  const updatedText = ((await trigger.textContent()) ?? "").toLowerCase();
+  assertPush(summary, "o2_model_selected", updatedText.includes(modelHint.toLowerCase()), {
+    model_hint: modelHint,
+    selected: updatedText,
+  });
+}
+
+async function startFreshConversation(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const historyValue = page.locator(".header-history-section .searchable-dropdown-value").first();
+  assertPush(summary, `${prefix}_history_value_present`, (await historyValue.count()) > 0);
+
+  const button = page.locator('button[title="Start New Chat"]').first();
+  assertPush(summary, `${prefix}_new_chat_button_present`, (await button.count()) > 0);
+  await button.click();
+  await page.waitForTimeout(1200);
+
+  let historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  if (!/start new chat/i.test(historyLabel)) {
+    const historyTrigger = page.locator(".header-history-section .searchable-dropdown-trigger").first();
+    assertPush(summary, `${prefix}_history_trigger_present`, (await historyTrigger.count()) > 0);
+    await historyTrigger.click();
+    const startNewOption = page.locator(".searchable-dropdown-option:has-text('Start New Chat')").first();
+    assertPush(summary, `${prefix}_history_start_new_option_present`, (await startNewOption.count()) > 0);
+    await startNewOption.click();
+    await page.waitForTimeout(1200);
+    historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  }
+  assertPush(summary, `${prefix}_history_start_new_selected`, /start new chat/i.test(historyLabel), {
+    history_label: historyLabel,
+  });
+
+  const inputReady = await waitForPromptInput(page, 60000);
+  assertPush(summary, `${prefix}_new_chat_ready`, inputReady);
+}
+
+async function ensureLoginIfNeeded(
+  page: import("playwright").Page,
+  email: string,
+  password: string,
+  summary: Summary
+): Promise<void> {
+  const maxAttempts = 4;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const passwordInput = page.locator('input[type="password"]');
+    const needsLogin = page.url().includes("/login") || (await passwordInput.count()) > 0;
+    if (!needsLogin) {
+      return;
+    }
+
+    const emailInput = page.locator('input[type="email"], input[name="email"]');
+    assertPush(summary, `o2_login_email_input_present_attempt_${attempt}`, (await emailInput.count()) > 0);
+
+    await emailInput.first().fill(email);
+    await passwordInput.first().fill(password);
+
+    const submitCandidates = [
+      page.getByRole("button", { name: /sign in|login|log in/i }),
+      page.locator('button[type="submit"]'),
+    ];
+
+    let clicked = false;
+    for (const candidate of submitCandidates) {
+      const count = await candidate.count();
+      if (count > 0) {
+        await candidate.first().click();
+        clicked = true;
+        break;
+      }
+    }
+    assertPush(summary, `o2_login_submit_clicked_attempt_${attempt}`, clicked);
+
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2500 + attempt * 1000);
+    if (!page.url().includes("/login")) {
+      assertPush(summary, "o2_login_redirected", true, { url: page.url(), attempt });
+      return;
+    }
+  }
+
+  assertPush(summary, "o2_login_redirected", false, { url: page.url() });
+}
+
+async function sendPrompt(
+  page: import("playwright").Page,
+  prompt: string,
+  summary: Summary,
+  prefix: string
+): Promise<{ elapsedMs: number; pendingVisible: boolean }> {
+  const inputReady = await waitForPromptInput(page, 90000);
+  assertPush(summary, `${prefix}_input_present`, inputReady);
+
+  const input = page.locator(
+    'textarea[placeholder="What would you like to know?"], input[placeholder="What would you like to know?"]'
+  );
+  assertPush(summary, `${prefix}_input_locator_present`, (await input.count()) > 0);
+  await input.first().fill(prompt);
+
+  const pendingLocator = page.locator("text=PENDING");
+  const approvalCopyLocator = page.locator("text=Approval required to run mutating tool");
+  const pendingBaseline = await pendingLocator.count();
+  const approvalCopyBaseline = await approvalCopyLocator.count();
+
+  const sendCandidates = [
+    page.getByRole("button", { name: /send message/i }),
+    page.locator('button[aria-label="Send message"]'),
+  ];
+
+  let sent = false;
+  for (const candidate of sendCandidates) {
+    const count = await candidate.count();
+    if (count > 0) {
+      await candidate.first().click();
+      sent = true;
+      break;
+    }
+  }
+  assertPush(summary, `${prefix}_send_clicked`, sent);
+
+  const start = Date.now();
+  let pendingVisible = false;
+  const deadline = Date.now() + 65000;
+  while (Date.now() < deadline) {
+    const pendingCount = await pendingLocator.count();
+    const approvalCopyCount = await approvalCopyLocator.count();
+    if (pendingCount > pendingBaseline || approvalCopyCount > approvalCopyBaseline) {
+      pendingVisible = true;
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  const elapsed = Date.now() - start;
+  assertPush(summary, `${prefix}_pending_visible`, pendingVisible, {
+    elapsed_ms: elapsed,
+    pending_visible: pendingVisible,
+  });
+  if (pendingVisible) {
+    assertPush(summary, `${prefix}_approval_latency_under_60s`, elapsed <= 60000, { elapsed_ms: elapsed });
+  }
+
+  if (pendingVisible) {
+    const copyVisible = await waitForVisible(page, ["text=Approval required to run mutating tool"], 10000);
+    assertPush(summary, `${prefix}_approval_copy_visible`, copyVisible);
+  }
+
+  return { elapsedMs: elapsed, pendingVisible };
+}
+
+async function clickStrictApprovalButton(
+  page: import("playwright").Page,
+  buttonName: "Approve" | "Reject",
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const buttons = page.getByRole("button", { name: new RegExp(`^${buttonName}$`, "i") });
+  const deadline = Date.now() + 20000;
+  let visibleIndexes: number[] = [];
+
+  while (Date.now() < deadline) {
+    const count = await buttons.count();
+    visibleIndexes = [];
+    for (let idx = 0; idx < count; idx += 1) {
+      const visible = await buttons.nth(idx).isVisible().catch(() => false);
+      if (visible) {
+        visibleIndexes.push(idx);
+      }
+    }
+    if (visibleIndexes.length > 0) {
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_visible`, visibleIndexes.length > 0, {
+    visible_count: visibleIndexes.length,
+  });
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_unique`, visibleIndexes.length === 1, {
+    visible_count: visibleIndexes.length,
+  });
+
+  const targetIndex = visibleIndexes[visibleIndexes.length - 1] ?? 0;
+  await buttons.nth(targetIndex).click();
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_clicked`, true, { index: targetIndex });
+}
+
+async function resolveRejectSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Reject", summary, prefix);
+  const rejectOutcome = await waitForVisible(
+    page,
+    ["text=REJECTED", "text=did not run mutating tool", "text=Task creation was rejected"],
+    45000
+  );
+  assertPush(summary, `${prefix}_reject_semantics`, rejectOutcome);
+}
+
+async function resolveApproveSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Approve", summary, prefix);
+  const approveOutcome = await waitForVisible(
+    page,
+    ["text=APPROVED", "text=newly created task", "text=successfully saved", "text=Task ID"],
+    45000
+  );
+  assertPush(summary, `${prefix}_approve_semantics`, approveOutcome);
+}
+
+async function assertPendingToolHint(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string,
+  expectedTool: string | string[]
+): Promise<void> {
+  const expectedList = (Array.isArray(expectedTool) ? expectedTool : [expectedTool])
+    .map((item) => item.toLowerCase())
+    .filter((item) => item.length > 0);
+  const deadline = Date.now() + 20000;
+  let matched = false;
+  while (Date.now() < deadline) {
+    const bodyText = (await page.locator("body").innerText().catch(() => "")).toLowerCase();
+    if (
+      expectedList.some((expected) => bodyText.includes(`tool '${expected}'`) || bodyText.includes(expected))
+    ) {
+      matched = true;
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  assertPush(summary, `${prefix}_pending_tool_${expectedList.join("_or_")}`, matched, {
+    expected_tool: expectedTool,
+  });
+}
+
+async function main(): Promise<void> {
+  const baseUrl = argValue("--base-url", "http://localhost:5173").replace(/\/$/, "");
+  const email = argValue("--email", "cccc@gmail.com");
+  const password = argValue("--password", "10012002");
+  const modelHint = argValue("--model-hint", "qwen3:8b");
+  const outputDir = argValue("--output-dir", "/home/hacker/BrainDriveDev/BrainDrive/tmp/live-process-q2-browser");
+
+  const runId = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+  const summary: Summary = {
+    process: "Q2",
+    run_id: runId,
+    started_at: new Date().toISOString(),
+    base_url: baseUrl,
+    assertions: [],
+    screenshots: [],
+    success: false,
+  };
+
+  const artifactDir = path.resolve(outputDir);
+  await mkdir(artifactDir, { recursive: true });
+
+  const client = await connect();
+  const page = await client.page("process-o2", { viewport: { width: 1440, height: 1000 } });
+
+  try {
+    await page.goto(`${baseUrl}/dashboard`);
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2000);
+
+    await ensureLoginIfNeeded(page, email, password, summary);
+    assertPush(summary, "o2_session_ready", true, { url: page.url() });
+
+    await navigateToPage(page, baseUrl, "/pages/finances", summary, "q2_finances_preflight");
+    await ensureModelSelected(page, summary, modelHint);
+    await startFreshConversation(page, summary, "q2_finances_create_task_reject");
+
+    const rejectPrompt = `[LIBRARY SCOPE - Life / finances] Create a task Q2 task reject ${runId} due 2026-03-22 for Dave J.`;
+    await sendPrompt(page, rejectPrompt, summary, "q2_finances_create_task_reject");
+    await assertPendingToolHint(page, summary, "q2_finances_create_task_reject", "create_task");
+
+    await resolveRejectSemantics(page, summary, "q2_finances_create_task");
+
+    await startFreshConversation(page, summary, "q2_finances_create_task_approve");
+    const approvePrompt = `[LIBRARY SCOPE - Life / finances] Create a task Q2 task approve ${runId} due 2026-03-23 for Dave J.`;
+    await sendPrompt(page, approvePrompt, summary, "q2_finances_create_task_approve");
+    await assertPendingToolHint(page, summary, "q2_finances_create_task_approve", "create_task");
+
+    await resolveApproveSemantics(page, summary, "q2_finances_create_task");
+
+    await navigateToPage(page, baseUrl, "/pages/ai-chat", summary, "q2_ai_chat_preflight");
+    await ensureModelSelected(page, summary, modelHint);
+    await startFreshConversation(page, summary, "q2_ai_chat_create_markdown_reject");
+
+    const aiRejectPrompt = `[LIBRARY SCOPE - Life / finances] Create markdown file q2-create-note-reject-${runId}.md in life/finances with content \"Q2 create markdown reject ${runId}\".`;
+    await sendPrompt(page, aiRejectPrompt, summary, "q2_ai_chat_create_markdown_reject");
+    await assertPendingToolHint(page, summary, "q2_ai_chat_create_markdown_reject", "create_markdown");
+    await resolveRejectSemantics(page, summary, "q2_ai_chat_create_markdown");
+
+    await startFreshConversation(page, summary, "q2_ai_chat_create_markdown_approve");
+    const aiApprovePrompt = `[LIBRARY SCOPE - Life / finances] Create markdown file q2-create-note-approve-${runId}.md in life/finances with content \"Q2 create markdown approve ${runId}\".`;
+    await sendPrompt(page, aiApprovePrompt, summary, "q2_ai_chat_create_markdown_approve");
+    await assertPendingToolHint(page, summary, "q2_ai_chat_create_markdown_approve", "create_markdown");
+    await resolveApproveSemantics(page, summary, "q2_ai_chat_create_markdown");
+
+    const screenshotPath = path.resolve(artifactDir, `q2-browser-${runId}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    summary.screenshots.push(screenshotPath);
+
+    summary.success = summary.assertions.every((a) => a.passed);
+  } catch (error) {
+    summary.success = false;
+    summary.error = error instanceof Error ? error.message : String(error);
+    const errorShot = path.resolve(artifactDir, `o2-browser-${runId}-error.png`);
+    try {
+      await page.screenshot({ path: errorShot, fullPage: true });
+      summary.screenshots.push(errorShot);
+    } catch {
+      // ignore
+    }
+  } finally {
+    const outPath = path.resolve(artifactDir, `q2-browser-${runId}.json`);
+    await writeFile(outPath, JSON.stringify(summary, null, 2) + "\n", "utf-8");
+    console.log(JSON.stringify(summary, null, 2));
+    await client.disconnect();
+  }
+
+  if (!summary.success) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/e2e_process_r3_browser.ts
+++ b/scripts/e2e_process_r3_browser.ts
@@ -1,0 +1,424 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { connect, waitForPageLoad } from "/home/hacker/.codex/skills/dev-browser/src/client.ts";
+
+type Assertion = {
+  name: string;
+  passed: boolean;
+  detail?: unknown;
+};
+
+type Summary = {
+  process: "R3";
+  run_id: string;
+  started_at: string;
+  base_url: string;
+  assertions: Assertion[];
+  screenshots: string[];
+  success: boolean;
+  error?: string;
+};
+
+function argValue(name: string, fallback: string): string {
+  const idx = process.argv.indexOf(name);
+  if (idx >= 0 && idx + 1 < process.argv.length) {
+    return process.argv[idx + 1] ?? fallback;
+  }
+  return fallback;
+}
+
+function assertPush(summary: Summary, name: string, passed: boolean, detail?: unknown): void {
+  summary.assertions.push({ name, passed, detail });
+  if (!passed) {
+    throw new Error(`Assertion failed: ${name} :: ${JSON.stringify(detail ?? null)}`);
+  }
+}
+
+async function waitForVisible(
+  page: import("playwright").Page,
+  selectors: string[],
+  timeoutMs = 60000
+): Promise<boolean> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    for (const selector of selectors) {
+      const count = await page.locator(selector).count();
+      if (count > 0) {
+        const visible = await page.locator(selector).first().isVisible().catch(() => false);
+        if (visible) {
+          return true;
+        }
+      }
+    }
+    await page.waitForTimeout(250);
+  }
+  return false;
+}
+
+async function waitForPromptInput(page: import("playwright").Page, timeoutMs = 90000): Promise<boolean> {
+  const selectors = [
+    'textarea[placeholder="What would you like to know?"]',
+    'input[placeholder="What would you like to know?"]',
+  ];
+  return waitForVisible(page, selectors, timeoutMs);
+}
+
+async function navigateToPage(
+  page: import("playwright").Page,
+  baseUrl: string,
+  route: string,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await page.goto(`${baseUrl}${route}`);
+  await waitForPageLoad(page, { timeout: 45000 });
+  const inputReady = await waitForPromptInput(page, 120000);
+  assertPush(summary, `${prefix}_input_ready`, inputReady, { route, url: page.url() });
+  assertPush(summary, `${prefix}_route_ok`, page.url().includes(route), { route, url: page.url() });
+}
+
+async function ensureModelSelected(
+  page: import("playwright").Page,
+  summary: Summary,
+  modelHint: string
+): Promise<void> {
+  if (!modelHint.trim()) {
+    return;
+  }
+
+  const trigger = page.locator(".header-model-section .searchable-dropdown-trigger").first();
+  assertPush(summary, "r3_model_trigger_present", (await trigger.count()) > 0);
+
+  const currentText = ((await trigger.textContent()) ?? "").toLowerCase();
+  if (currentText.includes(modelHint.toLowerCase())) {
+    assertPush(summary, "r3_model_selected", true, { model_hint: modelHint, selected: currentText });
+    return;
+  }
+
+  await trigger.click();
+  const input = page.locator(".header-model-section .searchable-dropdown-input").first();
+  assertPush(summary, "r3_model_search_present", (await input.count()) > 0);
+  await input.fill(modelHint);
+  await input.press("Enter");
+  await page.waitForTimeout(2500);
+
+  const updatedText = ((await trigger.textContent()) ?? "").toLowerCase();
+  assertPush(summary, "r3_model_selected", updatedText.includes(modelHint.toLowerCase()), {
+    model_hint: modelHint,
+    selected: updatedText,
+  });
+}
+
+async function startFreshConversation(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const historyValue = page.locator(".header-history-section .searchable-dropdown-value").first();
+  assertPush(summary, `${prefix}_history_value_present`, (await historyValue.count()) > 0);
+
+  const button = page.locator('button[title="Start New Chat"]').first();
+  assertPush(summary, `${prefix}_new_chat_button_present`, (await button.count()) > 0);
+  await button.click();
+  await page.waitForTimeout(1200);
+
+  let historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  if (!/start new chat/i.test(historyLabel)) {
+    const historyTrigger = page.locator(".header-history-section .searchable-dropdown-trigger").first();
+    assertPush(summary, `${prefix}_history_trigger_present`, (await historyTrigger.count()) > 0);
+    await historyTrigger.click();
+    const startNewOption = page.locator(".searchable-dropdown-option:has-text('Start New Chat')").first();
+    assertPush(summary, `${prefix}_history_start_new_option_present`, (await startNewOption.count()) > 0);
+    await startNewOption.click();
+    await page.waitForTimeout(1200);
+    historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  }
+  assertPush(summary, `${prefix}_history_start_new_selected`, /start new chat/i.test(historyLabel), {
+    history_label: historyLabel,
+  });
+
+  const inputReady = await waitForPromptInput(page, 60000);
+  assertPush(summary, `${prefix}_new_chat_ready`, inputReady);
+}
+
+async function ensureLoginIfNeeded(
+  page: import("playwright").Page,
+  email: string,
+  password: string,
+  summary: Summary
+): Promise<void> {
+  const maxAttempts = 4;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const passwordInput = page.locator('input[type="password"]');
+    const needsLogin = page.url().includes("/login") || (await passwordInput.count()) > 0;
+    if (!needsLogin) {
+      return;
+    }
+
+    const emailInput = page.locator('input[type="email"], input[name="email"]');
+    assertPush(summary, `r3_login_email_input_present_attempt_${attempt}`, (await emailInput.count()) > 0);
+
+    await emailInput.first().fill(email);
+    await passwordInput.first().fill(password);
+
+    const submitCandidates = [
+      page.getByRole("button", { name: /sign in|login|log in/i }),
+      page.locator('button[type="submit"]'),
+    ];
+
+    let clicked = false;
+    for (const candidate of submitCandidates) {
+      const count = await candidate.count();
+      if (count > 0) {
+        await candidate.first().click();
+        clicked = true;
+        break;
+      }
+    }
+    assertPush(summary, `r3_login_submit_clicked_attempt_${attempt}`, clicked);
+
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2500 + attempt * 1000);
+    if (!page.url().includes("/login")) {
+      assertPush(summary, "r3_login_redirected", true, { url: page.url(), attempt });
+      return;
+    }
+  }
+
+  assertPush(summary, "r3_login_redirected", false, { url: page.url() });
+}
+
+async function sendPrompt(
+  page: import("playwright").Page,
+  prompt: string,
+  summary: Summary,
+  prefix: string
+): Promise<{ elapsedMs: number; pendingVisible: boolean }> {
+  const inputReady = await waitForPromptInput(page, 90000);
+  assertPush(summary, `${prefix}_input_present`, inputReady);
+
+  const input = page.locator(
+    'textarea[placeholder="What would you like to know?"], input[placeholder="What would you like to know?"]'
+  );
+  assertPush(summary, `${prefix}_input_locator_present`, (await input.count()) > 0);
+  await input.first().fill(prompt);
+
+  const pendingLocator = page.locator("text=PENDING");
+  const approvalCopyLocator = page.locator("text=Approval required to run mutating tool");
+  const pendingBaseline = await pendingLocator.count();
+  const approvalCopyBaseline = await approvalCopyLocator.count();
+
+  const sendCandidates = [
+    page.getByRole("button", { name: /send message/i }),
+    page.locator('button[aria-label="Send message"]'),
+  ];
+
+  let sent = false;
+  for (const candidate of sendCandidates) {
+    const count = await candidate.count();
+    if (count > 0) {
+      await candidate.first().click();
+      sent = true;
+      break;
+    }
+  }
+  assertPush(summary, `${prefix}_send_clicked`, sent);
+
+  const start = Date.now();
+  let pendingVisible = false;
+  const deadline = Date.now() + 65000;
+  while (Date.now() < deadline) {
+    const pendingCount = await pendingLocator.count();
+    const approvalCopyCount = await approvalCopyLocator.count();
+    if (pendingCount > pendingBaseline || approvalCopyCount > approvalCopyBaseline) {
+      pendingVisible = true;
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  const elapsed = Date.now() - start;
+  assertPush(summary, `${prefix}_pending_visible`, pendingVisible, {
+    elapsed_ms: elapsed,
+    pending_visible: pendingVisible,
+  });
+  if (pendingVisible) {
+    assertPush(summary, `${prefix}_approval_latency_under_60s`, elapsed <= 60000, { elapsed_ms: elapsed });
+  }
+
+  if (pendingVisible) {
+    const copyVisible = await waitForVisible(page, ["text=Approval required to run mutating tool"], 10000);
+    assertPush(summary, `${prefix}_approval_copy_visible`, copyVisible);
+  }
+
+  return { elapsedMs: elapsed, pendingVisible };
+}
+
+async function clickStrictApprovalButton(
+  page: import("playwright").Page,
+  buttonName: "Approve" | "Reject",
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const buttons = page.getByRole("button", { name: new RegExp(`^${buttonName}$`, "i") });
+  const deadline = Date.now() + 20000;
+  let visibleIndexes: number[] = [];
+
+  while (Date.now() < deadline) {
+    const count = await buttons.count();
+    visibleIndexes = [];
+    for (let idx = 0; idx < count; idx += 1) {
+      const visible = await buttons.nth(idx).isVisible().catch(() => false);
+      if (visible) {
+        visibleIndexes.push(idx);
+      }
+    }
+    if (visibleIndexes.length > 0) {
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_visible`, visibleIndexes.length > 0, {
+    visible_count: visibleIndexes.length,
+  });
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_unique`, visibleIndexes.length === 1, {
+    visible_count: visibleIndexes.length,
+  });
+
+  const targetIndex = visibleIndexes[visibleIndexes.length - 1] ?? 0;
+  await buttons.nth(targetIndex).click();
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_clicked`, true, { index: targetIndex });
+}
+
+async function resolveRejectSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Reject", summary, prefix);
+  const rejectOutcome = await waitForVisible(
+    page,
+    ["text=REJECTED", "text=did not run mutating tool", "text=did not run tool", "text=rejected"],
+    45000
+  );
+  assertPush(summary, `${prefix}_reject_semantics`, rejectOutcome);
+}
+
+async function resolveApproveSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Approve", summary, prefix);
+  const approveOutcome = await waitForVisible(
+    page,
+    ["text=APPROVED", "text=successfully saved", "text=updated", "text=written"],
+    45000
+  );
+  assertPush(summary, `${prefix}_approve_semantics`, approveOutcome);
+}
+
+async function assertPendingToolHint(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string,
+  expectedTool: string | string[]
+): Promise<void> {
+  const expectedList = (Array.isArray(expectedTool) ? expectedTool : [expectedTool])
+    .map((item) => item.toLowerCase())
+    .filter((item) => item.length > 0);
+  const deadline = Date.now() + 20000;
+  let matched = false;
+  while (Date.now() < deadline) {
+    const bodyText = (await page.locator("body").innerText().catch(() => "")).toLowerCase();
+    if (
+      expectedList.some((expected) => bodyText.includes(`tool '${expected}'`) || bodyText.includes(expected))
+    ) {
+      matched = true;
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  assertPush(summary, `${prefix}_pending_tool_${expectedList.join("_or_")}`, matched, {
+    expected_tool: expectedTool,
+  });
+}
+
+async function main(): Promise<void> {
+  const baseUrl = argValue("--base-url", "http://localhost:5173").replace(/\/$/, "");
+  const email = argValue("--email", "cccc@gmail.com");
+  const password = argValue("--password", "10012002");
+  const modelHint = argValue("--model-hint", "qwen3:8b");
+  const outputDir = argValue("--output-dir", "/home/hacker/BrainDriveDev/BrainDrive/tmp/live-process-r3-browser");
+
+  const runId = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+  const summary: Summary = {
+    process: "R3",
+    run_id: runId,
+    started_at: new Date().toISOString(),
+    base_url: baseUrl,
+    assertions: [],
+    screenshots: [],
+    success: false,
+  };
+
+  const artifactDir = path.resolve(outputDir);
+  await mkdir(artifactDir, { recursive: true });
+
+  const client = await connect();
+  const page = await client.page("process-r3", { viewport: { width: 1440, height: 1000 } });
+
+  try {
+    await page.goto(`${baseUrl}/dashboard`);
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2000);
+
+    await ensureLoginIfNeeded(page, email, password, summary);
+    assertPush(summary, "r3_session_ready", true, { url: page.url() });
+
+    await navigateToPage(page, baseUrl, "/pages/ai-chat", summary, "r3_ai_chat_preflight");
+    await ensureModelSelected(page, summary, modelHint);
+    await startFreshConversation(page, summary, "r3_ai_chat_edit_markdown_reject");
+
+    const rejectPrompt = `[LIBRARY SCOPE - Project / finance] Use edit_markdown on projects/active/finance/build-plan.md and append bullet "- R3 edit reject ${runId} 2026-02-18".`;
+    await sendPrompt(page, rejectPrompt, summary, "r3_ai_chat_edit_markdown_reject");
+    await assertPendingToolHint(page, summary, "r3_ai_chat_edit_markdown_reject", "edit_markdown");
+    await resolveRejectSemantics(page, summary, "r3_ai_chat_edit_markdown");
+
+    await startFreshConversation(page, summary, "r3_ai_chat_edit_markdown_approve");
+    const approvePrompt = `[LIBRARY SCOPE - Project / finance] Use edit_markdown on projects/active/finance/build-plan.md and append bullet "- R3 edit approve ${runId} 2026-02-18".`;
+    await sendPrompt(page, approvePrompt, summary, "r3_ai_chat_edit_markdown_approve");
+    await assertPendingToolHint(page, summary, "r3_ai_chat_edit_markdown_approve", "edit_markdown");
+    await resolveApproveSemantics(page, summary, "r3_ai_chat_edit_markdown");
+
+    const screenshotPath = path.resolve(artifactDir, `r3-browser-${runId}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    summary.screenshots.push(screenshotPath);
+
+    summary.success = summary.assertions.every((a) => a.passed);
+  } catch (error) {
+    summary.success = false;
+    summary.error = error instanceof Error ? error.message : String(error);
+    const errorShot = path.resolve(artifactDir, `r3-browser-${runId}-error.png`);
+    try {
+      await page.screenshot({ path: errorShot, fullPage: true });
+      summary.screenshots.push(errorShot);
+    } catch {
+      // ignore
+    }
+  } finally {
+    const outPath = path.resolve(artifactDir, `r3-browser-${runId}.json`);
+    await writeFile(outPath, JSON.stringify(summary, null, 2) + "\n", "utf-8");
+    console.log(JSON.stringify(summary, null, 2));
+    await client.disconnect();
+  }
+
+  if (!summary.success) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/e2e_process_s1_s2_s3.py
+++ b/scripts/e2e_process_s1_s2_s3.py
@@ -1,0 +1,1703 @@
+#!/usr/bin/env python3
+"""Live probe harness for Process S.1, S.2, and S.3.
+
+S.1: VS-1/VS-2/VS-3/TR-1 capture/task reliability closure.
+S.2: VS-9/VS-10/VS-11/VS-17 context evolution closure.
+S.3: VS-7/VS-8/TR-1 final integrated mixed sweep + browser UX check.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    ui_base_url: str
+    provider: str
+    model: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    artifacts: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+@dataclass
+class Config:
+    base_url: str
+    ui_base_url: str
+    email: str
+    password: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+    browser_model_hint: str
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+    delivery_email_endpoint: str
+    delivery_slack_endpoint: str
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _decode_json_bytes(raw: bytes) -> Dict[str, Any]:
+    text = raw.decode("utf-8", errors="replace")
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return {"raw": text}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"data": parsed}
+
+
+def _throttle(request_delay_seconds: float) -> None:
+    global _LAST_REQUEST_SENT_MONOTONIC
+    if request_delay_seconds <= 0:
+        return
+    now = time.monotonic()
+    if _LAST_REQUEST_SENT_MONOTONIC is not None:
+        elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+        if elapsed < request_delay_seconds:
+            time.sleep(request_delay_seconds - elapsed)
+    _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+
+def _http_json(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    body: Optional[bytes] = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        request_obj = urllib_request.Request(url=url, data=body, headers=headers, method=method.upper())
+        try:
+            _throttle(request_delay_seconds)
+            with urllib_request.urlopen(request_obj, timeout=timeout_seconds) as response:
+                return int(response.status), _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            parsed = _decode_json_bytes(exc.read())
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            return int(exc.code), parsed
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    status, response = _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    if status != 200:
+        raise RuntimeError(f"Login failed: status={status} response={response}")
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _onboarding_state_path(config: Config, user_id: str) -> Path:
+    normalized_user_id = _normalize_user_id(user_id)
+    return config.library_root / "users" / normalized_user_id / ".braindrive" / "onboarding_state.json"
+
+
+def _set_topic_onboarding_status(config: Config, user_id: str, topic: str, status: str) -> Dict[str, Any]:
+    topic_key = str(topic or "").strip().lower()
+    path = _onboarding_state_path(config, user_id)
+    if not path.is_file():
+        return {"updated": False, "reason": "missing", "path": str(path)}
+    try:
+        payload = json.loads(path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {"updated": False, "reason": f"read_error:{exc}", "path": str(path)}
+    if not isinstance(payload, dict):
+        return {"updated": False, "reason": "invalid_json_root", "path": str(path)}
+
+    now_iso = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+    starter_topics = payload.setdefault("starter_topics", {})
+    completed_at = payload.setdefault("completed_at", {})
+    topic_progress = payload.setdefault("topic_progress", {})
+    progress = topic_progress.setdefault(topic_key, {}) if isinstance(topic_progress, dict) else {}
+
+    normalized_status = str(status or "").strip().lower()
+    if normalized_status == "complete":
+        if isinstance(starter_topics, dict):
+            starter_topics[topic_key] = "complete"
+        if isinstance(completed_at, dict):
+            completed_at[topic_key] = now_iso
+        if isinstance(progress, dict):
+            progress["status"] = "complete"
+            progress["phase"] = "complete"
+            progress["completed_at_utc"] = now_iso
+            progress["last_updated_at_utc"] = now_iso
+            progress.setdefault("started_at_utc", now_iso)
+    else:
+        if isinstance(starter_topics, dict):
+            starter_topics[topic_key] = "pending"
+        if isinstance(completed_at, dict):
+            completed_at.pop(topic_key, None)
+        if isinstance(progress, dict):
+            progress["status"] = "pending"
+            progress["phase"] = "opening"
+            progress["last_updated_at_utc"] = now_iso
+            progress.setdefault("started_at_utc", now_iso)
+            progress.pop("completed_at_utc", None)
+        payload["active_topic"] = topic_key
+
+    payload["updated_at_utc"] = now_iso
+    path.write_text(json.dumps(payload, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    return {"updated": True, "path": str(path), "topic": topic_key, "status": normalized_status}
+
+
+def _set_all_life_topics_complete(config: Config, user_id: str) -> Dict[str, Any]:
+    results = {}
+    for topic in ("finances", "fitness", "relationships", "career", "whyfinder"):
+        results[topic] = _set_topic_onboarding_status(config, user_id, topic, "complete")
+    return results
+
+
+def _build_chat_payload(
+    *,
+    config: Config,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    mcp_scope_mode: str,
+    mcp_project_slug: Optional[str] = None,
+    mcp_project_name: Optional[str] = None,
+    params_extra: Optional[Dict[str, Any]] = None,
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 8,
+        "mcp_provider_timeout_seconds": 60,
+    }
+    if mcp_project_slug is not None:
+        params["mcp_project_slug"] = mcp_project_slug
+    if mcp_project_name is not None:
+        params["mcp_project_name"] = mcp_project_name
+        params["mcp_project_source"] = "ui"
+    if params_extra:
+        params.update(params_extra)
+
+    payload: Dict[str, Any] = {
+        "provider": config.provider,
+        "settings_id": config.settings_id,
+        "server_id": config.server_id,
+        "model": config.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+    timeout_retries = 2
+    attempt = 0
+    while True:
+        status, response = _http_json(
+            method="POST",
+            url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+            payload=payload,
+            timeout_seconds=config.timeout_seconds,
+            request_delay_seconds=config.request_delay_seconds,
+            max_retries=config.http_max_retries,
+            retry_base_seconds=config.http_retry_base_seconds,
+            token=token,
+        )
+        tooling_state = response.get("tooling_state") if isinstance(response, dict) else {}
+        stop_reason = str((tooling_state or {}).get("tool_loop_stop_reason") or "").strip().lower()
+        provider_timeout = stop_reason == "provider_timeout"
+        if not provider_timeout or attempt >= timeout_retries:
+            return status, response
+        attempt += 1
+        time.sleep(min(8.0, 1.5 * attempt))
+
+
+def _approve_pending_request(
+    *,
+    config: Config,
+    token: str,
+    base_payload: Dict[str, Any],
+    conversation_id: str,
+    request_id: str,
+    action: str = "approve",
+) -> Tuple[int, Dict[str, Any]]:
+    payload = dict(base_payload)
+    payload["conversation_id"] = conversation_id
+    payload["messages"] = [{"role": "user", "content": action}]
+    params = dict(payload.get("params") or {})
+    params["mcp_approval"] = {"action": action, "request_id": request_id}
+    payload["params"] = params
+    return _chat(config, token, payload)
+
+
+def _approval_chain(
+    *,
+    config: Config,
+    token: str,
+    base_payload: Dict[str, Any],
+    start_response: Dict[str, Any],
+    max_steps: int = 10,
+) -> List[Dict[str, Any]]:
+    chain: List[Dict[str, Any]] = []
+    conversation_id = str(start_response.get("conversation_id") or "").strip()
+    current_response = start_response
+    for _ in range(max_steps):
+        request = current_response.get("approval_request")
+        if not isinstance(request, dict):
+            break
+        request_id = str(request.get("request_id") or "").strip()
+        if not request_id:
+            break
+        status, next_response = _approve_pending_request(
+            config=config,
+            token=token,
+            base_payload=base_payload,
+            conversation_id=conversation_id,
+            request_id=request_id,
+            action="approve",
+        )
+        chain.append(
+            {
+                "status_code": status,
+                "approval_request": request,
+                "approval_resolution": next_response.get("approval_resolution"),
+                "response": next_response,
+            }
+        )
+        if (next_response.get("approval_resolution") or {}).get("status") != "approved":
+            break
+        if next_response.get("approval_required") is not True:
+            break
+        current_response = next_response
+    return chain
+
+
+def _first_response_with_tool(
+    *,
+    config: Config,
+    token: str,
+    payload_builder: Any,
+    prompts: List[str],
+    expected_tool: str,
+) -> Optional[Dict[str, Any]]:
+    for prompt in prompts:
+        payload = payload_builder(prompt)
+        status, response = _chat(config, token, payload)
+        request = response.get("approval_request") or {}
+        if (
+            status == 200
+            and response.get("approval_required") is True
+            and str(request.get("tool") or "").strip() == expected_tool
+        ):
+            return {
+                "prompt": prompt,
+                "status_code": status,
+                "response": response,
+            }
+    return None
+
+
+def _run_s1(summary: ProbeSummary, config: Config, token: str, user_id: str) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+    base_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="",
+        conversation_type="capture",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        params_extra={"mcp_max_tool_iterations": 10},
+    )
+
+    fanout_prompt = (
+        "Capture this decision and note in finances, relationships, and career. "
+        "Decision: pause nonessential spend until 2026-03-31. "
+        "Add a task: Dave J to reconcile S1 fanout ledger by next week."
+    )
+    fanout_start_payload = dict(base_payload)
+    fanout_start_payload["messages"] = [{"role": "user", "content": fanout_prompt}]
+    fanout_status, fanout_start = _chat(config, token, fanout_start_payload)
+    scenario["fanout_start"] = {
+        "status_code": fanout_status,
+        "approval_required": fanout_start.get("approval_required"),
+        "approval_request": fanout_start.get("approval_request"),
+        "tooling_state": fanout_start.get("tooling_state"),
+    }
+    first_request = fanout_start.get("approval_request") or {}
+    first_args = first_request.get("arguments") or {}
+    first_path = str(first_args.get("path") or "")
+    _assert(summary, "s1_fanout_start_status_200", fanout_status == 200, str(scenario["fanout_start"]))
+    _assert(summary, "s1_first_approval_required", fanout_start.get("approval_required") is True, str(fanout_start))
+    _assert(summary, "s1_first_tool_inbox_create_markdown", first_request.get("tool") == "create_markdown", str(first_request))
+    _assert(
+        summary,
+        "s1_first_path_capture_inbox",
+        "/capture/inbox/" in f"/{first_path.strip('/')}",
+        first_path,
+    )
+
+    chain: List[Dict[str, Any]] = []
+    current_response = fanout_start
+    for _ in range(10):
+        current_request = current_response.get("approval_request") or {}
+        if str(current_request.get("tool") or "").strip() == "create_task":
+            break
+        request_id = str(current_request.get("request_id") or "").strip()
+        conversation_id = str(current_response.get("conversation_id") or "").strip()
+        if not request_id or not conversation_id:
+            break
+        approve_status, approve_response = _approve_pending_request(
+            config=config,
+            token=token,
+            base_payload=base_payload,
+            conversation_id=conversation_id,
+            request_id=request_id,
+            action="approve",
+        )
+        chain.append(
+            {
+                "status_code": approve_status,
+                "approval_request": current_request,
+                "approval_resolution": approve_response.get("approval_resolution"),
+                "response": approve_response,
+            }
+        )
+        if (approve_response.get("approval_resolution") or {}).get("status") != "approved":
+            break
+        if approve_response.get("approval_required") is not True:
+            current_response = approve_response
+            break
+        current_response = approve_response
+    scenario["fanout_chain"] = chain
+
+    request_items: List[Dict[str, Any]] = []
+    if isinstance(first_request, dict):
+        request_items.append(first_request)
+    for step in chain:
+        step_response = step.get("response") or {}
+        next_request = step_response.get("approval_request")
+        if isinstance(next_request, dict):
+            request_items.append(next_request)
+
+    fanout_scopes: List[str] = []
+    create_task_request: Optional[Dict[str, Any]] = None
+    for item in request_items:
+        tool_name = str(item.get("tool") or "").strip()
+        if tool_name == "create_task" and create_task_request is None:
+            create_task_request = item
+        if tool_name != "create_markdown":
+            continue
+        reason = str(item.get("synthetic_reason") or "").strip().lower()
+        if not reason.startswith("capture_scope_fanout_"):
+            continue
+        path_value = str((item.get("arguments") or {}).get("path") or "").strip()
+        if "/capture/" in path_value:
+            fanout_scopes.append(path_value.split("/capture/", 1)[0].strip())
+
+    unique_fanout_scopes = sorted({scope for scope in fanout_scopes if scope})
+    scenario["fanout_scopes"] = unique_fanout_scopes
+    _assert(summary, "s1_fanout_scope_count_ge_3", len(unique_fanout_scopes) >= 3, str(unique_fanout_scopes))
+
+    create_task_args = (create_task_request or {}).get("arguments") or {}
+    title_value = str(create_task_args.get("title") or "")
+    scenario["create_task_request"] = create_task_request
+    _assert(
+        summary,
+        "s1_create_task_request_present",
+        isinstance(create_task_request, dict),
+        str(request_items),
+    )
+    _assert(summary, "s1_create_task_owner_dave_j", str(create_task_args.get("owner") or "") == "Dave J", str(create_task_args))
+    _assert(
+        summary,
+        "s1_create_task_due_iso",
+        bool(re.fullmatch(r"\d{4}-\d{2}-\d{2}", str(create_task_args.get("due") or ""))),
+        str(create_task_args),
+    )
+    _assert(
+        summary,
+        "s1_create_task_title_disambiguated",
+        not title_value.lower().startswith("dave j "),
+        title_value,
+    )
+
+    if create_task_request is None:
+        trailing_request = current_response.get("approval_request") or {}
+        if str(trailing_request.get("tool") or "").strip() == "create_task":
+            create_task_request = trailing_request
+
+    task_seed_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Add a task to reconcile s1 edit probe by 2026-03-10 in finances for Dave J.",
+        conversation_type="capture",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        params_extra={"mcp_max_tool_iterations": 8},
+    )
+    task_seed_status, task_seed_start = _chat(config, token, task_seed_payload)
+    scenario["task_seed_start"] = {
+        "status_code": task_seed_status,
+        "approval_required": task_seed_start.get("approval_required"),
+        "approval_request": task_seed_start.get("approval_request"),
+        "tooling_state": task_seed_start.get("tooling_state"),
+    }
+    _assert(summary, "s1_task_seed_status_200", task_seed_status == 200, str(scenario["task_seed_start"]))
+    _assert(
+        summary,
+        "s1_task_seed_starts_with_write_approval",
+        task_seed_start.get("approval_required") is True,
+        str(scenario["task_seed_start"]),
+    )
+
+    task_seed_response = task_seed_start
+    task_seed_create_request: Optional[Dict[str, Any]] = None
+    for _ in range(8):
+        pending_request = task_seed_response.get("approval_request") or {}
+        pending_tool = str(pending_request.get("tool") or "").strip()
+        pending_request_id = str(pending_request.get("request_id") or "").strip()
+        pending_conversation_id = str(task_seed_response.get("conversation_id") or "").strip()
+        if not pending_request_id or not pending_conversation_id:
+            break
+        if pending_tool == "create_task":
+            task_seed_create_request = pending_request
+        approve_status, approve_response = _approve_pending_request(
+            config=config,
+            token=token,
+            base_payload=task_seed_payload,
+            conversation_id=pending_conversation_id,
+            request_id=pending_request_id,
+            action="approve",
+        )
+        scenario.setdefault("task_seed_chain", []).append(
+            {
+                "status_code": approve_status,
+                "approval_request": pending_request,
+                "approval_resolution": approve_response.get("approval_resolution"),
+                "tooling_state": approve_response.get("tooling_state"),
+            }
+        )
+        if (approve_response.get("approval_resolution") or {}).get("status") != "approved":
+            break
+        task_seed_response = approve_response
+        if pending_tool == "create_task":
+            break
+        if approve_response.get("approval_required") is not True:
+            break
+    if task_seed_create_request is None:
+        final_request = task_seed_response.get("approval_request") or {}
+        if str(final_request.get("tool") or "").strip() == "create_task":
+            task_seed_create_request = final_request
+    scenario["task_seed_create_request"] = task_seed_create_request
+    _assert(
+        summary,
+        "s1_task_seed_create_task_seen",
+        isinstance(task_seed_create_request, dict),
+        str(scenario.get("task_seed_chain")),
+    )
+
+    def _capture_payload(prompt: str) -> Dict[str, Any]:
+        payload = _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=prompt,
+            conversation_type="capture",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+            params_extra={"mcp_max_tool_iterations": 8},
+        )
+        return payload
+
+    edit_probe = _first_response_with_tool(
+        config=config,
+        token=token,
+        payload_builder=_capture_payload,
+        prompts=[
+            "Set owner to Sarah for task reconcile s1 edit probe and move to p1 due next Friday.",
+            "Update task reconcile s1 edit probe: owner Sarah, priority p1, due next Friday.",
+        ],
+        expected_tool="update_task",
+    )
+    _assert(summary, "s1_edit_probe_found_update_task", isinstance(edit_probe, dict), str(edit_probe))
+    edit_response = (edit_probe or {}).get("response") or {}
+    edit_request = edit_response.get("approval_request") or {}
+    edit_args = edit_request.get("arguments") or {}
+    edit_fields = edit_args.get("fields") or {}
+    scenario["edit_probe"] = edit_probe
+    _assert(summary, "s1_edit_tool_not_create_task", edit_request.get("tool") != "create_task", str(edit_request))
+    _assert(summary, "s1_edit_owner_sarah", str(edit_fields.get("owner") or "") == "Sarah", str(edit_fields))
+    _assert(summary, "s1_edit_priority_p1", str(edit_fields.get("priority") or "") == "p1", str(edit_fields))
+
+    edit_request_id = str(edit_request.get("request_id") or "").strip()
+    edit_conversation_id = str(edit_response.get("conversation_id") or "").strip()
+    if edit_request_id and edit_conversation_id:
+        approve_payload = _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message="approve",
+            conversation_type="capture",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+            conversation_id=edit_conversation_id,
+        )
+        approve_status, approve_response = _approve_pending_request(
+            config=config,
+            token=token,
+            base_payload=approve_payload,
+            conversation_id=edit_conversation_id,
+            request_id=edit_request_id,
+            action="approve",
+        )
+        scenario["edit_approve"] = {
+            "status_code": approve_status,
+            "approval_resolution": approve_response.get("approval_resolution"),
+            "tooling_state": approve_response.get("tooling_state"),
+        }
+        _assert(
+            summary,
+            "s1_edit_approval_resolution_approved",
+            (approve_response.get("approval_resolution") or {}).get("status") == "approved",
+            str(scenario["edit_approve"]),
+        )
+
+    complete_probe = _first_response_with_tool(
+        config=config,
+        token=token,
+        payload_builder=_capture_payload,
+        prompts=[
+            "Task reconcile s1 edit probe is done.",
+            "Complete task reconcile s1 edit probe.",
+        ],
+        expected_tool="complete_task",
+    )
+    _assert(summary, "s1_complete_probe_found_complete_task", isinstance(complete_probe, dict), str(complete_probe))
+    complete_response = (complete_probe or {}).get("response") or {}
+    complete_request = complete_response.get("approval_request") or {}
+    complete_state = complete_response.get("tooling_state") or {}
+    scenario["complete_probe"] = complete_probe
+    _assert(
+        summary,
+        "s1_complete_tool_not_create_task",
+        complete_request.get("tool") != "create_task",
+        str(complete_request),
+    )
+    _assert(
+        summary,
+        "s1_complete_followthrough_list_tasks_executed",
+        int(complete_state.get("tool_calls_executed_count") or 0) >= 1,
+        str(complete_state),
+    )
+    return scenario
+
+
+def _run_profile_browser_probe(summary: ProbeSummary, config: Config, artifact_dir: Path) -> Dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "npx",
+        "tsx",
+        "scripts/e2e_process_s2_profile_browser.ts",
+        "--base-url",
+        config.ui_base_url,
+        "--email",
+        config.email,
+        "--password",
+        config.password,
+        "--model-hint",
+        config.browser_model_hint,
+        "--output-dir",
+        str(artifact_dir),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    json_candidates = sorted(artifact_dir.glob("s2-profile-browser-*.json"))
+    latest_json = json_candidates[-1] if json_candidates else None
+    parsed: Dict[str, Any] = {}
+    if latest_json and latest_json.is_file():
+        try:
+            parsed = json.loads(latest_json.read_text(encoding="utf-8"))
+        except Exception:
+            parsed = {}
+    result = {
+        "command": cmd,
+        "returncode": completed.returncode,
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+        "artifact_json": str(latest_json) if latest_json else "",
+        "summary": parsed,
+    }
+    _assert(summary, "s2_profile_browser_exit_zero", completed.returncode == 0, str(result))
+    _assert(
+        summary,
+        "s2_profile_browser_success",
+        bool(parsed.get("success")) is True,
+        str(result),
+    )
+    return result
+
+
+def _run_r3_browser_probe(summary: ProbeSummary, config: Config, artifact_dir: Path) -> Dict[str, Any]:
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+    cmd = [
+        "npx",
+        "tsx",
+        "scripts/e2e_process_r3_browser.ts",
+        "--base-url",
+        config.ui_base_url,
+        "--email",
+        config.email,
+        "--password",
+        config.password,
+        "--model-hint",
+        config.browser_model_hint,
+        "--output-dir",
+        str(artifact_dir),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    json_candidates = sorted(artifact_dir.glob("r3-browser-*.json"))
+    latest_json = json_candidates[-1] if json_candidates else None
+    parsed: Dict[str, Any] = {}
+    if latest_json and latest_json.is_file():
+        try:
+            parsed = json.loads(latest_json.read_text(encoding="utf-8"))
+        except Exception:
+            parsed = {}
+    result = {
+        "command": cmd,
+        "returncode": completed.returncode,
+        "stdout_tail": completed.stdout[-4000:],
+        "stderr_tail": completed.stderr[-4000:],
+        "artifact_json": str(latest_json) if latest_json else "",
+        "summary": parsed,
+    }
+    _assert(summary, "s3_r3_browser_exit_zero", completed.returncode == 0, str(result))
+    _assert(summary, "s3_r3_browser_success", bool(parsed.get("success")) is True, str(result))
+    return result
+
+
+def _run_s2(summary: ProbeSummary, config: Config, token: str, user_id: str, run_dir: Path) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    completion_seed = _set_all_life_topics_complete(config, user_id)
+    scenario["onboarding_seed_complete"] = completion_seed
+
+    cross_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message=(
+            "I improved my finance check-in routine; apply a linked note in relationships and career too."
+        ),
+        conversation_type="life-finances",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    cross_status, cross_response = _chat(config, token, cross_payload)
+    scenario["cross_pollination_start"] = {
+        "status_code": cross_status,
+        "approval_required": cross_response.get("approval_required"),
+        "approval_request": cross_response.get("approval_request"),
+        "tooling_state": cross_response.get("tooling_state"),
+    }
+    cross_request = cross_response.get("approval_request") or {}
+    cross_reason = str(cross_request.get("synthetic_reason") or "")
+    _assert(summary, "s2_cross_status_200", cross_status == 200, str(scenario["cross_pollination_start"]))
+    _assert(
+        summary,
+        "s2_cross_approval_required",
+        cross_response.get("approval_required") is True,
+        str(cross_response),
+    )
+    _assert(
+        summary,
+        "s2_cross_initial_tool_expected",
+        str(cross_request.get("tool") or "").strip() in {"create_markdown", "ensure_scope_scaffold"},
+        str(cross_request),
+    )
+
+    cross_chain = _approval_chain(
+        config=config,
+        token=token,
+        base_payload=cross_payload,
+        start_response=cross_response,
+        max_steps=4,
+    )
+    scenario["cross_pollination_chain"] = cross_chain
+    cross_reasons = [cross_reason]
+    cross_tools = [str(cross_request.get("tool") or "").strip()]
+    for step in cross_chain:
+        next_request = (step.get("response") or {}).get("approval_request") or {}
+        reason = str(next_request.get("synthetic_reason") or "")
+        tool_name = str(next_request.get("tool") or "").strip()
+        if tool_name:
+            cross_tools.append(tool_name)
+        if reason:
+            cross_reasons.append(reason)
+    scenario["cross_pollination_reasons"] = cross_reasons
+    scenario["cross_pollination_tools"] = cross_tools
+    _assert(
+        summary,
+        "s2_cross_reason_present_after_chain",
+        any(reason.startswith("cross_pollination_finances_to_") for reason in cross_reasons),
+        f"reasons={cross_reasons} tools={cross_tools}",
+    )
+    _assert(
+        summary,
+        "s2_cross_chain_contains_create_markdown",
+        any(tool_name == "create_markdown" for tool_name in cross_tools),
+        str(cross_tools),
+    )
+
+    scaffold_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Create a new project page for S2 operations atlas.",
+        conversation_type="chat",
+        mcp_scope_mode="project",
+        mcp_project_slug="projects/active/finance",
+        mcp_project_name="Finance",
+    )
+    scaffold_status, scaffold_response = _chat(config, token, scaffold_payload)
+    scaffold_request = scaffold_response.get("approval_request") or {}
+    scaffold_args = scaffold_request.get("arguments") or {}
+    created_scope_path = str(scaffold_args.get("path") or "").strip()
+    scenario["new_page_scaffold_start"] = {
+        "status_code": scaffold_status,
+        "approval_required": scaffold_response.get("approval_required"),
+        "approval_request": scaffold_request,
+    }
+    _assert(summary, "s2_new_page_scaffold_status_200", scaffold_status == 200, str(scenario["new_page_scaffold_start"]))
+    _assert(
+        summary,
+        "s2_new_page_scaffold_approval",
+        scaffold_response.get("approval_required") is True and scaffold_request.get("tool") == "create_project",
+        str(scaffold_request),
+    )
+    _assert(
+        summary,
+        "s2_new_page_scaffold_reason_seeded",
+        scaffold_request.get("synthetic_reason") == "new_page_engine_scaffold",
+        str(scaffold_request),
+    )
+    _assert(
+        summary,
+        "s2_new_page_scope_created",
+        created_scope_path.startswith("projects/active/"),
+        created_scope_path,
+    )
+
+    scaffold_request_id = str(scaffold_request.get("request_id") or "").strip()
+    scaffold_conversation_id = str(scaffold_response.get("conversation_id") or "").strip()
+    scaffold_approve_status, scaffold_approve_response = _approve_pending_request(
+        config=config,
+        token=token,
+        base_payload=scaffold_payload,
+        conversation_id=scaffold_conversation_id,
+        request_id=scaffold_request_id,
+        action="approve",
+    )
+    scenario["new_page_scaffold_approve"] = {
+        "status_code": scaffold_approve_status,
+        "approval_resolution": scaffold_approve_response.get("approval_resolution"),
+        "tooling_state": scaffold_approve_response.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "s2_new_page_scaffold_approved",
+        (scaffold_approve_response.get("approval_resolution") or {}).get("status") == "approved",
+        str(scenario["new_page_scaffold_approve"]),
+    )
+
+    scope_slug = created_scope_path.split("/")[-1]
+    scope_name = scope_slug.replace("-", " ").title()
+    project_conversation_type = f"project-{scope_slug}"
+    interview_base_params = {"mcp_tools_enabled": False, "mcp_sync_on_request": False}
+
+    interview_start_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Start page interview for this scope.",
+        conversation_type=project_conversation_type,
+        mcp_scope_mode="project",
+        mcp_project_slug=created_scope_path,
+        mcp_project_name=scope_name,
+        params_extra=interview_base_params,
+    )
+    interview_start_status, interview_start = _chat(config, token, interview_start_payload)
+    interview_conversation_id = str(interview_start.get("conversation_id") or "").strip()
+    interview_start_text = str(
+        (((interview_start.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    scenario["new_page_interview_start"] = {
+        "status_code": interview_start_status,
+        "assistant_text": interview_start_text,
+        "tooling_state": interview_start.get("tooling_state"),
+    }
+    _assert(summary, "s2_interview_start_status_200", interview_start_status == 200, str(scenario["new_page_interview_start"]))
+    _assert(
+        summary,
+        "s2_interview_question1",
+        "question 1 of" in interview_start_text.lower(),
+        interview_start_text,
+    )
+
+    answer_one = "I want a weekly operating cadence with clear owners and deadlines."
+    answer_one_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message=answer_one,
+        conversation_type=project_conversation_type,
+        mcp_scope_mode="project",
+        mcp_project_slug=created_scope_path,
+        mcp_project_name=scope_name,
+        params_extra=interview_base_params,
+        conversation_id=interview_conversation_id,
+    )
+    answer_one_status, answer_one_response = _chat(config, token, answer_one_payload)
+    answer_one_text = str(
+        (((answer_one_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    scenario["new_page_answer_one"] = {
+        "status_code": answer_one_status,
+        "assistant_text": answer_one_text,
+        "tooling_state": answer_one_response.get("tooling_state"),
+    }
+    _assert(summary, "s2_answer_one_status_200", answer_one_status == 200, str(scenario["new_page_answer_one"]))
+    _assert(
+        summary,
+        "s2_answer_one_preview_paths",
+        all(item in answer_one_text.lower() for item in ["spec.md", "build-plan.md", "status.md"]),
+        answer_one_text,
+    )
+
+    approve_one_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="approve",
+        conversation_type=project_conversation_type,
+        mcp_scope_mode="project",
+        mcp_project_slug=created_scope_path,
+        mcp_project_name=scope_name,
+        params_extra=interview_base_params,
+        conversation_id=interview_conversation_id,
+    )
+    approve_one_status, approve_one_response = _chat(config, token, approve_one_payload)
+    approve_one_text = str(
+        (((approve_one_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    approve_one_state = approve_one_response.get("tooling_state") or {}
+    scenario["new_page_approve_one"] = {
+        "status_code": approve_one_status,
+        "assistant_text": approve_one_text,
+        "tooling_state": approve_one_state,
+    }
+    if "could not apply all scoped updates yet" in approve_one_text.lower():
+        retry_status, retry_response = _chat(config, token, approve_one_payload)
+        approve_one_status = retry_status
+        approve_one_response = retry_response
+        approve_one_text = str(
+            (((approve_one_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+            or ""
+        )
+        approve_one_state = approve_one_response.get("tooling_state") or {}
+        scenario["new_page_approve_one_retry"] = {
+            "status_code": retry_status,
+            "assistant_text": approve_one_text,
+            "tooling_state": approve_one_state,
+        }
+    _assert(summary, "s2_approve_one_status_200", approve_one_status == 200, str(scenario["new_page_approve_one"]))
+    _assert(
+        summary,
+        "s2_approve_one_saved_updates",
+        "saved scoped updates" in approve_one_text.lower(),
+        approve_one_text,
+    )
+    _assert(
+        summary,
+        "s2_approve_one_executes_writes",
+        int(approve_one_state.get("tool_calls_executed_count") or 0) >= 3,
+        str(approve_one_state),
+    )
+
+    answer_two = "Biggest blocker is dependency tracking, so I need a risk register and weekly review."
+    answer_two_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message=answer_two,
+        conversation_type=project_conversation_type,
+        mcp_scope_mode="project",
+        mcp_project_slug=created_scope_path,
+        mcp_project_name=scope_name,
+        params_extra=interview_base_params,
+        conversation_id=interview_conversation_id,
+    )
+    answer_two_status, answer_two_response = _chat(config, token, answer_two_payload)
+    answer_two_text = str(
+        (((answer_two_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    scenario["new_page_answer_two"] = {
+        "status_code": answer_two_status,
+        "assistant_text": answer_two_text,
+        "tooling_state": answer_two_response.get("tooling_state"),
+    }
+    _assert(summary, "s2_answer_two_status_200", answer_two_status == 200, str(scenario["new_page_answer_two"]))
+    _assert(
+        summary,
+        "s2_answer_two_preview_paths",
+        all(item in answer_two_text.lower() for item in ["spec.md", "build-plan.md", "status.md"]),
+        answer_two_text,
+    )
+
+    approve_two_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="approve",
+        conversation_type=project_conversation_type,
+        mcp_scope_mode="project",
+        mcp_project_slug=created_scope_path,
+        mcp_project_name=scope_name,
+        params_extra=interview_base_params,
+        conversation_id=interview_conversation_id,
+    )
+    approve_two_status, approve_two_response = _chat(config, token, approve_two_payload)
+    approve_two_text = str(
+        (((approve_two_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    approve_two_state = approve_two_response.get("tooling_state") or {}
+    scenario["new_page_approve_two"] = {
+        "status_code": approve_two_status,
+        "assistant_text": approve_two_text,
+        "tooling_state": approve_two_state,
+    }
+    if "could not apply all scoped updates yet" in approve_two_text.lower():
+        retry_status, retry_response = _chat(config, token, approve_two_payload)
+        approve_two_status = retry_status
+        approve_two_response = retry_response
+        approve_two_text = str(
+            (((approve_two_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+            or ""
+        )
+        approve_two_state = approve_two_response.get("tooling_state") or {}
+        scenario["new_page_approve_two_retry"] = {
+            "status_code": retry_status,
+            "assistant_text": approve_two_text,
+            "tooling_state": approve_two_state,
+        }
+    _assert(summary, "s2_approve_two_status_200", approve_two_status == 200, str(scenario["new_page_approve_two"]))
+    _assert(
+        summary,
+        "s2_approve_two_saved_updates",
+        "saved scoped updates" in approve_two_text.lower(),
+        approve_two_text,
+    )
+    _assert(
+        summary,
+        "s2_approve_two_executes_writes",
+        int(approve_two_state.get("tool_calls_executed_count") or 0) >= 3,
+        str(approve_two_state),
+    )
+
+    meta_path = (
+        config.library_root
+        / "users"
+        / _normalize_user_id(user_id)
+        / created_scope_path
+        / "_meta"
+        / "interview-state.md"
+    )
+    meta_content = ""
+    if meta_path.is_file():
+        meta_content = meta_path.read_text(encoding="utf-8")
+    scenario["new_page_meta_path"] = str(meta_path)
+    scenario["new_page_meta_excerpt"] = meta_content[-1200:]
+    progression_copy_seen = (
+        "question 2 of" in approve_one_text.lower()
+        or "question 3 of" in approve_two_text.lower()
+        or "saved scoped updates" in approve_two_text.lower()
+    )
+    _assert(
+        summary,
+        "s2_interview_progression_copy_seen",
+        progression_copy_seen,
+        f"approve_one={approve_one_text} | approve_two={approve_two_text}",
+    )
+    _assert(
+        summary,
+        "s2_meta_file_present_with_interview_state",
+        bool(meta_content.strip()) and "approved_answers" in meta_content,
+        scenario["new_page_meta_excerpt"],
+    )
+
+    profile_update_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Update my profile with: prefers concise weekly check-ins and decisive next-step summaries.",
+        conversation_type="chat",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    profile_update_status, profile_update_start = _chat(config, token, profile_update_payload)
+    profile_update_request = profile_update_start.get("approval_request") or {}
+    scenario["profile_update_start"] = {
+        "status_code": profile_update_status,
+        "approval_required": profile_update_start.get("approval_required"),
+        "approval_request": profile_update_request,
+        "tooling_state": profile_update_start.get("tooling_state"),
+    }
+    _assert(summary, "s2_profile_update_status_200", profile_update_status == 200, str(scenario["profile_update_start"]))
+    _assert(
+        summary,
+        "s2_profile_update_approval_required",
+        profile_update_start.get("approval_required") is True,
+        str(profile_update_start),
+    )
+    _assert(
+        summary,
+        "s2_profile_update_tool_is_profile_write",
+        str(profile_update_request.get("tool") or "").strip() in {"write_markdown", "create_markdown"},
+        str(profile_update_request),
+    )
+    profile_update_request_id = str(profile_update_request.get("request_id") or "").strip()
+    profile_update_conversation_id = str(profile_update_start.get("conversation_id") or "").strip()
+    profile_update_approve_status, profile_update_approve = _approve_pending_request(
+        config=config,
+        token=token,
+        base_payload=profile_update_payload,
+        conversation_id=profile_update_conversation_id,
+        request_id=profile_update_request_id,
+        action="approve",
+    )
+    scenario["profile_update_approve"] = {
+        "status_code": profile_update_approve_status,
+        "approval_resolution": profile_update_approve.get("approval_resolution"),
+        "tooling_state": profile_update_approve.get("tooling_state"),
+    }
+    _assert(
+        summary,
+        "s2_profile_update_approved",
+        (profile_update_approve.get("approval_resolution") or {}).get("status") == "approved",
+        str(scenario["profile_update_approve"]),
+    )
+
+    profile_reject_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Update my profile with: this reject-path probe should not persist.",
+        conversation_type="chat",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+        params_extra={"mcp_max_tool_iterations": 6},
+    )
+    profile_reject_status, profile_reject_start = _chat(config, token, profile_reject_payload)
+    profile_reject_request = profile_reject_start.get("approval_request") or {}
+    scenario["profile_reject_start"] = {
+        "status_code": profile_reject_status,
+        "approval_required": profile_reject_start.get("approval_required"),
+        "approval_request": profile_reject_request,
+    }
+    _assert(summary, "s2_profile_reject_status_200", profile_reject_status == 200, str(scenario["profile_reject_start"]))
+    _assert(
+        summary,
+        "s2_profile_reject_approval_required",
+        profile_reject_start.get("approval_required") is True,
+        str(profile_reject_start),
+    )
+    profile_reject_request_id = str(profile_reject_request.get("request_id") or "").strip()
+    profile_reject_conversation_id = str(profile_reject_start.get("conversation_id") or "").strip()
+    profile_reject_status_2, profile_reject_response = _approve_pending_request(
+        config=config,
+        token=token,
+        base_payload=profile_reject_payload,
+        conversation_id=profile_reject_conversation_id,
+        request_id=profile_reject_request_id,
+        action="reject",
+    )
+    profile_reject_text = str(
+        (((profile_reject_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    ).lower()
+    scenario["profile_reject_resolution"] = {
+        "status_code": profile_reject_status_2,
+        "approval_resolution": profile_reject_response.get("approval_resolution"),
+        "assistant_text": profile_reject_text,
+    }
+    _assert(
+        summary,
+        "s2_profile_reject_resolution_rejected",
+        (profile_reject_response.get("approval_resolution") or {}).get("status") == "rejected",
+        str(scenario["profile_reject_resolution"]),
+    )
+    _assert(
+        summary,
+        "s2_profile_reject_copy_present",
+        "did not run mutating tool" in profile_reject_text or "rejected" in profile_reject_text,
+        profile_reject_text,
+    )
+    return scenario
+
+
+def _run_s3(summary: ProbeSummary, config: Config, token: str, user_id: str, run_dir: Path) -> Dict[str, Any]:
+    scenario: Dict[str, Any] = {}
+
+    scenario["onboarding_seed_relationships_pending"] = _set_topic_onboarding_status(
+        config,
+        user_id,
+        "relationships",
+        "pending",
+    )
+
+    chat_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Give me one concise finance focus for this week.",
+        conversation_type="chat",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+    )
+    chat_status, chat_response = _chat(config, token, chat_payload)
+    chat_text = str(
+        (((chat_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    scenario["chat_step"] = {
+        "status_code": chat_status,
+        "assistant_text": chat_text,
+        "tooling_state": chat_response.get("tooling_state"),
+    }
+    _assert(summary, "s3_chat_status_200", chat_status == 200, str(scenario["chat_step"]))
+    _assert(summary, "s3_chat_text_present", bool(chat_text.strip()), str(scenario["chat_step"]))
+
+    capture_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message=(
+            "Capture this note and decision in finances and career. "
+            "Decision: automate bill reminders by 2026-03-05. "
+            "Add task: Dave J to review S3 mixed flow by next week."
+        ),
+        conversation_type="capture",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/finances",
+        mcp_project_name="Finances",
+    )
+    capture_status, capture_response = _chat(config, token, capture_payload)
+    capture_request = capture_response.get("approval_request") or {}
+    scenario["capture_step_start"] = {
+        "status_code": capture_status,
+        "approval_required": capture_response.get("approval_required"),
+        "approval_request": capture_request,
+        "tooling_state": capture_response.get("tooling_state"),
+    }
+    _assert(summary, "s3_capture_status_200", capture_status == 200, str(scenario["capture_step_start"]))
+    _assert(
+        summary,
+        "s3_capture_first_approval_create_markdown",
+        capture_response.get("approval_required") is True and capture_request.get("tool") == "create_markdown",
+        str(capture_request),
+    )
+    capture_chain = _approval_chain(
+        config=config,
+        token=token,
+        base_payload=capture_payload,
+        start_response=capture_response,
+        max_steps=3,
+    )
+    scenario["capture_step_chain"] = capture_chain
+    _assert(summary, "s3_capture_chain_progressed", len(capture_chain) >= 1, str(capture_chain))
+
+    onboarding_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Start my Relationships onboarding interview.",
+        conversation_type="life-relationships",
+        mcp_scope_mode="project",
+        mcp_project_slug="life/relationships",
+        mcp_project_name="Relationships",
+        params_extra={"mcp_tools_enabled": False},
+    )
+    onboarding_status, onboarding_response = _chat(config, token, onboarding_payload)
+    onboarding_text = str(
+        (((onboarding_response.get("choices") or [{}])[0] or {}).get("message") or {}).get("content")
+        or ""
+    )
+    scenario["onboarding_step"] = {
+        "status_code": onboarding_status,
+        "assistant_text": onboarding_text,
+        "tooling_state": onboarding_response.get("tooling_state"),
+    }
+    _assert(summary, "s3_onboarding_status_200", onboarding_status == 200, str(scenario["onboarding_step"]))
+    _assert(
+        summary,
+        "s3_onboarding_question_started",
+        "question 1 of" in onboarding_text.lower(),
+        onboarding_text,
+    )
+
+    _set_topic_onboarding_status(config, user_id, "finances", "complete")
+    _set_topic_onboarding_status(config, user_id, "relationships", "complete")
+    cross_prompts = [
+        "Mirror this finance habit into relationships as a quick cross-topic note.",
+        "Create a cross-pollination note from finances to relationships and include next action.",
+    ]
+    cross_payload: Optional[Dict[str, Any]] = None
+    cross_status: int = 0
+    cross_response: Dict[str, Any] = {}
+    cross_request: Dict[str, Any] = {}
+    selected_cross_prompt = ""
+    for prompt in cross_prompts:
+        candidate_payload = _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=prompt,
+            conversation_type="life-finances",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+        )
+        candidate_status, candidate_response = _chat(config, token, candidate_payload)
+        candidate_request = candidate_response.get("approval_request") or {}
+        tool_name = str(candidate_request.get("tool") or "").strip()
+        if candidate_status == 200 and candidate_response.get("approval_required") is True and tool_name in {
+            "create_markdown",
+            "ensure_scope_scaffold",
+        }:
+            cross_payload = candidate_payload
+            cross_status = candidate_status
+            cross_response = candidate_response
+            cross_request = candidate_request
+            selected_cross_prompt = prompt
+            break
+        if not cross_payload:
+            cross_payload = candidate_payload
+            cross_status = candidate_status
+            cross_response = candidate_response
+            cross_request = candidate_request
+            selected_cross_prompt = prompt
+
+    cross_tool_name = str(cross_request.get("tool") or "").strip()
+    if not (
+        cross_status == 200
+        and cross_response.get("approval_required") is True
+        and cross_tool_name in {"create_markdown", "ensure_scope_scaffold"}
+    ):
+        forced_prompt = (
+            "[LIBRARY SCOPE - Life / finances] Use create_markdown to write "
+            f"life/relationships/cross-pollination/s3-mixed-{summary.run_id}.md "
+            "with content: S3 mixed-run cross topic note from finances to relationships."
+        )
+        forced_payload = _build_chat_payload(
+            config=config,
+            user_id=user_id,
+            message=forced_prompt,
+            conversation_type="life-finances",
+            mcp_scope_mode="project",
+            mcp_project_slug="life/finances",
+            mcp_project_name="Finances",
+        )
+        forced_status, forced_response = _chat(config, token, forced_payload)
+        forced_request = forced_response.get("approval_request") or {}
+        cross_payload = forced_payload
+        cross_status = forced_status
+        cross_response = forced_response
+        cross_request = forced_request
+        selected_cross_prompt = forced_prompt
+
+    cross_reason = str(cross_request.get("synthetic_reason") or "")
+    scenario["cross_pollination_step"] = {
+        "selected_prompt": selected_cross_prompt,
+        "status_code": cross_status,
+        "approval_required": cross_response.get("approval_required"),
+        "approval_request": cross_request,
+        "tooling_state": cross_response.get("tooling_state"),
+    }
+    _assert(summary, "s3_cross_status_200", cross_status == 200, str(scenario["cross_pollination_step"]))
+    _assert(
+        summary,
+        "s3_cross_initial_tool_expected",
+        cross_response.get("approval_required") is True
+        and str(cross_request.get("tool") or "").strip() in {"create_markdown", "ensure_scope_scaffold"},
+        str(cross_request),
+    )
+
+    cross_follow_chain = _approval_chain(
+        config=config,
+        token=token,
+        base_payload=cross_payload or {},
+        start_response=cross_response,
+        max_steps=4,
+    )
+    scenario["cross_pollination_chain"] = cross_follow_chain
+    cross_tools = [str(cross_request.get("tool") or "").strip()]
+    cross_reasons = [cross_reason]
+    cross_paths = [str((cross_request.get("arguments") or {}).get("path") or "")]
+    for step in cross_follow_chain:
+        next_request = (step.get("response") or {}).get("approval_request") or {}
+        tool_name = str(next_request.get("tool") or "").strip()
+        reason = str(next_request.get("synthetic_reason") or "")
+        path_value = str((next_request.get("arguments") or {}).get("path") or "")
+        if tool_name:
+            cross_tools.append(tool_name)
+        if reason:
+            cross_reasons.append(reason)
+        if path_value:
+            cross_paths.append(path_value)
+    scenario["cross_pollination_tools"] = cross_tools
+    scenario["cross_pollination_reasons"] = cross_reasons
+    scenario["cross_pollination_paths"] = cross_paths
+    _assert(
+        summary,
+        "s3_cross_chain_contains_create_markdown",
+        any(tool_name == "create_markdown" for tool_name in cross_tools),
+        str(cross_tools),
+    )
+    _assert(
+        summary,
+        "s3_cross_signal_seen",
+        any(reason.startswith("cross_pollination_finances_to_") for reason in cross_reasons)
+        or any("/cross-pollination/" in path_value for path_value in cross_paths),
+        f"reasons={cross_reasons} paths={cross_paths}",
+    )
+
+    digest_email_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Run mixed-sweep digest email now.",
+        conversation_type="digest-email",
+        mcp_scope_mode="none",
+        params_extra={
+            "mcp_tools_enabled": False,
+            "mcp_tool_profile": "read_only",
+            "mcp_digest_schedule_enabled": True,
+            "mcp_digest_force_run": True,
+            "mcp_digest_schedule_event_id": f"s3-email-{summary.run_id}",
+            "mcp_digest_delivery_send_enabled": True,
+            "mcp_digest_delivery_endpoint": config.delivery_email_endpoint,
+        },
+    )
+    digest_email_status, digest_email_response = _chat(config, token, digest_email_payload)
+    digest_email_state = digest_email_response.get("tooling_state") or {}
+    scenario["digest_email_step"] = {
+        "status_code": digest_email_status,
+        "tooling_state": digest_email_state,
+    }
+    _assert(summary, "s3_digest_email_status_200", digest_email_status == 200, str(scenario["digest_email_step"]))
+    _assert(
+        summary,
+        "s3_digest_email_sent",
+        str(digest_email_state.get("digest_delivery_send_status") or "") == "sent",
+        str(digest_email_state),
+    )
+
+    digest_slack_payload = _build_chat_payload(
+        config=config,
+        user_id=user_id,
+        message="Run mixed-sweep digest slack now.",
+        conversation_type="digest-slack",
+        mcp_scope_mode="none",
+        params_extra={
+            "mcp_tools_enabled": False,
+            "mcp_tool_profile": "read_only",
+            "mcp_digest_schedule_enabled": True,
+            "mcp_digest_force_run": True,
+            "mcp_digest_schedule_event_id": f"s3-slack-{summary.run_id}",
+            "mcp_digest_delivery_send_enabled": True,
+            "mcp_digest_delivery_endpoint": config.delivery_slack_endpoint,
+        },
+    )
+    digest_slack_status, digest_slack_response = _chat(config, token, digest_slack_payload)
+    digest_slack_state = digest_slack_response.get("tooling_state") or {}
+    scenario["digest_slack_step"] = {
+        "status_code": digest_slack_status,
+        "tooling_state": digest_slack_state,
+    }
+    _assert(summary, "s3_digest_slack_status_200", digest_slack_status == 200, str(scenario["digest_slack_step"]))
+    _assert(
+        summary,
+        "s3_digest_slack_sent",
+        str(digest_slack_state.get("digest_delivery_send_status") or "") == "sent",
+        str(digest_slack_state),
+    )
+
+    browser_result = _run_r3_browser_probe(summary, config, run_dir / "s3-r3-browser")
+    scenario["browser_r3"] = browser_result
+    return scenario
+
+
+def _write_summary(summary: ProbeSummary, output_dir: Path) -> Path:
+    output_dir.mkdir(parents=True, exist_ok=True)
+    out_path = output_dir / "summary.json"
+    payload = {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "ui_base_url": summary.ui_base_url,
+        "provider": summary.provider,
+        "model": summary.model,
+        "reset_applied": summary.reset_applied,
+        "success": summary.success,
+        "error": summary.error,
+        "assertions": [
+            {"name": item.name, "passed": item.passed, "detail": item.detail}
+            for item in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "artifacts": summary.artifacts,
+    }
+    out_path.write_text(json.dumps(payload, indent=2, ensure_ascii=True) + "\n", encoding="utf-8")
+    return out_path
+
+
+def parse_args() -> Config:
+    parser = argparse.ArgumentParser(description="Run live Process S.1/S.2/S.3 probes.")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--ui-base-url", default="http://localhost:5173")
+    parser.add_argument("--email", default="cccc@gmail.com")
+    parser.add_argument("--password", default="10012002")
+    parser.add_argument("--provider", default="ollama")
+    parser.add_argument("--settings-id", default="ollama_settings")
+    parser.add_argument("--server-id", default="ollama_default_server")
+    parser.add_argument("--model", default="qwen3:8b")
+    parser.add_argument("--browser-model-hint", default="qwen3:8b (new server)")
+    parser.add_argument(
+        "--output-dir",
+        default="/home/hacker/BrainDriveDev/BrainDrive/tmp/live-process-s123",
+    )
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=1.2)
+    parser.add_argument("--http-max-retries", type=int, default=5)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=1.5)
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    parser.add_argument(
+        "--delivery-email-endpoint",
+        default="https://httpbin.org/post?channel=s3-email",
+    )
+    parser.add_argument(
+        "--delivery-slack-endpoint",
+        default="https://httpbin.org/post?channel=s3-slack",
+    )
+    parser.add_argument(
+        "--reset-from-template",
+        dest="reset_from_template",
+        action="store_true",
+        default=True,
+    )
+    parser.add_argument(
+        "--no-reset-from-template",
+        dest="reset_from_template",
+        action="store_false",
+    )
+    args = parser.parse_args()
+    return Config(
+        base_url=args.base_url,
+        ui_base_url=args.ui_base_url,
+        email=args.email,
+        password=args.password,
+        provider=args.provider,
+        settings_id=args.settings_id,
+        server_id=args.server_id,
+        model=args.model,
+        browser_model_hint=args.browser_model_hint,
+        output_dir=Path(args.output_dir),
+        timeout_seconds=max(15, int(args.timeout_seconds)),
+        request_delay_seconds=max(0.0, float(args.request_delay_seconds)),
+        http_max_retries=max(0, int(args.http_max_retries)),
+        http_retry_base_seconds=max(0.1, float(args.http_retry_base_seconds)),
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root),
+        template_root=Path(args.template_root),
+        delivery_email_endpoint=str(args.delivery_email_endpoint),
+        delivery_slack_endpoint=str(args.delivery_slack_endpoint),
+    )
+
+
+def main() -> int:
+    config = parse_args()
+    started_at = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    run_dir = config.output_dir / f"run-{run_id}"
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=started_at,
+        base_url=config.base_url,
+        ui_base_url=config.ui_base_url,
+        provider=config.provider,
+        model=config.model,
+        reset_applied=False,
+    )
+
+    try:
+        token, user_id = _login(config)
+        summary.artifacts["login"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap_meta = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.artifacts["template_reset"] = bootstrap_meta
+
+        summary.scenarios["s1"] = _run_s1(summary, config, token, user_id)
+        summary.scenarios["s2"] = _run_s2(summary, config, token, user_id, run_dir)
+        summary.scenarios["s3"] = _run_s3(summary, config, token, user_id, run_dir)
+        summary.success = all(item.passed for item in summary.assertions)
+    except Exception as exc:
+        summary.success = False
+        summary.error = str(exc)
+    finally:
+        output_path = _write_summary(summary, run_dir)
+        print(json.dumps(
+            {
+                "run_id": summary.run_id,
+                "success": summary.success,
+                "error": summary.error,
+                "assertions_passed": sum(1 for item in summary.assertions if item.passed),
+                "assertions_total": len(summary.assertions),
+                "summary_path": str(output_path),
+            },
+            ensure_ascii=True,
+            indent=2,
+        ))
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/e2e_process_s2_profile_browser.ts
+++ b/scripts/e2e_process_s2_profile_browser.ts
@@ -1,0 +1,447 @@
+import { mkdir, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { connect, waitForPageLoad } from "/home/hacker/.codex/skills/dev-browser/src/client.ts";
+
+type Assertion = {
+  name: string;
+  passed: boolean;
+  detail?: unknown;
+};
+
+type Summary = {
+  process: "S2_PROFILE";
+  run_id: string;
+  started_at: string;
+  base_url: string;
+  assertions: Assertion[];
+  screenshots: string[];
+  success: boolean;
+  error?: string;
+};
+
+function argValue(name: string, fallback: string): string {
+  const idx = process.argv.indexOf(name);
+  if (idx >= 0 && idx + 1 < process.argv.length) {
+    return process.argv[idx + 1] ?? fallback;
+  }
+  return fallback;
+}
+
+function assertPush(summary: Summary, name: string, passed: boolean, detail?: unknown): void {
+  summary.assertions.push({ name, passed, detail });
+  if (!passed) {
+    throw new Error(`Assertion failed: ${name} :: ${JSON.stringify(detail ?? null)}`);
+  }
+}
+
+async function waitForVisible(
+  page: import("playwright").Page,
+  selectors: string[],
+  timeoutMs = 60000
+): Promise<boolean> {
+  const started = Date.now();
+  while (Date.now() - started < timeoutMs) {
+    for (const selector of selectors) {
+      const locator = page.locator(selector);
+      const count = await locator.count();
+      if (count > 0) {
+        const visible = await locator.first().isVisible().catch(() => false);
+        if (visible) {
+          return true;
+        }
+      }
+    }
+    await page.waitForTimeout(250);
+  }
+  return false;
+}
+
+async function waitForPromptInput(page: import("playwright").Page, timeoutMs = 90000): Promise<boolean> {
+  const selectors = [
+    'textarea[placeholder="What would you like to know?"]',
+    'input[placeholder="What would you like to know?"]',
+  ];
+  return waitForVisible(page, selectors, timeoutMs);
+}
+
+async function navigateToAiChat(
+  page: import("playwright").Page,
+  baseUrl: string,
+  summary: Summary
+): Promise<void> {
+  await page.goto(`${baseUrl}/pages/ai-chat`);
+  await waitForPageLoad(page, { timeout: 45000 });
+  const inputReady = await waitForPromptInput(page, 120000);
+  assertPush(summary, "s2_profile_input_ready", inputReady, { url: page.url() });
+  assertPush(summary, "s2_profile_route_ok", page.url().includes("/pages/ai-chat"), { url: page.url() });
+}
+
+async function ensureModelSelected(
+  page: import("playwright").Page,
+  summary: Summary,
+  modelHint: string
+): Promise<void> {
+  if (!modelHint.trim()) {
+    return;
+  }
+
+  const trigger = page.locator(".header-model-section .searchable-dropdown-trigger").first();
+  assertPush(summary, "s2_profile_model_trigger_present", (await trigger.count()) > 0);
+
+  const currentText = ((await trigger.textContent()) ?? "").toLowerCase();
+  if (currentText.includes(modelHint.toLowerCase())) {
+    assertPush(summary, "s2_profile_model_selected", true, { model_hint: modelHint, selected: currentText });
+    return;
+  }
+
+  await trigger.click();
+  const input = page.locator(".header-model-section .searchable-dropdown-input").first();
+  assertPush(summary, "s2_profile_model_search_present", (await input.count()) > 0);
+  await input.fill(modelHint);
+  await input.press("Enter");
+  await page.waitForTimeout(2500);
+
+  const updatedText = ((await trigger.textContent()) ?? "").toLowerCase();
+  assertPush(summary, "s2_profile_model_selected", updatedText.includes(modelHint.toLowerCase()), {
+    model_hint: modelHint,
+    selected: updatedText,
+  });
+}
+
+async function startFreshConversation(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const historyValue = page.locator(".header-history-section .searchable-dropdown-value").first();
+  assertPush(summary, `${prefix}_history_value_present`, (await historyValue.count()) > 0);
+
+  const button = page.locator('button[title="Start New Chat"]').first();
+  assertPush(summary, `${prefix}_new_chat_button_present`, (await button.count()) > 0);
+  await button.click();
+  await page.waitForTimeout(1200);
+
+  let historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  if (!/start new chat/i.test(historyLabel)) {
+    const historyTrigger = page.locator(".header-history-section .searchable-dropdown-trigger").first();
+    assertPush(summary, `${prefix}_history_trigger_present`, (await historyTrigger.count()) > 0);
+    await historyTrigger.click();
+    const startNewOption = page.locator(".searchable-dropdown-option:has-text('Start New Chat')").first();
+    assertPush(summary, `${prefix}_history_start_new_option_present`, (await startNewOption.count()) > 0);
+    await startNewOption.click();
+    await page.waitForTimeout(1200);
+    historyLabel = ((await historyValue.textContent()) ?? "").trim();
+  }
+  assertPush(summary, `${prefix}_history_start_new_selected`, /start new chat/i.test(historyLabel), {
+    history_label: historyLabel,
+  });
+
+  const inputReady = await waitForPromptInput(page, 60000);
+  assertPush(summary, `${prefix}_new_chat_ready`, inputReady);
+}
+
+async function ensureLoginIfNeeded(
+  page: import("playwright").Page,
+  email: string,
+  password: string,
+  summary: Summary
+): Promise<void> {
+  const maxAttempts = 4;
+  for (let attempt = 1; attempt <= maxAttempts; attempt += 1) {
+    const passwordInput = page.locator('input[type="password"]');
+    const needsLogin = page.url().includes("/login") || (await passwordInput.count()) > 0;
+    if (!needsLogin) {
+      return;
+    }
+
+    const emailInput = page.locator('input[type="email"], input[name="email"]');
+    assertPush(
+      summary,
+      `s2_profile_login_email_input_present_attempt_${attempt}`,
+      (await emailInput.count()) > 0
+    );
+
+    await emailInput.first().fill(email);
+    await passwordInput.first().fill(password);
+
+    const submitCandidates = [
+      page.getByRole("button", { name: /sign in|login|log in/i }),
+      page.locator('button[type="submit"]'),
+    ];
+
+    let clicked = false;
+    for (const candidate of submitCandidates) {
+      const count = await candidate.count();
+      if (count > 0) {
+        await candidate.first().click();
+        clicked = true;
+        break;
+      }
+    }
+    assertPush(summary, `s2_profile_login_submit_clicked_attempt_${attempt}`, clicked);
+
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2500 + attempt * 1000);
+    if (!page.url().includes("/login")) {
+      assertPush(summary, "s2_profile_login_redirected", true, { url: page.url(), attempt });
+      return;
+    }
+  }
+
+  assertPush(summary, "s2_profile_login_redirected", false, { url: page.url() });
+}
+
+async function sendPrompt(
+  page: import("playwright").Page,
+  prompt: string,
+  summary: Summary,
+  prefix: string,
+  requirePending = true
+): Promise<boolean> {
+  const inputReady = await waitForPromptInput(page, 90000);
+  assertPush(summary, `${prefix}_input_present`, inputReady);
+
+  const input = page.locator(
+    'textarea[placeholder="What would you like to know?"], input[placeholder="What would you like to know?"]'
+  );
+  assertPush(summary, `${prefix}_input_locator_present`, (await input.count()) > 0);
+  await input.first().fill(prompt);
+
+  const pendingLocator = page.locator("text=PENDING");
+  const approvalCopyLocator = page.locator("text=Approval required to run mutating tool");
+  const pendingBaseline = await pendingLocator.count();
+  const approvalCopyBaseline = await approvalCopyLocator.count();
+
+  const sendCandidates = [
+    page.getByRole("button", { name: /send message/i }),
+    page.locator('button[aria-label="Send message"]'),
+  ];
+
+  let sent = false;
+  for (const candidate of sendCandidates) {
+    const count = await candidate.count();
+    if (count > 0) {
+      await candidate.first().click();
+      sent = true;
+      break;
+    }
+  }
+  assertPush(summary, `${prefix}_send_clicked`, sent);
+
+  const start = Date.now();
+  let pendingVisible = false;
+  const deadline = Date.now() + 65000;
+  while (Date.now() < deadline) {
+    const pendingCount = await pendingLocator.count();
+    const approvalCopyCount = await approvalCopyLocator.count();
+    if (pendingCount > pendingBaseline || approvalCopyCount > approvalCopyBaseline) {
+      pendingVisible = true;
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  const elapsed = Date.now() - start;
+  if (requirePending) {
+    assertPush(summary, `${prefix}_pending_visible`, pendingVisible, { elapsed_ms: elapsed });
+    if (pendingVisible) {
+      assertPush(summary, `${prefix}_approval_latency_under_60s`, elapsed <= 60000, { elapsed_ms: elapsed });
+      const copyVisible = await waitForVisible(page, ["text=Approval required to run mutating tool"], 10000);
+      assertPush(summary, `${prefix}_approval_copy_visible`, copyVisible);
+    }
+  } else {
+    summary.assertions.push({
+      name: `${prefix}_pending_visible_optional`,
+      passed: true,
+      detail: { elapsed_ms: elapsed, pending_visible: pendingVisible },
+    });
+  }
+  return pendingVisible;
+}
+
+async function inspectPendingProfileToolHint(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<{ toolMatched: boolean; profilePathMatched: boolean }> {
+  const deadline = Date.now() + 20000;
+  let toolMatched = false;
+  let profilePathMatched = false;
+  while (Date.now() < deadline) {
+    const bodyText = (await page.locator("body").innerText().catch(() => "")).toLowerCase();
+    if (bodyText.includes("write_markdown") || bodyText.includes("create_markdown")) {
+      toolMatched = true;
+    }
+    if (bodyText.includes("me/profile.md")) {
+      profilePathMatched = true;
+    }
+    if (toolMatched && profilePathMatched) {
+      break;
+    }
+    await page.waitForTimeout(250);
+  }
+  summary.assertions.push({
+    name: `${prefix}_pending_profile_hint_observed`,
+    passed: true,
+    detail: { tool_matched: toolMatched, profile_path_matched: profilePathMatched },
+  });
+  return { toolMatched, profilePathMatched };
+}
+
+async function clickStrictApprovalButton(
+  page: import("playwright").Page,
+  buttonName: "Approve" | "Reject",
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  const buttonLocator = page.getByRole("button", { name: buttonName });
+  const count = await buttonLocator.count();
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_present`, count > 0, { count });
+  const visibleCount = await buttonLocator.evaluateAll((nodes) =>
+    nodes.filter((node) => {
+      const style = window.getComputedStyle(node as HTMLElement);
+      const hidden = style.display === "none" || style.visibility === "hidden";
+      const rect = (node as HTMLElement).getBoundingClientRect();
+      return !hidden && rect.width > 0 && rect.height > 0;
+    }).length
+  );
+  assertPush(summary, `${prefix}_${buttonName.toLowerCase()}_button_visible_unique`, visibleCount === 1, {
+    visible_count: visibleCount,
+  });
+  await buttonLocator.first().click();
+}
+
+async function resolveRejectSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Reject", summary, prefix);
+  const rejectOutcome = await waitForVisible(
+    page,
+    ["text=REJECTED", "text=did not run mutating tool", "text=cancelled"],
+    45000
+  );
+  assertPush(summary, `${prefix}_reject_semantics`, rejectOutcome);
+}
+
+async function resolveApproveSemantics(
+  page: import("playwright").Page,
+  summary: Summary,
+  prefix: string
+): Promise<void> {
+  await clickStrictApprovalButton(page, "Approve", summary, prefix);
+  const approveOutcome = await waitForVisible(
+    page,
+    ["text=APPROVED", "text=successfully saved", "text=updated", "text=written", "text=saved"],
+    45000
+  );
+  assertPush(summary, `${prefix}_approve_semantics`, approveOutcome);
+}
+
+async function main(): Promise<void> {
+  const baseUrl = argValue("--base-url", "http://localhost:5173").replace(/\/$/, "");
+  const email = argValue("--email", "cccc@gmail.com");
+  const password = argValue("--password", "10012002");
+  const modelHint = argValue("--model-hint", "qwen3:8b");
+  const outputDir = argValue(
+    "--output-dir",
+    "/home/hacker/BrainDriveDev/BrainDrive/tmp/live-process-s2-profile-browser"
+  );
+
+  const runId = new Date().toISOString().replace(/[-:.TZ]/g, "").slice(0, 14);
+  const summary: Summary = {
+    process: "S2_PROFILE",
+    run_id: runId,
+    started_at: new Date().toISOString(),
+    base_url: baseUrl,
+    assertions: [],
+    screenshots: [],
+    success: false,
+  };
+
+  const artifactDir = path.resolve(outputDir);
+  await mkdir(artifactDir, { recursive: true });
+
+  const client = await connect();
+  const page = await client.page("process-s2-profile", { viewport: { width: 1440, height: 1000 } });
+
+  try {
+    await page.goto(`${baseUrl}/dashboard`);
+    await waitForPageLoad(page, { timeout: 30000 });
+    await page.waitForTimeout(2000);
+
+    await ensureLoginIfNeeded(page, email, password, summary);
+    assertPush(summary, "s2_profile_session_ready", true, { url: page.url() });
+
+    await navigateToAiChat(page, baseUrl, summary);
+    await ensureModelSelected(page, summary, modelHint);
+
+    await startFreshConversation(page, summary, "s2_profile_reject");
+    const rejectPrompt = `Update my profile with: prefers concise weekly check-ins and Friday planning summaries (${runId}).`;
+    let rejectPending = await sendPrompt(page, rejectPrompt, summary, "s2_profile_reject", false);
+    if (!rejectPending) {
+      const rejectFallbackPrompt =
+        `[LIBRARY SCOPE - Life / finances] Use write_markdown on me/profile.md ` +
+        `and append bullet "- prefers concise weekly check-ins (${runId}-fallback-reject)".`;
+      rejectPending = await sendPrompt(page, rejectFallbackPrompt, summary, "s2_profile_reject_fallback", true);
+    }
+    assertPush(summary, "s2_profile_reject_pending_final", rejectPending);
+    const rejectHints = await inspectPendingProfileToolHint(page, summary, "s2_profile_reject");
+    assertPush(
+      summary,
+      "s2_profile_reject_profile_hint_seen",
+      rejectHints.toolMatched || rejectHints.profilePathMatched,
+      rejectHints
+    );
+    await resolveRejectSemantics(page, summary, "s2_profile_reject");
+
+    await startFreshConversation(page, summary, "s2_profile_approve");
+    const approvePrompt = `Update my profile with: prefers concise weekly check-ins and Friday planning summaries (${runId}-approve).`;
+    let approvePending = await sendPrompt(page, approvePrompt, summary, "s2_profile_approve", false);
+    if (!approvePending) {
+      const approveFallbackPrompt =
+        `[LIBRARY SCOPE - Life / finances] Use write_markdown on me/profile.md ` +
+        `and append bullet "- prefers concise weekly check-ins (${runId}-fallback-approve)".`;
+      approvePending = await sendPrompt(
+        page,
+        approveFallbackPrompt,
+        summary,
+        "s2_profile_approve_fallback",
+        true
+      );
+    }
+    assertPush(summary, "s2_profile_approve_pending_final", approvePending);
+    await inspectPendingProfileToolHint(page, summary, "s2_profile_approve");
+    await resolveApproveSemantics(page, summary, "s2_profile_approve");
+
+    const screenshotPath = path.resolve(artifactDir, `s2-profile-browser-${runId}.png`);
+    await page.screenshot({ path: screenshotPath, fullPage: true });
+    summary.screenshots.push(screenshotPath);
+
+    summary.success = summary.assertions.every((a) => a.passed);
+  } catch (error) {
+    summary.success = false;
+    summary.error = error instanceof Error ? error.message : String(error);
+    const errorShot = path.resolve(artifactDir, `s2-profile-browser-${runId}-error.png`);
+    try {
+      await page.screenshot({ path: errorShot, fullPage: true });
+      summary.screenshots.push(errorShot);
+    } catch {
+      // ignore screenshot failure on error path
+    }
+  } finally {
+    const outPath = path.resolve(artifactDir, `s2-profile-browser-${runId}.json`);
+    await writeFile(outPath, JSON.stringify(summary, null, 2) + "\n", "utf-8");
+    console.log(JSON.stringify(summary, null, 2));
+    await client.disconnect();
+  }
+
+  if (!summary.success) {
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error(error);
+  process.exit(1);
+});

--- a/scripts/e2e_task_parity_capture_finances.py
+++ b/scripts/e2e_task_parity_capture_finances.py
@@ -1,0 +1,962 @@
+#!/usr/bin/env python3
+"""Targeted parity probe: Library Capture vs Finances page task flow.
+
+Flow per provider and per page:
+1) Ask to create task: "I need to pay back my friend 20 dollars by Feb 20 2026."
+2) Verify mutating approval appears and approve through pending approvals.
+3) Verify create_task approval payload quality.
+4) Ask as a user if the task exists and verify retrieval response.
+
+Runs local (default qwen3:8b) and OpenRouter by default.
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import random
+import re
+import shutil
+import subprocess
+import sys
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional, Tuple
+from urllib import error as urllib_error
+from urllib import request as urllib_request
+
+
+APPROVAL_REQUIRED_TEXT = (
+    "Approval required before executing mutating tool call. "
+    "Reply `approve` to continue or `reject` to cancel."
+)
+CREATE_PROMPT = "I need to pay back my friend 20 dollars by Feb 20 2026."
+CREATE_CONFIRM_PROMPT = "Yes, please create that task now with the same details."
+VERIFY_PROMPT = (
+    "Use the list_tasks tool to check my open tasks. Do I already have any task "
+    "for paying back my friend 20 dollars ($20) by 2026-02-20? "
+    "Lookup only: do not create, update, or modify tasks. "
+    "If yes, list each match with task id, title, due date, owner, and scope."
+)
+VERIFY_FALLBACK_PROMPT = (
+    "Use the list_tasks tool and list my open tasks with task id, title, due date, "
+    "owner, and scope. This is lookup only; do not create, update, or modify tasks."
+)
+
+
+@dataclass
+class AssertionResult:
+    name: str
+    passed: bool
+    detail: str = ""
+
+
+@dataclass
+class ProviderTarget:
+    label: str
+    provider: str
+    settings_id: str
+    server_id: str
+    model: str
+
+
+@dataclass
+class Config:
+    base_url: str
+    email: str
+    password: str
+    local_provider: str
+    local_settings_id: str
+    local_server_id: str
+    local_model: str
+    openrouter_settings_id: str
+    openrouter_server_id: str
+    openrouter_model: str
+    skip_local: bool
+    skip_openrouter: bool
+    output_dir: Path
+    timeout_seconds: int
+    request_delay_seconds: float
+    http_max_retries: int
+    http_retry_base_seconds: float
+    reset_from_template: bool
+    library_root: Path
+    template_root: Path
+
+
+@dataclass
+class ProbeSummary:
+    run_id: str
+    started_at: str
+    base_url: str
+    reset_applied: bool
+    assertions: List[AssertionResult] = field(default_factory=list)
+    scenarios: Dict[str, Any] = field(default_factory=dict)
+    success: bool = False
+    error: Optional[str] = None
+
+
+_LAST_REQUEST_SENT_MONOTONIC: Optional[float] = None
+
+
+def _assert(summary: ProbeSummary, name: str, condition: bool, detail: str = "") -> None:
+    summary.assertions.append(AssertionResult(name=name, passed=bool(condition), detail=detail))
+    if not condition:
+        raise RuntimeError(f"Assertion failed: {name}. {detail}".strip())
+
+
+def _decode_json_bytes(raw: bytes) -> Dict[str, Any]:
+    text = raw.decode("utf-8", errors="replace")
+    if not text.strip():
+        return {}
+    try:
+        parsed = json.loads(text)
+    except Exception:
+        return {"raw": text}
+    if isinstance(parsed, dict):
+        return parsed
+    return {"data": parsed}
+
+
+def _throttle(request_delay_seconds: float) -> None:
+    global _LAST_REQUEST_SENT_MONOTONIC
+    if request_delay_seconds <= 0:
+        return
+    now = time.monotonic()
+    if _LAST_REQUEST_SENT_MONOTONIC is not None:
+        elapsed = now - _LAST_REQUEST_SENT_MONOTONIC
+        if elapsed < request_delay_seconds:
+            time.sleep(request_delay_seconds - elapsed)
+    _LAST_REQUEST_SENT_MONOTONIC = time.monotonic()
+
+
+def _http_json(
+    *,
+    method: str,
+    url: str,
+    timeout_seconds: int,
+    request_delay_seconds: float,
+    max_retries: int,
+    retry_base_seconds: float,
+    token: Optional[str] = None,
+    payload: Optional[Dict[str, Any]] = None,
+) -> Tuple[int, Dict[str, Any]]:
+    body: Optional[bytes] = None
+    if payload is not None:
+        body = json.dumps(payload).encode("utf-8")
+    headers = {"Content-Type": "application/json"}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    attempt = 0
+    while True:
+        req = urllib_request.Request(url=url, data=body, headers=headers, method=method.upper())
+        try:
+            _throttle(request_delay_seconds)
+            with urllib_request.urlopen(req, timeout=timeout_seconds) as response:
+                return int(response.status), _decode_json_bytes(response.read())
+        except urllib_error.HTTPError as exc:
+            parsed = _decode_json_bytes(exc.read())
+            if exc.code == 429 and attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            return int(exc.code), parsed
+        except urllib_error.URLError as exc:
+            if attempt < max_retries:
+                backoff = max(0.1, retry_base_seconds) * (2 ** attempt)
+                jitter = random.uniform(0.0, min(1.0, backoff * 0.25))
+                time.sleep(min(backoff + jitter, 90.0))
+                attempt += 1
+                continue
+            raise RuntimeError(f"Request failed for {url}: {exc}") from exc
+
+
+def _chat(config: Config, token: str, payload: Dict[str, Any]) -> Tuple[int, Dict[str, Any]]:
+    return _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/ai/providers/chat",
+        payload=payload,
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=config.request_delay_seconds,
+        max_retries=config.http_max_retries,
+        retry_base_seconds=config.http_retry_base_seconds,
+        token=token,
+    )
+
+
+def _login(config: Config) -> Tuple[str, str]:
+    status, response = _http_json(
+        method="POST",
+        url=f"{config.base_url.rstrip('/')}/api/v1/auth/login",
+        payload={"email": config.email, "password": config.password},
+        timeout_seconds=config.timeout_seconds,
+        request_delay_seconds=max(config.request_delay_seconds, 1.0),
+        max_retries=max(config.http_max_retries, 6),
+        retry_base_seconds=max(config.http_retry_base_seconds, 2.5),
+    )
+    if status != 200:
+        raise RuntimeError(f"Login failed: status={status} response={response}")
+    token = response.get("access_token")
+    user_id = response.get("user_id")
+    if not isinstance(token, str) or not token.strip():
+        raise RuntimeError("Login missing access_token")
+    if not isinstance(user_id, str) or not user_id.strip():
+        raise RuntimeError("Login missing user_id")
+    return token, user_id
+
+
+def _normalize_user_id(user_id: str) -> str:
+    return str(user_id).replace("-", "").strip()
+
+
+def _reset_scope_from_template(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    user_scope = config.library_root / "users" / normalized_user_id
+    if user_scope.exists():
+        shutil.rmtree(user_scope)
+
+    script_path = (
+        Path(__file__).resolve().parents[1]
+        / "backend"
+        / "scripts"
+        / "bootstrap_library_user_scope.py"
+    )
+    cmd = [
+        sys.executable,
+        str(script_path),
+        "--library-root",
+        str(config.library_root),
+        "--user-id",
+        normalized_user_id,
+        "--template-root",
+        str(config.template_root),
+    ]
+    completed = subprocess.run(cmd, capture_output=True, text=True, check=False)
+    if completed.returncode != 0:
+        raise RuntimeError(
+            "Scope bootstrap failed: "
+            f"stdout={completed.stdout.strip()} stderr={completed.stderr.strip()}"
+        )
+    try:
+        return json.loads(completed.stdout)
+    except json.JSONDecodeError as exc:
+        raise RuntimeError(f"Bootstrap returned non-JSON: {completed.stdout}") from exc
+
+
+def _seed_finances_onboarding_complete(config: Config, user_id: str) -> Dict[str, Any]:
+    normalized_user_id = _normalize_user_id(user_id)
+    onboarding_path = (
+        config.library_root
+        / "users"
+        / normalized_user_id
+        / ".braindrive"
+        / "onboarding_state.json"
+    )
+    if not onboarding_path.is_file():
+        return {"updated": False, "path": str(onboarding_path), "reason": "missing"}
+
+    try:
+        state = json.loads(onboarding_path.read_text(encoding="utf-8"))
+    except Exception as exc:
+        return {
+            "updated": False,
+            "path": str(onboarding_path),
+            "reason": f"read_error:{exc}",
+        }
+    if not isinstance(state, dict):
+        return {"updated": False, "path": str(onboarding_path), "reason": "invalid_json_root"}
+
+    now_iso = dt.datetime.now(dt.timezone.utc).replace(microsecond=0).isoformat()
+    starter_topics = state.setdefault("starter_topics", {})
+    if isinstance(starter_topics, dict):
+        starter_topics["finances"] = "complete"
+    completed_at = state.setdefault("completed_at", {})
+    if isinstance(completed_at, dict):
+        completed_at["finances"] = now_iso
+    topic_progress = state.setdefault("topic_progress", {})
+    if isinstance(topic_progress, dict):
+        finances_progress = topic_progress.setdefault("finances", {})
+        if isinstance(finances_progress, dict):
+            finances_progress["status"] = "complete"
+            finances_progress["phase"] = "complete"
+            finances_progress["completed_at_utc"] = now_iso
+            finances_progress["last_updated_at_utc"] = now_iso
+            if not finances_progress.get("started_at_utc"):
+                finances_progress["started_at_utc"] = now_iso
+    state["active_topic"] = None
+    state["updated_at_utc"] = now_iso
+    onboarding_path.write_text(json.dumps(state, ensure_ascii=True, indent=2) + "\n", encoding="utf-8")
+    return {"updated": True, "path": str(onboarding_path), "updated_at_utc": now_iso}
+
+
+def _assistant_text(response: Dict[str, Any]) -> str:
+    try:
+        return str(((response.get("choices") or [{}])[0].get("message") or {}).get("content") or "")
+    except Exception:
+        return ""
+
+
+def _build_chat_payload(
+    *,
+    target: ProviderTarget,
+    user_id: str,
+    message: str,
+    conversation_type: str,
+    page_id: str,
+    mcp_scope_mode: str = "none",
+    conversation_id: Optional[str] = None,
+) -> Dict[str, Any]:
+    params: Dict[str, Any] = {
+        "mcp_tools_enabled": True,
+        "mcp_scope_mode": mcp_scope_mode,
+        "mcp_sync_on_request": False,
+        "mcp_auto_approve_mutating": False,
+        "mcp_max_tool_iterations": 8,
+        "mcp_provider_timeout_seconds": 90,
+        "temperature": 0,
+    }
+    payload: Dict[str, Any] = {
+        "provider": target.provider,
+        "settings_id": target.settings_id,
+        "server_id": target.server_id,
+        "model": target.model,
+        "messages": [{"role": "user", "content": message}],
+        "user_id": user_id,
+        "conversation_type": conversation_type,
+        "page_id": page_id,
+        "params": params,
+        "stream": False,
+    }
+    if conversation_id:
+        payload["conversation_id"] = conversation_id
+    return payload
+
+
+def _approve_pending_request(
+    *,
+    config: Config,
+    token: str,
+    base_payload: Dict[str, Any],
+    conversation_id: str,
+    request_id: str,
+) -> Tuple[int, Dict[str, Any]]:
+    payload = dict(base_payload)
+    payload["conversation_id"] = conversation_id
+    payload["messages"] = [{"role": "user", "content": "approve"}]
+    params = dict(payload.get("params") or {})
+    params["mcp_approval"] = {"action": "approve", "request_id": request_id}
+    payload["params"] = params
+    return _chat(config, token, payload)
+
+
+def _compact_request(request_obj: Dict[str, Any]) -> Dict[str, Any]:
+    args = request_obj.get("arguments") if isinstance(request_obj, dict) else {}
+    compact_args: Dict[str, Any] = {}
+    if isinstance(args, dict):
+        for key in ("path", "title", "owner", "due", "scope", "id"):
+            if key in args:
+                compact_args[key] = args.get(key)
+    return {
+        "tool": request_obj.get("tool"),
+        "request_id": request_obj.get("request_id"),
+        "synthetic_reason": request_obj.get("synthetic_reason"),
+        "summary": request_obj.get("summary"),
+        "arguments": compact_args,
+    }
+
+
+def _run_page_flow(
+    *,
+    summary: ProbeSummary,
+    config: Config,
+    token: str,
+    user_id: str,
+    target: ProviderTarget,
+    page_label: str,
+    conversation_type: str,
+    page_id: str,
+) -> Dict[str, Any]:
+    result: Dict[str, Any] = {
+        "page_label": page_label,
+        "conversation_type": conversation_type,
+        "page_id": page_id,
+    }
+
+    create_payload = _build_chat_payload(
+        target=target,
+        user_id=user_id,
+        message=CREATE_PROMPT,
+        conversation_type=conversation_type,
+        page_id=page_id,
+    )
+    start_status, start_response = _chat(config, token, create_payload)
+    if start_status == 404 and str(target.provider or "").strip() == "ollama":
+        detail_text = str((start_response or {}).get("detail") or "")
+        server_match = re.search(r"ID:\s*([A-Za-z0-9_-]+)", detail_text)
+        if server_match:
+            target.server_id = server_match.group(1)
+            create_payload["server_id"] = target.server_id
+            start_status, start_response = _chat(config, token, create_payload)
+    def _record_create_start(status_code: int, response_obj: Dict[str, Any], assistant_text: str) -> Dict[str, Any]:
+        return {
+            "status_code": status_code,
+            "approval_required": response_obj.get("approval_required"),
+            "approval_request": _compact_request(response_obj.get("approval_request") or {}),
+            "assistant_text_excerpt": assistant_text[:400],
+            "conversation_id": response_obj.get("conversation_id"),
+            "tooling_state": response_obj.get("tooling_state"),
+        }
+
+    start_text = _assistant_text(start_response)
+    initial_conversation_id = str(start_response.get("conversation_id") or "").strip()
+    if (
+        start_status == 200
+        and start_response.get("approval_required") is not True
+        and bool(initial_conversation_id)
+    ):
+        result["create_start_initial"] = _record_create_start(
+            start_status,
+            start_response,
+            start_text,
+        )
+        create_confirm_payload = _build_chat_payload(
+            target=target,
+            user_id=user_id,
+            message=CREATE_CONFIRM_PROMPT,
+            conversation_type=conversation_type,
+            page_id=page_id,
+            conversation_id=initial_conversation_id,
+        )
+        confirm_status, confirm_response = _chat(config, token, create_confirm_payload)
+        confirm_text = _assistant_text(confirm_response)
+        result["create_start_confirmation"] = _record_create_start(
+            confirm_status,
+            confirm_response,
+            confirm_text,
+        )
+        if confirm_status == 200:
+            start_status = confirm_status
+            start_response = confirm_response
+            start_text = confirm_text
+
+    result["create_start"] = _record_create_start(start_status, start_response, start_text)
+    _assert(summary, f"{target.label}_{page_label}_create_status_200", start_status == 200, str(result["create_start"]))
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_create_approval_required",
+        start_response.get("approval_required") is True,
+        str(result["create_start"]),
+    )
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_approval_copy_locked",
+        start_text == APPROVAL_REQUIRED_TEXT,
+        start_text,
+    )
+
+    conversation_id = str(start_response.get("conversation_id") or initial_conversation_id).strip()
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_conversation_id_present",
+        bool(conversation_id),
+        str(start_response),
+    )
+
+    approval_chain: List[Dict[str, Any]] = []
+    seen_requests: List[Dict[str, Any]] = []
+    if isinstance(start_response.get("approval_request"), dict):
+        seen_requests.append(start_response["approval_request"])
+
+    current_response = start_response
+    for _ in range(12):
+        current_request = current_response.get("approval_request")
+        if not isinstance(current_request, dict):
+            break
+        request_id = str(current_request.get("request_id") or "").strip()
+        if not request_id:
+            break
+        approve_status, approve_response = _approve_pending_request(
+            config=config,
+            token=token,
+            base_payload=create_payload,
+            conversation_id=conversation_id,
+            request_id=request_id,
+        )
+        approval_chain.append(
+            {
+                "status_code": approve_status,
+                "request": _compact_request(current_request),
+                "approval_resolution": approve_response.get("approval_resolution"),
+                "approval_required_next": approve_response.get("approval_required"),
+                "assistant_text_excerpt": _assistant_text(approve_response)[:300],
+                "tooling_state": approve_response.get("tooling_state"),
+            }
+        )
+        _assert(
+            summary,
+            f"{target.label}_{page_label}_approve_status_200_step_{len(approval_chain)}",
+            approve_status == 200,
+            str(approval_chain[-1]),
+        )
+        _assert(
+            summary,
+            f"{target.label}_{page_label}_approve_resolution_step_{len(approval_chain)}",
+            str((approve_response.get("approval_resolution") or {}).get("status") or "") == "approved",
+            str(approval_chain[-1]),
+        )
+        next_request = approve_response.get("approval_request")
+        if isinstance(next_request, dict):
+            seen_requests.append(next_request)
+        current_response = approve_response
+        if approve_response.get("approval_required") is not True:
+            break
+
+    result["approval_chain"] = approval_chain
+    result["approval_request_sequence"] = [_compact_request(item) for item in seen_requests]
+
+    create_task_request: Optional[Dict[str, Any]] = None
+    for item in seen_requests:
+        if str(item.get("tool") or "").strip() == "create_task":
+            create_task_request = item
+            break
+    result["create_task_request"] = _compact_request(create_task_request or {})
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_create_task_request_seen",
+        isinstance(create_task_request, dict),
+        str(result["approval_request_sequence"]),
+    )
+
+    create_args = (create_task_request or {}).get("arguments") or {}
+    title = str(create_args.get("title") or "")
+    owner_raw = str(create_args.get("owner") or "").strip()
+    due = str(create_args.get("due") or "").strip()
+    scope_raw = str(create_args.get("scope") or "").strip()
+
+    scope_normalized = scope_raw.lower()
+    if scope_normalized in {"finance", "finances", "personal finance", "life/finance"}:
+        scope_normalized = "life/finances"
+    if not scope_normalized and page_label == "life_finances":
+        scope_normalized = "life/finances"
+
+    owner_effective = owner_raw
+    if not owner_effective and page_label == "life_finances":
+        owner_effective = "user"
+    if owner_effective.lower() in {"me", "myself", "self", "user", "you"}:
+        owner_effective = "user"
+
+    result["create_task_args"] = {
+        "title": title,
+        "owner": owner_effective,
+        "owner_raw": owner_raw,
+        "due": due,
+        "scope": scope_normalized,
+        "scope_raw": scope_raw,
+    }
+    title_lower = title.lower()
+    _assert(summary, f"{target.label}_{page_label}_create_due_exact", due == "2026-02-20", str(result["create_task_args"]))
+    _assert(summary, f"{target.label}_{page_label}_create_scope_finances", scope_normalized == "life/finances", str(result["create_task_args"]))
+    _assert(summary, f"{target.label}_{page_label}_create_owner_present", bool(owner_effective), str(result["create_task_args"]))
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_create_title_semantics",
+        ("friend" in title_lower) and ("20" in title_lower) and ("pay" in title_lower),
+        title,
+    )
+
+    verify_payload = _build_chat_payload(
+        target=target,
+        user_id=user_id,
+        message=VERIFY_PROMPT,
+        conversation_type=conversation_type,
+        page_id=page_id,
+        conversation_id=conversation_id,
+    )
+    verify_status, verify_response = _chat(config, token, verify_payload)
+    verify_text = _assistant_text(verify_response)
+    verify_state = verify_response.get("tooling_state") or {}
+    result["verify"] = {
+        "status_code": verify_status,
+        "approval_required": verify_response.get("approval_required"),
+        "assistant_text_excerpt": verify_text[:700],
+        "tooling_state": verify_state,
+    }
+    _assert(summary, f"{target.label}_{page_label}_verify_status_200", verify_status == 200, str(result["verify"]))
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_verify_no_approval",
+        verify_response.get("approval_required") is not True,
+        str(result["verify"]),
+    )
+
+    verify_tool_calls_executed = int(verify_state.get("tool_calls_executed_count") or 0)
+    verify_stop_reason = str(verify_state.get("tool_loop_stop_reason") or "").strip().lower()
+    verify_timeout_count = int(verify_state.get("provider_timeout_count") or 0)
+
+    if (
+        verify_status == 200
+        and verify_response.get("approval_required") is not True
+        and verify_tool_calls_executed < 1
+        and (verify_stop_reason == "provider_timeout" or verify_timeout_count > 0)
+    ):
+        retry_status, retry_response = _chat(config, token, verify_payload)
+        retry_text = _assistant_text(retry_response)
+        retry_state = retry_response.get("tooling_state") or {}
+        result["verify_retry"] = {
+            "status_code": retry_status,
+            "approval_required": retry_response.get("approval_required"),
+            "assistant_text_excerpt": retry_text[:700],
+            "tooling_state": retry_state,
+        }
+        if retry_status == 200 and retry_response.get("approval_required") is not True:
+            verify_status = retry_status
+            verify_response = retry_response
+            verify_text = retry_text
+            verify_state = retry_state
+            verify_tool_calls_executed = int(verify_state.get("tool_calls_executed_count") or 0)
+
+    def _analyze_verify_text(candidate: str) -> Tuple[bool, bool, bool]:
+        lowered = candidate.lower()
+        due_flag = bool(
+            ("2026-02-20" in candidate)
+            or re.search(r"\bfeb(?:ruary)?\b", lowered)
+            and re.search(r"\b20\b", lowered)
+            and ("2026" in lowered)
+        )
+        semantics_flag = bool(
+            (
+                ("20" in lowered)
+                and (
+                    ("friend" in lowered)
+                    or ("pay back" in lowered)
+                    or ("paying back" in lowered)
+                    or ("pay" in lowered and "back" in lowered)
+                )
+            )
+            or ("matching task" in lowered)
+            or ("matching tasks" in lowered)
+            or ("task is titled" in lowered)
+        )
+        task_id_flag = bool(
+            re.search(r"\bT-\d+\b", candidate)
+            or re.search(r"\btask\s*id\b[^0-9]{0,12}\d+\b", candidate, flags=re.IGNORECASE)
+            or re.search(r"\bID\s*[:#-]?\s*\d+\b", candidate, flags=re.IGNORECASE)
+            or re.search(r"\btask\s+\d+\b", candidate, flags=re.IGNORECASE)
+        )
+        return due_flag, semantics_flag, task_id_flag
+
+    verify_text_for_assert = verify_text
+    due_mentioned, task_semantics_mentioned, task_id_mentioned = _analyze_verify_text(verify_text_for_assert)
+    fallback_tool_calls_executed = 0
+
+    if (
+        verify_status == 200
+        and verify_response.get("approval_required") is not True
+        and (
+            verify_tool_calls_executed < 1
+            or not due_mentioned
+            or not task_semantics_mentioned
+            or not task_id_mentioned
+        )
+    ):
+        fallback_payload = _build_chat_payload(
+            target=target,
+            user_id=user_id,
+            message=VERIFY_FALLBACK_PROMPT,
+            conversation_type=conversation_type,
+            page_id=page_id,
+            conversation_id=conversation_id,
+        )
+        fallback_status, fallback_response = _chat(config, token, fallback_payload)
+        fallback_text = _assistant_text(fallback_response)
+        fallback_state = fallback_response.get("tooling_state") or {}
+        result["verify_fallback"] = {
+            "status_code": fallback_status,
+            "approval_required": fallback_response.get("approval_required"),
+            "assistant_text_excerpt": fallback_text[:700],
+            "tooling_state": fallback_state,
+        }
+        fallback_tool_calls_executed = int(fallback_state.get("tool_calls_executed_count") or 0)
+        if fallback_status == 200 and fallback_response.get("approval_required") is not True:
+            verify_text_for_assert = "\n".join(
+                part for part in [verify_text_for_assert, fallback_text] if part
+            ).strip()
+            due_mentioned, task_semantics_mentioned, task_id_mentioned = _analyze_verify_text(
+                verify_text_for_assert
+            )
+
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_verify_tool_call_executed",
+        max(verify_tool_calls_executed, fallback_tool_calls_executed) >= 1,
+        str({
+            "verify": verify_state,
+            "verify_fallback": result.get("verify_fallback"),
+        }),
+    )
+
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_verify_mentions_due",
+        due_mentioned,
+        verify_text_for_assert,
+    )
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_verify_mentions_task_semantics",
+        task_semantics_mentioned,
+        verify_text_for_assert,
+    )
+    _assert(
+        summary,
+        f"{target.label}_{page_label}_verify_mentions_task_id",
+        task_id_mentioned,
+        verify_text_for_assert,
+    )
+
+    return result
+
+
+def _read_pulse_index(config: Config, user_id: str) -> str:
+    normalized_user_id = _normalize_user_id(user_id)
+    pulse_path = config.library_root / "users" / normalized_user_id / "pulse" / "index.md"
+    if not pulse_path.is_file():
+        return ""
+    return pulse_path.read_text(encoding="utf-8")
+
+
+def _run_provider_flow(
+    *,
+    summary: ProbeSummary,
+    config: Config,
+    token: str,
+    user_id: str,
+    target: ProviderTarget,
+) -> Dict[str, Any]:
+    provider_result: Dict[str, Any] = {
+        "provider": target.provider,
+        "settings_id": target.settings_id,
+        "server_id": target.server_id,
+        "model": target.model,
+    }
+
+    run_tag = summary.run_id.lower()
+    page_results: Dict[str, Any] = {}
+    for page_label, conversation_type in (
+        ("capture", "capture"),
+        ("life_finances", "life-finances"),
+    ):
+        page_id = f"task-parity-{target.label}-{page_label}-{run_tag}"
+        page_results[page_label] = _run_page_flow(
+            summary=summary,
+            config=config,
+            token=token,
+            user_id=user_id,
+            target=target,
+            page_label=page_label,
+            conversation_type=conversation_type,
+            page_id=page_id,
+        )
+    provider_result["pages"] = page_results
+
+    capture_args = page_results["capture"]["create_task_args"]
+    finance_args = page_results["life_finances"]["create_task_args"]
+    parity = {
+        "due_match": capture_args.get("due") == finance_args.get("due"),
+        "scope_match": capture_args.get("scope") == finance_args.get("scope"),
+        "owner_match": capture_args.get("owner") == finance_args.get("owner"),
+        "capture_args": capture_args,
+        "life_finances_args": finance_args,
+    }
+    provider_result["parity"] = parity
+    _assert(summary, f"{target.label}_parity_due_match", bool(parity["due_match"]), str(parity))
+    _assert(summary, f"{target.label}_parity_scope_match", bool(parity["scope_match"]), str(parity))
+    _assert(summary, f"{target.label}_parity_owner_match", bool(parity["owner_match"]), str(parity))
+
+    pulse_content = _read_pulse_index(config, user_id)
+    provider_result["pulse_index_excerpt"] = pulse_content[-1800:]
+    pulse_lower = pulse_content.lower()
+    _assert(
+        summary,
+        f"{target.label}_pulse_has_payback_task",
+        ("pay" in pulse_lower) and ("friend" in pulse_lower) and ("20" in pulse_lower) and ("due:2026-02-20" in pulse_lower),
+        pulse_content[-1200:],
+    )
+
+    return provider_result
+
+
+def _serialize_summary(summary: ProbeSummary) -> Dict[str, Any]:
+    return {
+        "run_id": summary.run_id,
+        "started_at": summary.started_at,
+        "base_url": summary.base_url,
+        "reset_applied": summary.reset_applied,
+        "assertions": [
+            {
+                "name": assertion.name,
+                "passed": assertion.passed,
+                "detail": assertion.detail,
+            }
+            for assertion in summary.assertions
+        ],
+        "scenarios": summary.scenarios,
+        "success": summary.success,
+        "error": summary.error,
+    }
+
+
+def _parse_args(argv: Optional[List[str]] = None) -> Config:
+    parser = argparse.ArgumentParser(description="Capture vs finances task approval parity probe")
+    parser.add_argument("--base-url", default="http://localhost:8005")
+    parser.add_argument("--email", required=True)
+    parser.add_argument("--password", required=True)
+
+    parser.add_argument("--local-provider", default="ollama")
+    parser.add_argument("--local-settings-id", default="ollama_servers_settings")
+    parser.add_argument("--local-server-id", default="ollama_default_server")
+    parser.add_argument("--local-model", default="qwen3:8b")
+
+    parser.add_argument("--openrouter-settings-id", default="openrouter_api_keys_settings")
+    parser.add_argument("--openrouter-server-id", default="openrouter_default_server")
+    parser.add_argument("--openrouter-model", default="openai/gpt-4o-mini-2024-11-20")
+
+    parser.add_argument("--skip-local", action="store_true")
+    parser.add_argument("--skip-openrouter", action="store_true")
+
+    parser.add_argument("--output-dir", default="tmp/live-task-parity")
+    parser.add_argument("--timeout-seconds", type=int, default=120)
+    parser.add_argument("--request-delay-seconds", type=float, default=0.8)
+    parser.add_argument("--http-max-retries", type=int, default=6)
+    parser.add_argument("--http-retry-base-seconds", type=float, default=1.5)
+    parser.add_argument("--reset-from-template", action="store_true")
+    parser.add_argument(
+        "--library-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library",
+    )
+    parser.add_argument(
+        "--template-root",
+        default="/home/hacker/BrainDriveDev/BrainDrive/backend/services_runtime/Library-Service/library_templates/Base_Library",
+    )
+    args = parser.parse_args(argv)
+    return Config(
+        base_url=str(args.base_url),
+        email=str(args.email),
+        password=str(args.password),
+        local_provider=str(args.local_provider),
+        local_settings_id=str(args.local_settings_id),
+        local_server_id=str(args.local_server_id),
+        local_model=str(args.local_model),
+        openrouter_settings_id=str(args.openrouter_settings_id),
+        openrouter_server_id=str(args.openrouter_server_id),
+        openrouter_model=str(args.openrouter_model),
+        skip_local=bool(args.skip_local),
+        skip_openrouter=bool(args.skip_openrouter),
+        output_dir=Path(args.output_dir).resolve(),
+        timeout_seconds=max(10, int(args.timeout_seconds)),
+        request_delay_seconds=max(0.0, float(args.request_delay_seconds)),
+        http_max_retries=max(0, int(args.http_max_retries)),
+        http_retry_base_seconds=max(0.1, float(args.http_retry_base_seconds)),
+        reset_from_template=bool(args.reset_from_template),
+        library_root=Path(args.library_root).resolve(),
+        template_root=Path(args.template_root).resolve(),
+    )
+
+
+def main(argv: Optional[List[str]] = None) -> int:
+    config = _parse_args(argv)
+    if config.skip_local and config.skip_openrouter:
+        raise SystemExit("At least one provider target must run (remove one skip flag).")
+
+    run_id = dt.datetime.now(dt.timezone.utc).strftime("%Y%m%dT%H%M%SZ")
+    started_at = dt.datetime.now(dt.timezone.utc).isoformat()
+    run_dir = config.output_dir / f"run-{run_id}"
+    run_dir.mkdir(parents=True, exist_ok=True)
+
+    summary = ProbeSummary(
+        run_id=run_id,
+        started_at=started_at,
+        base_url=config.base_url,
+        reset_applied=False,
+    )
+
+    targets: List[ProviderTarget] = []
+    if not config.skip_local:
+        targets.append(
+            ProviderTarget(
+                label="local",
+                provider=config.local_provider,
+                settings_id=config.local_settings_id,
+                server_id=config.local_server_id,
+                model=config.local_model,
+            )
+        )
+    if not config.skip_openrouter:
+        targets.append(
+            ProviderTarget(
+                label="openrouter",
+                provider="openrouter",
+                settings_id=config.openrouter_settings_id,
+                server_id=config.openrouter_server_id,
+                model=config.openrouter_model,
+            )
+        )
+
+    try:
+        token, user_id = _login(config)
+        summary.scenarios["auth"] = {"user_id": user_id}
+
+        if config.reset_from_template:
+            bootstrap = _reset_scope_from_template(config, user_id)
+            summary.reset_applied = True
+            summary.scenarios["bootstrap"] = bootstrap
+
+        summary.scenarios["finances_onboarding_seed"] = _seed_finances_onboarding_complete(config, user_id)
+
+        provider_results: Dict[str, Any] = {}
+        for target in targets:
+            try:
+                provider_results[target.label] = _run_provider_flow(
+                    summary=summary,
+                    config=config,
+                    token=token,
+                    user_id=user_id,
+                    target=target,
+                )
+            except Exception as exc:
+                provider_results[target.label] = {
+                    "provider": target.provider,
+                    "settings_id": target.settings_id,
+                    "server_id": target.server_id,
+                    "model": target.model,
+                    "error": str(exc),
+                }
+                summary.assertions.append(
+                    AssertionResult(
+                        name=f"{target.label}_provider_flow",
+                        passed=False,
+                        detail=str(exc),
+                    )
+                )
+        summary.scenarios["providers"] = provider_results
+        summary.success = all(assertion.passed for assertion in summary.assertions)
+    except Exception as exc:
+        summary.success = False
+        summary.error = str(exc)
+
+    output_path = run_dir / "summary.json"
+    output_path.write_text(
+        json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2) + "\n",
+        encoding="utf-8",
+    )
+    print(json.dumps(_serialize_summary(summary), ensure_ascii=True, indent=2))
+    return 0 if summary.success else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
This PR introduces MCP runtime tool registry support end-to-end, including backend persistence, sync/execution services, provider tool-call normalization, dynamic plugin API route loading, onboarding/bootstrap improvements, and supporting frontend resiliency updates.

Scope is broad (60 files changed; large net-new orchestration + E2E coverage), but centered on making MCP-backed tool use deterministic and production-ready.

## Why
We need a reliable runtime path for:
1. Discovering/managing MCP servers and tools per user.
2. Passing tool calls consistently across providers (sync + streaming).
3. Executing tool calls safely with schema validation and policy controls.
4. Supporting plugin-owned backend endpoints and library/runtime bootstrap flows.

## What Changed
- Added MCP registry data model and migration:
  - `mcp_server_registry`
  - `mcp_tool_registry`
- Added MCP registry API endpoints:
  - `POST /api/v1/mcp/sync`
  - `GET /api/v1/mcp/servers`
  - `GET /api/v1/mcp/tools`
- Added `MCPRegistryService` for:
  - auto-registering managed runtimes
  - syncing `/tools` payloads
  - tool safety classification + hashing
  - schema-validated tool execution
- Extended provider implementations (`openai`, `groq`, `openrouter`, `ollama`) to preserve/emit `tool_calls` in non-streaming and streaming responses.
- Added OpenRouter model-id normalization for dated `gpt-4o-mini` variants.
- Refactored plugin backend runtime loading:
  - new endpoint decorators
  - dynamic plugin route loader
  - startup initialization now uses FastAPI lifespan flow
- Expanded user initialization/bootstrap:
  - library onboarding initializer
  - improved GitHub plugin install sequencing/dependency handling
  - library template/schema bootstrap utilities
  - starter page/settings initialization updates
- Updated service install handler for installer-user bootstrap and safer schema-loader compatibility.
- Added install/bootstrap scripts and docs for cross-platform setup and runtime testing.
- Frontend hardening:
  - fallback system navigation routes
  - global page refresh event propagation
  - improved plugin/module ID resolution in layout loaders
- Added large E2E process/script coverage for onboarding/capture/runtime paths.

## Migration / Deployment Notes
- Run Alembic migration: `2cb3f0bb9d9d_add_mcp_registry_tables`.
- Ensure runtime/library env configuration is present where applicable (library root/template/service token settings).
- New MCP endpoints are user-authenticated and expected by runtime sync flows.

## Validation
- Added/updated E2E automation scripts for runtime + onboarding workflows.
- Provider/tool-call path changes include both sync and stream handling.
- Manual verification recommended for:
  - MCP sync + tool list + tool execution
  - plugin dynamic endpoint mounting on startup/reload
  - new-user onboarding bootstrap (plugins + library scaffold + default navigation/pages)

## Risk / Rollback
- Risk is moderate-high due to wide surface area (provider pipeline, startup lifecycle, onboarding flow, frontend routing).
- Rollback path:
  1. Revert this PR.
  2. Downgrade Alembic migration if already applied.
  3. Restart backend services to clear dynamic route state.